### PR TITLE
feat: use simplex views for registry and update index handling in registry

### DIFF
--- a/application/src/actor.rs
+++ b/application/src/actor.rs
@@ -248,7 +248,7 @@ impl<R: Storage + Metrics + Clock + Spawner + governor::clock::Clock + Rng, C: E
         // Request pending withdrawals
         let (tx, rx) = oneshot::channel();
         self.tx_pending_withdrawal
-            .try_send((parent.height, tx))
+            .try_send((parent.height + 1, tx))
             .expect("finalizer dropped");
 
         // await response

--- a/application/src/actor.rs
+++ b/application/src/actor.rs
@@ -18,6 +18,7 @@ use futures::{
 };
 use rand::Rng;
 
+use commonware_consensus::threshold_simplex::types::View;
 use futures::task::{Context, Poll};
 use std::{
     pin::Pin,
@@ -133,7 +134,7 @@ impl<R: Storage + Metrics + Clock + Spawner + governor::clock::Clock + Rng, C: E
 
                     let built = self.built_block.clone();
                     select! {
-                            res = self.handle_proposal(parent, &mut marshal) => {
+                            res = self.handle_proposal(parent, &mut marshal, view) => {
                                 match res {
                                     Ok(block) => {
                                         // store block
@@ -226,6 +227,7 @@ impl<R: Storage + Metrics + Clock + Spawner + governor::clock::Clock + Rng, C: E
         &mut self,
         parent: (u64, Digest),
         marshal: &mut marshal::Mailbox<MinPk, Block>,
+        view: View,
     ) -> Result<Block> {
         // Get the parent block
         let parent_request = if parent.1 == self.genesis_hash.into() {
@@ -282,6 +284,7 @@ impl<R: Storage + Metrics + Clock + Spawner + governor::clock::Clock + Rng, C: E
             payload_envelope.envelope_inner.execution_payload,
             payload_envelope.execution_requests.to_vec(),
             payload_envelope.envelope_inner.block_value,
+            view,
         );
 
         Ok(block)

--- a/application/src/finalizer.rs
+++ b/application/src/finalizer.rs
@@ -239,6 +239,7 @@ impl<R: Storage + Metrics + Clock + Spawner + governor::clock::Clock + Rng, C: E
                                                         withdrawal_request.amount = remaining_balance;
                                                         account.status = ValidatorStatus::SubmittedExitRequest;
                                                     }
+
                                                     account.pending_withdrawal_amount += withdrawal_request.amount;
                                                     self.state.set_account(&withdrawal_request.validator_pubkey, account).await;
                                                     self.state.push_withdrawal_request(withdrawal_request.clone(), new_height + self.validator_withdrawal_period).await;
@@ -307,13 +308,13 @@ impl<R: Storage + Metrics + Clock + Spawner + governor::clock::Clock + Rng, C: E
                                             let gauge: Gauge = Gauge::default();
                                             gauge.set(validator_balance as i64);
                                             ctx.register(
-                                                format!("<creds>{}</creds><ed_key>{}</ed_key><bls_key>{}</bls_key>_validator_balance",
+                                                format!("<creds>{}</creds><ed_key>{}</ed_key><bls_key>{}</bls_key>_deposit_validator_balance",
                                                 hex::encode(request.withdrawal_credentials), request.ed25519_pubkey, hex::encode(request.bls_pubkey)),
                                                 "Validator balance",
                                                 gauge
                                             );
                                         }
-                                        if validator_balance > self.validator_minimum_stake {
+                                        if validator_balance >= self.validator_minimum_stake {
                                             // If the node shuts down, before the account changes are committed,
                                             // then everything should work normally, because the registry is not persisted to disk
                                             if let Err(e) = self.registry.add_participant(request.ed25519_pubkey.clone(), last_indexed) {
@@ -339,6 +340,18 @@ impl<R: Storage + Metrics + Clock + Spawner + governor::clock::Clock + Rng, C: E
                                         // adding the pending withdrawal to the queue
                                         account.balance = account.balance.saturating_sub(withdrawal.amount);
                                         account.pending_withdrawal_amount = account.pending_withdrawal_amount.saturating_sub(withdrawal.amount);
+
+                                        #[cfg(debug_assertions)]
+                                        {
+                                            let gauge: Gauge = Gauge::default();
+                                            gauge.set(account.balance as i64);
+                                            ctx.register(
+                                                format!("<creds>{}</creds><ed_key>{}</ed_key><bls_key>{}</bls_key>_withdrawal_validator_balance",
+                                                hex::encode(account.withdrawal_credentials), account.ed25519_pubkey, hex::encode(pending_withdrawal.bls_pubkey)),
+                                                "Validator balance",
+                                                gauge
+                                            );
+                                        }
 
                                         // If the remaining balance is 0, mark the validator as inactive.
                                         // An argument can be made from removing the validator account from the DB here.

--- a/application/src/finalizer.rs
+++ b/application/src/finalizer.rs
@@ -319,7 +319,7 @@ impl<R: Storage + Metrics + Clock + Spawner + governor::clock::Clock + Rng, C: E
                                         if !account_exists && validator_balance >= self.validator_minimum_stake {
                                             // If the node shuts down, before the account changes are committed,
                                             // then everything should work normally, because the registry is not persisted to disk
-                                            if let Err(e) = self.registry.add_participant(request.ed25519_pubkey.clone(), last_indexed) {
+                                            if let Err(e) = self.registry.add_participant(request.ed25519_pubkey.clone(), last_indexed + 1) {
                                                 // This only happens if the key already exists
                                                 warn!("failed to add validator: {}", e);
                                             }
@@ -359,7 +359,7 @@ impl<R: Storage + Metrics + Clock + Spawner + governor::clock::Clock + Rng, C: E
                                         // An argument can be made from removing the validator account from the DB here.
                                         if account.balance == 0 {
                                             account.status = ValidatorStatus::Inactive;
-                                            if let Err(e) = self.registry.remove_participant(&account.ed25519_pubkey, last_indexed) {
+                                            if let Err(e) = self.registry.remove_participant(&account.ed25519_pubkey, last_indexed + 1) {
                                                 warn!("failed to remove validator: {}", e);
                                             }
                                         }

--- a/application/src/finalizer.rs
+++ b/application/src/finalizer.rs
@@ -259,6 +259,7 @@ impl<R: Storage + Metrics + Clock + Spawner + governor::clock::Clock + Rng, C: E
                                 for _ in 0..self.validator_onboarding_limit_per_block {
                                     if let Some(request) = self.state.pop_deposit().await {
                                         let mut validator_balance = 0;
+                                        let mut account_exists = false;
                                         if let Some(mut account) = self.state.get_account(&request.bls_pubkey).await {
                                             if request.index > account.last_deposit_index {
                                                 account.balance += request.amount;
@@ -271,6 +272,7 @@ impl<R: Storage + Metrics + Clock + Spawner + governor::clock::Clock + Rng, C: E
                                                 account.last_deposit_index = request.index;
                                                 validator_balance = account.balance;
                                                 self.state.set_account(&request.bls_pubkey, account).await;
+                                                account_exists = true;
                                             }
                                         } else {
                                             // Validate the withdrawal credentials format
@@ -314,7 +316,7 @@ impl<R: Storage + Metrics + Clock + Spawner + governor::clock::Clock + Rng, C: E
                                                 gauge
                                             );
                                         }
-                                        if validator_balance >= self.validator_minimum_stake {
+                                        if !account_exists && validator_balance >= self.validator_minimum_stake {
                                             // If the node shuts down, before the account changes are committed,
                                             // then everything should work normally, because the registry is not persisted to disk
                                             if let Err(e) = self.registry.add_participant(request.ed25519_pubkey.clone(), last_indexed) {

--- a/application/src/finalizer.rs
+++ b/application/src/finalizer.rs
@@ -34,6 +34,7 @@ use tracing::{info, warn};
 
 const PAGE_SIZE: usize = 77;
 const PAGE_CACHE_SIZE: usize = 9;
+const REGISTRY_CHANGE_VIEW_DELTA: u64 = 3;
 
 pub struct Finalizer<
     R: Storage + Metrics + Clock + Spawner + governor::clock::Clock + Rng,
@@ -319,7 +320,7 @@ impl<R: Storage + Metrics + Clock + Spawner + governor::clock::Clock + Rng, C: E
                                         if !account_exists && validator_balance >= self.validator_minimum_stake {
                                             // If the node shuts down, before the account changes are committed,
                                             // then everything should work normally, because the registry is not persisted to disk
-                                            if let Err(e) = self.registry.add_participant(request.ed25519_pubkey.clone(), last_indexed + 1) {
+                                            if let Err(e) = self.registry.add_participant(request.ed25519_pubkey.clone(), block.view + 2) {
                                                 // This only happens if the key already exists
                                                 warn!("failed to add validator: {}", e);
                                             }
@@ -359,7 +360,7 @@ impl<R: Storage + Metrics + Clock + Spawner + governor::clock::Clock + Rng, C: E
                                         // An argument can be made from removing the validator account from the DB here.
                                         if account.balance == 0 {
                                             account.status = ValidatorStatus::Inactive;
-                                            if let Err(e) = self.registry.remove_participant(&account.ed25519_pubkey, last_indexed + 1) {
+                                            if let Err(e) = self.registry.remove_participant(&account.ed25519_pubkey, block.view + REGISTRY_CHANGE_VIEW_DELTA) {
                                                 warn!("failed to remove validator: {}", e);
                                             }
                                         }
@@ -376,6 +377,16 @@ impl<R: Storage + Metrics + Clock + Spawner + governor::clock::Clock + Rng, C: E
                         }
 
                         // This will commit all changes to the state db
+                        #[cfg(debug_assertions)]
+                        {
+                            let gauge: Gauge = Gauge::default();
+                            gauge.set(new_height as i64);
+                            ctx.register(
+                                "height",
+                                "chain height",
+                                gauge
+                            );
+                        }
                         self.state.set_latest_height(new_height).await;
                         self.height_notifier.notify_up_to(new_height);
                         let _ = notifier.send(());

--- a/node/src/engine.rs
+++ b/node/src/engine.rs
@@ -51,7 +51,7 @@ const VALIDATOR_ONBOARDING_LIMIT_PER_BLOCK: usize = 3;
 const VALIDATOR_MINIMUM_STAKE: u64 = 32_000_000_000; // in gwei
 
 #[cfg(debug_assertions)]
-const VALIDATOR_WITHDRAWAL_PERIOD: u64 = 5;
+pub const VALIDATOR_WITHDRAWAL_PERIOD: u64 = 5;
 #[cfg(not(debug_assertions))]
 const VALIDATOR_WITHDRAWAL_PERIOD: u64 = 100;
 const VALIDATOR_MAX_WITHDRAWALS_PER_BLOCK: usize = 16;

--- a/node/src/test_harness/common.rs
+++ b/node/src/test_harness/common.rs
@@ -9,7 +9,7 @@ use commonware_cryptography::{
 use crate::test_harness::mock_engine_client::MockEngineNetwork;
 use crate::{config::EngineConfig, engine::Engine};
 use alloy_eips::eip7685::Requests;
-use alloy_primitives::Bytes;
+use alloy_primitives::{Address, Bytes};
 use alloy_signer::k256::elliptic_curve::rand_core::OsRng;
 use commonware_codec::{DecodeExt, Write};
 use commonware_p2p::simulated::{self, Link, Network, Oracle, Receiver, Sender};
@@ -25,7 +25,7 @@ use std::{
     num::NonZeroU32,
 };
 use summit_application::engine_client::EngineClient;
-use summit_types::execution_request::{DepositRequest, ExecutionRequest};
+use summit_types::execution_request::{DepositRequest, ExecutionRequest, WithdrawalRequest};
 use summit_types::{Identity, PrivateKey, PublicKey};
 
 pub const GENESIS_HASH: &str = "0x683713729fcb72be6f3d8b88c8cda3e10569d73b9640d3bf6f5184d94bd97616";
@@ -316,6 +316,27 @@ pub fn create_deposit_requests(n: usize) -> Vec<DepositRequest> {
     }
 
     deposits
+}
+
+/// Create a single WithdrawalRequest for testing
+///
+/// # Arguments
+/// * `source_address` - The address that initiated the withdrawal
+/// * `validator_pubkey` - The validator BLS public key
+/// * `amount` - The withdrawal amount in gwei
+///
+/// # Returns
+/// * `WithdrawalRequest` - A withdrawal request with the specified data
+pub fn create_withdrawal_request(
+    source_address: Address,
+    validator_pubkey: [u8; 48],
+    amount: u64,
+) -> WithdrawalRequest {
+    WithdrawalRequest {
+        source_address,
+        validator_pubkey,
+        amount,
+    }
 }
 
 /// Convert a list of ExecutionRequests to Requests

--- a/node/src/test_harness/mock_engine_client.rs
+++ b/node/src/test_harness/mock_engine_client.rs
@@ -226,6 +226,7 @@ impl MockEngineState {
         parent_hash: FixedBytes<32>,
         timestamp: u64,
         client_id: &str,
+        withdrawals: Vec<Withdrawal>,
     ) -> ExecutionPayloadV3 {
         // Create deterministic but unique block hash
         use sha3::{Digest, Keccak256};
@@ -257,7 +258,7 @@ impl MockEngineState {
 
         let payload_v2 = ExecutionPayloadV2 {
             payload_inner: payload_v1,
-            withdrawals: vec![],
+            withdrawals,
         };
 
         ExecutionPayloadV3 {
@@ -273,7 +274,7 @@ impl EngineClient for MockEngineClient {
         &self,
         fork_choice_state: ForkchoiceState,
         timestamp: u64,
-        _withdrawals: Vec<Withdrawal>,
+        withdrawals: Vec<Withdrawal>,
     ) -> Option<PayloadId> {
         let mut state = self.state.lock().unwrap();
 
@@ -302,6 +303,7 @@ impl EngineClient for MockEngineClient {
             fork_choice_state.head_block_hash,
             timestamp,
             &self.client_id,
+            withdrawals,
         );
 
         // Wrap in envelope

--- a/node/src/test_harness/mock_engine_client.rs
+++ b/node/src/test_harness/mock_engine_client.rs
@@ -690,6 +690,7 @@ mod tests {
             timestamp: 1000,
             block_value: alloy_primitives::U256::from(1_000_000_000_000_000_000u64),
             execution_requests: Vec::new(),
+            view: 1,
         };
 
         // Client2 checks the payload (validates it)
@@ -759,6 +760,7 @@ mod tests {
                         timestamp: (round * 1000) as u64,
                         block_value: U256::from(1_000_000_000_000_000_000u64),
                         execution_requests: Vec::new(),
+                        view: 1,
                     };
 
                     // Client validates the block
@@ -847,6 +849,7 @@ mod tests {
             timestamp: 1000,
             block_value: alloy_primitives::U256::from(1_000_000_000_000_000_000u64),
             execution_requests: Vec::new(),
+            view: 1,
         };
 
         client2.check_payload(&block_for_validation).await;

--- a/node/src/tests/execution_requests.rs
+++ b/node/src/tests/execution_requests.rs
@@ -2,7 +2,7 @@ use crate::engine::Engine;
 use crate::test_harness::common;
 use crate::test_harness::common::get_default_engine_config;
 use crate::test_harness::mock_engine_client::MockEngineNetworkBuilder;
-use alloy_primitives::hex;
+use alloy_primitives::{Address, hex};
 use alloy_signer::k256::elliptic_curve::rand_core::OsRng;
 use commonware_cryptography::bls12381::dkg::ops;
 use commonware_cryptography::bls12381::primitives::variant::MinPk;
@@ -17,6 +17,8 @@ use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 use summit_types::PrivateKey;
 use summit_types::execution_request::ExecutionRequest;
+
+use crate::engine::VALIDATOR_WITHDRAWAL_PERIOD;
 
 #[test_traced("INFO")]
 fn test_deposit_request() {
@@ -257,12 +259,12 @@ fn test_deposit_request_top_up() {
         let requests2 = common::execution_requests_to_requests(execution_requests2);
 
         // Create execution requests map (add deposit to block 5)
-        let deposit_block_height1 = 5;
-        let deposit_block_height2 = 10;
-        let stop_height = deposit_block_height2;
+        let deposit_block_height = 5;
+        let withdrawal_block_height = 10;
+        let stop_height = withdrawal_block_height + VALIDATOR_WITHDRAWAL_PERIOD;
         let mut execution_requests_map = HashMap::new();
-        execution_requests_map.insert(deposit_block_height1, requests1);
-        execution_requests_map.insert(deposit_block_height2, requests2);
+        execution_requests_map.insert(deposit_block_height, requests1);
+        execution_requests_map.insert(withdrawal_block_height, requests2);
 
         let engine_client_network = MockEngineNetworkBuilder::new(genesis_hash)
             .with_execution_requests(execution_requests_map)
@@ -367,6 +369,201 @@ fn test_deposit_request_top_up() {
             // Still waiting for all validators to complete
             context.sleep(Duration::from_secs(1)).await;
         }
+
+        // Check that all nodes have the same canonical chain
+        assert!(
+            engine_client_network
+                .verify_consensus(Some(stop_height))
+                .is_ok()
+        );
+
+        context.auditor().state()
+    })
+}
+
+#[test_traced("INFO")]
+fn test_deposit_and_withdrawal_request() {
+    // Adds a deposit request to the block at height 5, and then checks
+    // the internal validator state to make sure that the validator balance, public keys,
+    // and withdrawal credentials were added correctly.
+    let n = 10;
+    let link = Link {
+        latency: 80.0,
+        jitter: 10.0,
+        success_rate: 0.98,
+    };
+    // Create context
+    let threshold = quorum(n);
+    let cfg = deterministic::Config::default().with_seed(0);
+    let executor = Runner::from(cfg);
+    executor.start(|context| async move {
+        // Create simulated network
+        let (network, mut oracle) = Network::new(
+            context.with_label("network"),
+            simulated::Config {
+                max_size: 1024 * 1024,
+            },
+        );
+
+        // Start network
+        network.start();
+
+        // Register participants
+        let mut signers = Vec::new();
+        let mut validators = Vec::new();
+        for i in 0..n {
+            let signer = PrivateKey::from_seed(i as u64);
+            let pk = signer.public_key();
+            signers.push(signer);
+            validators.push(pk);
+        }
+        validators.sort();
+        signers.sort_by_key(|s| s.public_key());
+        let mut registrations = common::register_validators(&mut oracle, &validators).await;
+
+        // Link all validators
+        common::link_validators(&mut oracle, &validators, link, None).await;
+
+        // Create the engine clients
+        let genesis_hash =
+            from_hex_formatted(common::GENESIS_HASH).expect("failed to decode genesis hash");
+        let genesis_hash: [u8; 32] = genesis_hash
+            .try_into()
+            .expect("failed to convert genesis hash");
+
+        // Create a single deposit request using the helper
+        let deposit_requests = common::create_deposit_requests(1);
+        let test_deposit = deposit_requests[0].clone();
+
+        let withdrawal_address = Address::from_slice(&test_deposit.withdrawal_credentials[12..32]);
+        let test_withdrawal = common::create_withdrawal_request(
+            withdrawal_address,
+            test_deposit.bls_pubkey,
+            test_deposit.amount,
+        );
+
+        // Convert to ExecutionRequest and then to Requests
+        let execution_requests1 = vec![ExecutionRequest::Deposit(test_deposit.clone())];
+        let requests1 = common::execution_requests_to_requests(execution_requests1);
+
+        let execution_requests2 = vec![ExecutionRequest::Withdrawal(test_withdrawal.clone())];
+        let requests2 = common::execution_requests_to_requests(execution_requests2);
+
+        // Create execution requests map (add deposit to block 5)
+        let deposit_block_height = 5;
+        let withdrawal_block_height = 7;
+        let stop_height = deposit_block_height + 1;
+        let mut execution_requests_map = HashMap::new();
+        execution_requests_map.insert(deposit_block_height, requests1);
+        execution_requests_map.insert(withdrawal_block_height, requests2);
+
+        let engine_client_network = MockEngineNetworkBuilder::new(genesis_hash)
+            .with_execution_requests(execution_requests_map)
+            .build();
+
+        // Derive threshold
+        let (polynomial, shares) = ops::generate_shares::<_, MinPk>(&mut OsRng, None, n, threshold);
+
+        // Create instances
+        let mut public_keys = HashSet::new();
+        for (idx, signer) in signers.into_iter().enumerate() {
+            // Create signer context
+            let public_key = signer.public_key();
+            public_keys.insert(public_key.clone());
+
+            // Configure engine
+            let uid = format!("validator-{public_key}");
+            let namespace = String::from("_SEISMIC_BFT");
+
+            let engine_client = engine_client_network.create_client(uid.clone());
+
+            let config = get_default_engine_config(
+                engine_client,
+                uid.clone(),
+                genesis_hash,
+                namespace,
+                signer,
+                polynomial.clone(),
+                shares[idx].clone(),
+                validators.clone(),
+            );
+            let engine = Engine::new(
+                context.with_label(&uid),
+                config,
+                oracle.control(public_key.clone()),
+            )
+            .await;
+
+            // Get networking
+            let (pending, recovered, resolver, broadcast, backfill) =
+                registrations.remove(&public_key).unwrap();
+
+            // Start engine
+            engine.start(pending, recovered, resolver, broadcast, backfill);
+        }
+
+        // Poll metrics
+        let mut num_nodes_finished = 0;
+        loop {
+            let metrics = context.encode();
+
+            // Iterate over all lines
+            let mut success = false;
+            for line in metrics.lines() {
+                // Ensure it is a metrics line
+                if !line.starts_with("validator-") {
+                    continue;
+                }
+
+                // Split metric and value
+                let mut parts = line.split_whitespace();
+                let metric = parts.next().unwrap();
+                let value = parts.next().unwrap();
+
+                // If ends with peers_blocked, ensure it is zero
+                if metric.ends_with("_peers_blocked") {
+                    let value = value.parse::<u64>().unwrap();
+                    assert_eq!(value, 0);
+                }
+
+                if metric.ends_with("withdrawal_validator_balance") {
+                    let balance = value.parse::<u64>().unwrap();
+                    // Parse the pubkey from the metric name using helper function
+                    if let Some(pubkey_hex) = common::parse_metric_substring(metric, "bls_key") {
+                        let ed_pubkey_hex = common::parse_metric_substring(metric, "ed_key")
+                            .expect("ed key missing");
+                        let creds =
+                            common::parse_metric_substring(metric, "creds").expect("creds missing");
+                        assert_eq!(creds, hex::encode(test_withdrawal.source_address));
+                        assert_eq!(ed_pubkey_hex, test_deposit.ed25519_pubkey.to_string());
+                        let bls_pubkey_hex = hex::encode(test_deposit.bls_pubkey);
+                        assert_eq!(bls_pubkey_hex, pubkey_hex);
+                        assert_eq!(balance, test_deposit.amount - test_withdrawal.amount);
+                        num_nodes_finished += 1;
+                        if num_nodes_finished == n {
+                            success = true;
+                            break;
+                        }
+                    } else {
+                        println!("{}: {} (failed to parse pubkey)", metric, value);
+                    }
+                }
+            }
+            if success {
+                break;
+            }
+
+            // Still waiting for all validators to complete
+            context.sleep(Duration::from_secs(1)).await;
+        }
+
+        let withdrawals = engine_client_network.get_withdrawals();
+        assert_eq!(withdrawals.len(), 1);
+        let withdrawals = withdrawals
+            .get(&(withdrawal_block_height + VALIDATOR_WITHDRAWAL_PERIOD))
+            .expect("missing withdrawal");
+        assert_eq!(withdrawals[0].amount, test_withdrawal.amount);
+        assert_eq!(withdrawals[0].address, test_withdrawal.source_address);
 
         // Check that all nodes have the same canonical chain
         assert!(

--- a/node/src/tests/execution_requests.rs
+++ b/node/src/tests/execution_requests.rs
@@ -21,7 +21,7 @@ use summit_types::execution_request::ExecutionRequest;
 use crate::engine::VALIDATOR_WITHDRAWAL_PERIOD;
 
 #[test_traced("INFO")]
-fn test_deposit_request() {
+fn test_deposit_request_single() {
     // Adds a deposit request to the block at height 5, and then checks
     // the internal validator state to make sure that the validator balance, public keys,
     // and withdrawal credentials were added correctly.
@@ -80,7 +80,7 @@ fn test_deposit_request() {
 
         // Create execution requests map (add deposit to block 5)
         let deposit_block_height = 5;
-        let stop_height = deposit_block_height + 1;
+        let stop_height = deposit_block_height + 5;
         let mut execution_requests_map = HashMap::new();
         execution_requests_map.insert(deposit_block_height, requests);
 
@@ -261,7 +261,7 @@ fn test_deposit_request_top_up() {
         // Create execution requests map (add deposit to block 5)
         let deposit_block_height = 5;
         let withdrawal_block_height = 10;
-        let stop_height = withdrawal_block_height + VALIDATOR_WITHDRAWAL_PERIOD;
+        let stop_height = withdrawal_block_height + VALIDATOR_WITHDRAWAL_PERIOD + 5;
         let mut execution_requests_map = HashMap::new();
         execution_requests_map.insert(deposit_block_height, requests1);
         execution_requests_map.insert(withdrawal_block_height, requests2);
@@ -312,7 +312,8 @@ fn test_deposit_request_top_up() {
         }
 
         // Poll metrics
-        let mut num_nodes_finished = 0;
+        let mut num_nodes_height_reached = 0;
+        let mut num_nodes_processed_requests = 0;
         loop {
             let metrics = context.encode();
 
@@ -335,6 +336,13 @@ fn test_deposit_request_top_up() {
                     assert_eq!(value, 0);
                 }
 
+                if metric.ends_with("finalizer_height") {
+                    let height = value.parse::<u64>().unwrap();
+                    if height == stop_height {
+                        num_nodes_height_reached += 1;
+                    }
+                }
+
                 if metric.ends_with("validator_balance") {
                     let balance = value.parse::<u64>().unwrap();
                     if balance == test_deposit1.amount {
@@ -352,14 +360,14 @@ fn test_deposit_request_top_up() {
                         assert_eq!(bls_pubkey_hex, pubkey_hex);
                         // The amount from both deposits should be added to the validator balance
                         assert_eq!(balance, test_deposit1.amount + test_deposit2.amount);
-                        num_nodes_finished += 1;
-                        if num_nodes_finished == n {
-                            success = true;
-                            break;
-                        }
+                        num_nodes_processed_requests += 1;
                     } else {
                         println!("{}: {} (failed to parse pubkey)", metric, value);
                     }
+                }
+                if num_nodes_processed_requests >= n && num_nodes_height_reached >= n {
+                    success = true;
+                    break;
                 }
             }
             if success {
@@ -454,7 +462,7 @@ fn test_deposit_and_withdrawal_request() {
         // Create execution requests map (add deposit to block 5)
         let deposit_block_height = 5;
         let withdrawal_block_height = 7;
-        let stop_height = deposit_block_height + 1;
+        let stop_height = deposit_block_height + 10;
         let mut execution_requests_map = HashMap::new();
         execution_requests_map.insert(deposit_block_height, requests1);
         execution_requests_map.insert(withdrawal_block_height, requests2);
@@ -505,7 +513,8 @@ fn test_deposit_and_withdrawal_request() {
         }
 
         // Poll metrics
-        let mut num_nodes_finished = 0;
+        let mut num_nodes_height_reached = 0;
+        let mut num_nodes_processed_requests = 0;
         loop {
             let metrics = context.encode();
 
@@ -528,6 +537,13 @@ fn test_deposit_and_withdrawal_request() {
                     assert_eq!(value, 0);
                 }
 
+                if metric.ends_with("finalizer_height") {
+                    let height = value.parse::<u64>().unwrap();
+                    if height == stop_height {
+                        num_nodes_height_reached += 1;
+                    }
+                }
+
                 if metric.ends_with("withdrawal_validator_balance") {
                     let balance = value.parse::<u64>().unwrap();
                     // Parse the pubkey from the metric name using helper function
@@ -541,14 +557,14 @@ fn test_deposit_and_withdrawal_request() {
                         let bls_pubkey_hex = hex::encode(test_deposit.bls_pubkey);
                         assert_eq!(bls_pubkey_hex, pubkey_hex);
                         assert_eq!(balance, test_deposit.amount - test_withdrawal.amount);
-                        num_nodes_finished += 1;
-                        if num_nodes_finished == n {
-                            success = true;
-                            break;
-                        }
+                        num_nodes_processed_requests += 1;
                     } else {
                         println!("{}: {} (failed to parse pubkey)", metric, value);
                     }
+                }
+                if num_nodes_processed_requests >= n && num_nodes_height_reached >= n {
+                    success = true;
+                    break;
                 }
             }
             if success {

--- a/node/src/tests/execution_requests.rs
+++ b/node/src/tests/execution_requests.rs
@@ -383,9 +383,11 @@ fn test_deposit_request_top_up() {
 
 #[test_traced("INFO")]
 fn test_deposit_and_withdrawal_request() {
-    // Adds a deposit request to the block at height 5, and then checks
-    // the internal validator state to make sure that the validator balance, public keys,
-    // and withdrawal credentials were added correctly.
+    // Adds a deposit request to the block at height 5, and then adds a withdrawal request
+    // to the block at height 7.
+    // It is verified that the validator balance is correctly decremented after the withdrawal,
+    // and that the withdrawal request that is send to the execution layer matches the
+    // withdrawal request (execution request) that was initially added to block 7.
     let n = 10;
     let link = Link {
         latency: 80.0,

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,15 @@
+i=1
+while cargo test test_deposit_request_top_up -- --nocapture; do
+  echo "=== Test passed (iteration $i) ==="
+  ((i++))
+done
+echo "=== Test failed on iteration $i ==="
+
+Or if you want to capture all output to a file while also seeing it on screen:
+
+i=1
+while cargo test test_deposit_request_top_up -- --nocapture 2>&1 | tee test_output_$i.log; do
+  echo "=== Test passed (iteration $i) ==="
+  ((i++))
+done
+echo "=== Test failed on iteration $i ==="

--- a/types/src/block.rs
+++ b/types/src/block.rs
@@ -23,9 +23,13 @@ pub struct Block {
 
     pub timestamp: u64,
 
+    // consensus view from threshold simplex when this block was created
+    pub view: u64,
+
     pub payload: ExecutionPayloadV3,
 
     pub execution_requests: Vec<AlloyBytes>,
+
     pub block_value: U256,
 
     // precomputed digest of this block
@@ -53,6 +57,7 @@ impl Block {
         payload: ExecutionPayloadV3,
         execution_requests: Vec<AlloyBytes>,
         block_value: U256,
+        view: u64,
     ) -> Self {
         let mut hasher = Sha256::new();
         hasher.update(&parent);
@@ -61,6 +66,7 @@ impl Block {
         hasher.update(&payload.as_ssz_bytes());
         hasher.update(&execution_requests.as_ssz_bytes());
         hasher.update(&block_value.as_ssz_bytes());
+        hasher.update(&view.to_be_bytes());
         let digest = hasher.finalize();
 
         Self {
@@ -70,6 +76,7 @@ impl Block {
             payload,
             execution_requests,
             block_value,
+            view,
             digest,
         }
     }
@@ -83,6 +90,7 @@ impl Block {
             timestamp: 0,
             payload: ExecutionPayloadV3::from_block_slow(&AlloyBlock::<TxEnvelope>::default()),
             block_value: U256::ZERO,
+            view: 1,
         }
     }
 }
@@ -112,7 +120,7 @@ impl ssz::Encode for Block {
 
     fn ssz_append(&self, buf: &mut Vec<u8>) {
         let offset = <[u8; 32] as ssz::Encode>::ssz_fixed_len()
-            + <u64 as ssz::Encode>::ssz_fixed_len() * 2
+            + <u64 as ssz::Encode>::ssz_fixed_len() * 3
             + <ExecutionPayloadV3 as ssz::Encode>::ssz_fixed_len()
             + <Vec<AlloyBytes> as ssz::Encode>::ssz_fixed_len()
             + <U256 as ssz::Encode>::ssz_fixed_len();
@@ -129,6 +137,7 @@ impl ssz::Encode for Block {
         encoder.append(&fixed_sized_digest);
         encoder.append(&self.height);
         encoder.append(&self.timestamp);
+        encoder.append(&self.view);
         encoder.append(&self.payload);
         encoder.append(&self.execution_requests);
         encoder.append(&self.block_value);
@@ -140,6 +149,7 @@ impl ssz::Encode for Block {
         Digest::SIZE
             + self.height.ssz_bytes_len()
             + self.timestamp.ssz_bytes_len()
+            + self.view.ssz_bytes_len()
             + self.payload.ssz_bytes_len()
             + self.execution_requests.ssz_bytes_len()
             + ssz::BYTES_PER_LENGTH_OFFSET
@@ -157,6 +167,7 @@ impl ssz::Decode for Block {
         builder.register_type::<[u8; 32]>()?;
         builder.register_type::<u64>()?;
         builder.register_type::<u64>()?;
+        builder.register_type::<u64>()?;
         builder.register_type::<ExecutionPayloadV3>()?;
         builder.register_type::<Vec<AlloyBytes>>()?;
         builder.register_type::<U256>()?;
@@ -166,6 +177,7 @@ impl ssz::Decode for Block {
         let parent: [u8; 32] = decoder.decode_next()?;
         let height = decoder.decode_next()?;
         let timestamp = decoder.decode_next()?;
+        let view = decoder.decode_next()?;
         let payload = decoder.decode_next()?;
         let execution_requests = decoder.decode_next()?;
         let block_value = decoder.decode_next()?;
@@ -177,6 +189,7 @@ impl ssz::Decode for Block {
             payload,
             execution_requests,
             block_value,
+            view,
         );
         Ok(block)
     }
@@ -360,6 +373,7 @@ mod test {
             payload,
             vec![Default::default()],
             U256::ZERO,
+            42,
         );
 
         let encoded = block.encode();
@@ -395,8 +409,15 @@ mod test {
             excess_blob_gas: 0x580000,
         };
 
-        let block =
-            Block::compute_digest([27u8; 32].into(), 27, 2727, payload, Vec::new(), U256::ZERO);
+        let block = Block::compute_digest(
+            [27u8; 32].into(),
+            27,
+            2727,
+            payload,
+            Vec::new(),
+            U256::ZERO,
+            42,
+        );
 
         let encoded = block.encode();
 


### PR DESCRIPTION
We mixed up the block height and the view

There are three places where the view is incremented in threshold simplex:
- [handle_notarization](https://github.com/commonwarexyz/monorepo/blob/ce5341d4754ebac5e7708111e419fd51c4909660/consensus/src/threshold_simplex/actors/voter/actor.rs#L1175)
- [handle_finalization](https://github.com/commonwarexyz/monorepo/blob/ce5341d4754ebac5e7708111e419fd51c4909660/consensus/src/threshold_simplex/actors/voter/actor.rs#L1318)
- [handle_nullification](https://github.com/commonwarexyz/monorepo/blob/ce5341d4754ebac5e7708111e419fd51c4909660/consensus/src/threshold_simplex/actors/voter/actor.rs#L1232)

The happy path is handle_notarization -> handle_finalization, which will increment the view twice. However, the block height will only be incremented once, when the block is finalized.
Also, in case of a nullification, there is no block added, but the view is still incremented.

This causes the view to outpace the block height. This isn't an issue in itself, however, we've been using the block height to update registry. But simplex will use the view when it calls the registry methods (via the Supervisor traits).

This can cause the following issue. For example, lets say we are at block height 4 and view 6, with 10 validators:
- A new [round](https://github.com/commonwarexyz/monorepo/blob/e3fffd347e68f947a292d322b9fbbd4346428d65/consensus/src/threshold_simplex/actors/batcher/actor.rs#L69) is created for view 6.
- It will call the `participants(6)` method with view 6, which will return a list of the 10 validators.
- A validator is added at height 5.
- From now on, any call to `participants(6)`  will return a list of 11 validators.
- This breaks the contract imposed by the Supervisor trait. For a given view, the returned list of validators has to always be the same.

Changes:
- Adds the view (from simplex) to the [Block](https://github.com/SeismicSystems/summit/blob/819c5c6520371c08f5a240fe2a5b07efaa429745/types/src/block.rs#L27) because the finalizer needs access to it.
- Uses the view instead of the block height for the registry
- Updates the registry to always find the largest view that is <= the requested view

Possible TODOs:
- The [view](https://github.com/SeismicSystems/summit/blob/819c5c6520371c08f5a240fe2a5b07efaa429745/types/src/block.rs#L112) method of the Block returns the height. We should probably change that to the view as well. 
