### PR TITLE
test: increase test coverage for execution request e2e tests

### DIFF
--- a/application/src/finalizer.rs
+++ b/application/src/finalizer.rs
@@ -307,21 +307,22 @@ impl<R: Storage + Metrics + Clock + Spawner + governor::clock::Clock + Rng, C: E
                                             validator_balance = request.amount;
 
                                         }
+                                        if !account_exists && validator_balance >= self.validator_minimum_stake {
+                                            // If the node shuts down, before the account changes are committed,
+                                            // then everything should work normally, because the registry is not persisted to disk
+                                            add_validators.push(request.ed25519_pubkey.clone());
+                                        }
                                         #[cfg(debug_assertions)]
                                         {
                                             let gauge: Gauge = Gauge::default();
                                             gauge.set(validator_balance as i64);
                                             ctx.register(
-                                                format!("<creds>{}</creds><ed_key>{}</ed_key><bls_key>{}</bls_key>_deposit_validator_balance",
+                                                format!("<registry>{}</registry><creds>{}</creds><ed_key>{}</ed_key><bls_key>{}</bls_key>_deposit_validator_balance",
+                                                !account_exists && validator_balance >= self.validator_minimum_stake,
                                                 hex::encode(request.withdrawal_credentials), request.ed25519_pubkey, hex::encode(request.bls_pubkey)),
                                                 "Validator balance",
                                                 gauge
                                             );
-                                        }
-                                        if !account_exists && validator_balance >= self.validator_minimum_stake {
-                                            // If the node shuts down, before the account changes are committed,
-                                            // then everything should work normally, because the registry is not persisted to disk
-                                            add_validators.push(request.ed25519_pubkey.clone());
                                         }
                                     }
                                 }

--- a/node/src/engine.rs
+++ b/node/src/engine.rs
@@ -48,7 +48,7 @@ const VALIDATOR_ONBOARDING_INTERVAL: u64 = 1;
 #[cfg(not(debug_assertions))]
 const VALIDATOR_ONBOARDING_INTERVAL: u64 = 10;
 const VALIDATOR_ONBOARDING_LIMIT_PER_BLOCK: usize = 3;
-const VALIDATOR_MINIMUM_STAKE: u64 = 32_000_000_000; // in gwei
+pub const VALIDATOR_MINIMUM_STAKE: u64 = 32_000_000_000; // in gwei
 
 #[cfg(debug_assertions)]
 pub const VALIDATOR_WITHDRAWAL_PERIOD: u64 = 5;

--- a/node/src/test_harness/common.rs
+++ b/node/src/test_harness/common.rs
@@ -272,30 +272,34 @@ pub fn parse_metric_substring(metric: &str, tag: &str) -> Option<String> {
 /// Create a single DepositRequest for testing
 ///
 /// # Arguments
+/// * `seed` - The seed value used to generate deterministic but unique keys
 /// * `amount` - The deposit amount in gwei
 ///
 /// # Returns
 /// * `DepositRequest` - A single deposit request with valid test data
-pub fn create_deposit_request(amount: u64) -> DepositRequest {
+pub fn create_deposit_request(seed: u64, amount: u64) -> DepositRequest {
     // Create valid Eth1 withdrawal credentials: 0x01 + 11 zero bytes + 20-byte address
     let mut withdrawal_credentials = [0u8; 32];
     withdrawal_credentials[0] = 0x01; // Eth1 withdrawal prefix
-    // Use a deterministic address pattern for the last 20 bytes
+    // Use seed-based address pattern for the last 20 bytes
     for j in 0..20 {
-        withdrawal_credentials[12 + j] = (j % 256) as u8;
+        withdrawal_credentials[12 + j] = ((seed + j as u64) % 256) as u8;
     }
 
-    // Create deterministic but valid keys
-    let ed25519_seed = [1u8; 32];
-    
+    // Create deterministic but seed-based keys
+    let mut ed25519_seed = [0u8; 32];
+    for j in 0..32 {
+        ed25519_seed[j] = ((seed + j as u64 + 1) % 256) as u8;
+    }
+
     let mut bls_pubkey = [0u8; 48];
     for j in 0..48 {
-        bls_pubkey[j] = ((j + 1) % 256) as u8;
+        bls_pubkey[j] = ((seed + j as u64 + 33) % 256) as u8;
     }
 
     let mut signature = [0u8; 96];
     for j in 0..96 {
-        signature[j] = ((j + 2) % 256) as u8;
+        signature[j] = ((seed + j as u64 + 81) % 256) as u8;
     }
 
     DepositRequest {
@@ -304,7 +308,7 @@ pub fn create_deposit_request(amount: u64) -> DepositRequest {
         withdrawal_credentials,
         amount,
         signature,
-        index: 1,
+        index: seed,
     }
 }
 

--- a/node/src/test_harness/common.rs
+++ b/node/src/test_harness/common.rs
@@ -11,7 +11,7 @@ use crate::{config::EngineConfig, engine::Engine};
 use alloy_eips::eip7685::Requests;
 use alloy_primitives::{Address, Bytes};
 use alloy_signer::k256::elliptic_curve::rand_core::OsRng;
-use commonware_codec::{DecodeExt, Write};
+use commonware_codec::Write;
 use commonware_p2p::simulated::{self, Link, Network, Oracle, Receiver, Sender};
 use commonware_runtime::{
     Clock, Metrics, Runner as _,
@@ -287,10 +287,9 @@ pub fn create_deposit_request(seed: u64, amount: u64) -> DepositRequest {
     }
 
     // Create deterministic but seed-based keys
-    let mut ed25519_seed = [0u8; 32];
-    for j in 0..32 {
-        ed25519_seed[j] = ((seed + j as u64 + 1) % 256) as u8;
-    }
+    // Generate a valid ED25519 private key using the seed
+    let ed25519_private_key = PrivateKey::from_seed(seed);
+    let ed25519_pubkey = ed25519_private_key.public_key();
 
     let mut bls_pubkey = [0u8; 48];
     for j in 0..48 {
@@ -303,7 +302,7 @@ pub fn create_deposit_request(seed: u64, amount: u64) -> DepositRequest {
     }
 
     DepositRequest {
-        ed25519_pubkey: PublicKey::decode(&ed25519_seed[..]).expect("valid ed25519 key"),
+        ed25519_pubkey,
         bls_pubkey,
         withdrawal_credentials,
         amount,

--- a/node/src/test_harness/common.rs
+++ b/node/src/test_harness/common.rs
@@ -269,53 +269,43 @@ pub fn parse_metric_substring(metric: &str, tag: &str) -> Option<String> {
     Some(metric[substring_start..end].to_string())
 }
 
-/// Create a list of n DepositRequests for testing
+/// Create a single DepositRequest for testing
 ///
 /// # Arguments
-/// * `n` - The number of deposit requests to create
+/// * `amount` - The deposit amount in gwei
 ///
 /// # Returns
-/// * `Vec<DepositRequest>` - A vector containing n deposit requests with valid test data
-pub fn create_deposit_requests(n: usize) -> Vec<DepositRequest> {
-    let mut deposits = Vec::new();
-
-    for i in 0..n {
-        // Create valid Eth1 withdrawal credentials: 0x01 + 11 zero bytes + 20-byte address
-        let mut withdrawal_credentials = [0u8; 32];
-        withdrawal_credentials[0] = 0x01; // Eth1 withdrawal prefix
-        // Use a deterministic address pattern for the last 20 bytes
-        for j in 0..20 {
-            withdrawal_credentials[12 + j] = ((i + j) % 256) as u8;
-        }
-
-        // Create deterministic but valid keys for each deposit
-        let mut ed25519_seed = [1u8; 32];
-        ed25519_seed[0] = (i % 256) as u8;
-        ed25519_seed[1] = ((i / 256) % 256) as u8;
-
-        let mut bls_pubkey = [0u8; 48];
-        for j in 0..48 {
-            bls_pubkey[j] = ((i + j + 1) % 256) as u8;
-        }
-
-        let mut signature = [0u8; 96];
-        for j in 0..96 {
-            signature[j] = ((i + j + 2) % 256) as u8;
-        }
-
-        let deposit = DepositRequest {
-            ed25519_pubkey: PublicKey::decode(&ed25519_seed[..]).expect("valid ed25519 key"),
-            bls_pubkey,
-            withdrawal_credentials,
-            amount: 32_000_000_000,
-            signature,
-            index: i as u64 + 1,
-        };
-
-        deposits.push(deposit);
+/// * `DepositRequest` - A single deposit request with valid test data
+pub fn create_deposit_request(amount: u64) -> DepositRequest {
+    // Create valid Eth1 withdrawal credentials: 0x01 + 11 zero bytes + 20-byte address
+    let mut withdrawal_credentials = [0u8; 32];
+    withdrawal_credentials[0] = 0x01; // Eth1 withdrawal prefix
+    // Use a deterministic address pattern for the last 20 bytes
+    for j in 0..20 {
+        withdrawal_credentials[12 + j] = (j % 256) as u8;
     }
 
-    deposits
+    // Create deterministic but valid keys
+    let ed25519_seed = [1u8; 32];
+    
+    let mut bls_pubkey = [0u8; 48];
+    for j in 0..48 {
+        bls_pubkey[j] = ((j + 1) % 256) as u8;
+    }
+
+    let mut signature = [0u8; 96];
+    for j in 0..96 {
+        signature[j] = ((j + 2) % 256) as u8;
+    }
+
+    DepositRequest {
+        ed25519_pubkey: PublicKey::decode(&ed25519_seed[..]).expect("valid ed25519 key"),
+        bls_pubkey,
+        withdrawal_credentials,
+        amount,
+        signature,
+        index: 1,
+    }
 }
 
 /// Create a single WithdrawalRequest for testing

--- a/node/src/tests/execution_requests.rs
+++ b/node/src/tests/execution_requests.rs
@@ -71,7 +71,7 @@ fn test_deposit_request_single() {
             .expect("failed to convert genesis hash");
 
         // Create a single deposit request using the helper
-        let test_deposit = common::create_deposit_request(VALIDATOR_MINIMUM_STAKE);
+        let test_deposit = common::create_deposit_request(0, VALIDATOR_MINIMUM_STAKE);
 
         // Convert to ExecutionRequest and then to Requests
         let execution_requests = vec![ExecutionRequest::Deposit(test_deposit.clone())];
@@ -244,7 +244,7 @@ fn test_deposit_request_top_up() {
             .expect("failed to convert genesis hash");
 
         // Create a single deposit request using the helper
-        let test_deposit1 = common::create_deposit_request(VALIDATOR_MINIMUM_STAKE);
+        let test_deposit1 = common::create_deposit_request(0, VALIDATOR_MINIMUM_STAKE);
         let mut test_deposit2 = test_deposit1.clone();
         test_deposit2.amount = 10_000_000_000;
         test_deposit2.index += 1;
@@ -440,7 +440,7 @@ fn test_deposit_and_withdrawal_request() {
             .expect("failed to convert genesis hash");
 
         // Create a single deposit request using the helper
-        let test_deposit = common::create_deposit_request(VALIDATOR_MINIMUM_STAKE);
+        let test_deposit = common::create_deposit_request(0, VALIDATOR_MINIMUM_STAKE);
 
         let withdrawal_address = Address::from_slice(&test_deposit.withdrawal_credentials[12..32]);
         let test_withdrawal = common::create_withdrawal_request(
@@ -645,7 +645,7 @@ fn test_partial_withdrawal_balance_below_minimum_stake() {
             .expect("failed to convert genesis hash");
 
         // Create a single deposit request using the helper
-        let test_deposit = common::create_deposit_request(VALIDATOR_MINIMUM_STAKE);
+        let test_deposit = common::create_deposit_request(0, VALIDATOR_MINIMUM_STAKE);
 
         let withdrawal_address = Address::from_slice(&test_deposit.withdrawal_credentials[12..32]);
         let test_withdrawal1 = common::create_withdrawal_request(
@@ -710,7 +710,7 @@ fn test_partial_withdrawal_balance_below_minimum_stake() {
                 config,
                 oracle.control(public_key.clone()),
             )
-                .await;
+            .await;
 
             // Get networking
             let (pending, recovered, resolver, broadcast, backfill) =
@@ -859,7 +859,7 @@ fn test_deposit_less_than_min_stake_and_withdrawal() {
             .expect("failed to convert genesis hash");
 
         // Create a single deposit request using the helper
-        let test_deposit = common::create_deposit_request(VALIDATOR_MINIMUM_STAKE / 2);
+        let test_deposit = common::create_deposit_request(0, VALIDATOR_MINIMUM_STAKE / 2);
 
         let withdrawal_address = Address::from_slice(&test_deposit.withdrawal_credentials[12..32]);
         let test_withdrawal = common::create_withdrawal_request(
@@ -918,7 +918,7 @@ fn test_deposit_less_than_min_stake_and_withdrawal() {
                 config,
                 oracle.control(public_key.clone()),
             )
-                .await;
+            .await;
 
             // Get networking
             let (pending, recovered, resolver, broadcast, backfill) =
@@ -962,7 +962,8 @@ fn test_deposit_less_than_min_stake_and_withdrawal() {
 
                 if metric.ends_with("deposit_validator_balance") {
                     let balance = value.parse::<u64>().unwrap();
-                    let registry_flag = common::parse_metric_substring(metric, "registry").expect("registry flag missing");
+                    let registry_flag = common::parse_metric_substring(metric, "registry")
+                        .expect("registry flag missing");
                     assert_eq!(balance, test_deposit.amount);
                     // Make sure that the validator was not added to the registry
                     assert_eq!(registry_flag, "false");
@@ -1006,6 +1007,247 @@ fn test_deposit_less_than_min_stake_and_withdrawal() {
             .expect("missing withdrawal");
         assert_eq!(withdrawals[0].amount, test_withdrawal.amount);
         assert_eq!(withdrawals[0].address, test_withdrawal.source_address);
+
+        // Check that all nodes have the same canonical chain
+        assert!(
+            engine_client_network
+                .verify_consensus(Some(stop_height))
+                .is_ok()
+        );
+
+        context.auditor().state()
+    })
+}
+
+#[test_traced("INFO")]
+fn test_deposit_and_withdrawal_request_multiple() {
+    // This test is very similar to `test_deposit_and_withdrawal_request`, but instead
+    // of a single deposit and withdrawal request, it has 5 deposit and withdrawal requests
+    // (from different public keys).
+    let n = 10;
+    let link = Link {
+        latency: 80.0,
+        jitter: 10.0,
+        success_rate: 0.98,
+    };
+    // Create context
+    let threshold = quorum(n);
+    let cfg = deterministic::Config::default().with_seed(0);
+    let executor = Runner::from(cfg);
+    executor.start(|context| async move {
+        // Create simulated network
+        let (network, mut oracle) = Network::new(
+            context.with_label("network"),
+            simulated::Config {
+                max_size: 1024 * 1024,
+            },
+        );
+
+        // Start network
+        network.start();
+
+        // Register participants
+        let mut signers = Vec::new();
+        let mut validators = Vec::new();
+        for i in 0..n {
+            let signer = PrivateKey::from_seed(i as u64);
+            let pk = signer.public_key();
+            signers.push(signer);
+            validators.push(pk);
+        }
+        validators.sort();
+        signers.sort_by_key(|s| s.public_key());
+        let mut registrations = common::register_validators(&mut oracle, &validators).await;
+
+        // Link all validators
+        common::link_validators(&mut oracle, &validators, link, None).await;
+
+        // Create the engine clients
+        let genesis_hash =
+            from_hex_formatted(common::GENESIS_HASH).expect("failed to decode genesis hash");
+        let genesis_hash: [u8; 32] = genesis_hash
+            .try_into()
+            .expect("failed to convert genesis hash");
+
+        // Create deposit and matching withdrawal requests
+        let mut deposit_reqs = HashMap::new();
+        let mut withdrawal_reqs = HashMap::new();
+        for i in 0..deposit_reqs.len() {
+            let test_deposit = common::create_deposit_request(i as u64, VALIDATOR_MINIMUM_STAKE);
+
+            let withdrawal_address =
+                Address::from_slice(&test_deposit.withdrawal_credentials[12..32]);
+            let test_withdrawal = common::create_withdrawal_request(
+                withdrawal_address,
+                test_deposit.bls_pubkey,
+                test_deposit.amount,
+            );
+            deposit_reqs.insert(hex::encode(test_deposit.bls_pubkey), test_deposit);
+            withdrawal_reqs.insert(
+                hex::encode(test_withdrawal.validator_pubkey),
+                test_withdrawal,
+            );
+        }
+
+        // Convert to ExecutionRequest and then to Requests
+        let execution_requests1: Vec<ExecutionRequest> = deposit_reqs
+            .values()
+            .map(|d| ExecutionRequest::Deposit(d.clone()))
+            .collect();
+        let requests1 = common::execution_requests_to_requests(execution_requests1);
+
+        let execution_requests2: Vec<ExecutionRequest> = withdrawal_reqs
+            .values()
+            .map(|w| ExecutionRequest::Withdrawal(w.clone()))
+            .collect();
+        let requests2 = common::execution_requests_to_requests(execution_requests2);
+
+        // Create execution requests map (add deposit to block 5)
+        let deposit_block_height = 5;
+        let withdrawal_block_height = 6;
+        let stop_height = deposit_block_height + 15;
+        let mut execution_requests_map = HashMap::new();
+        execution_requests_map.insert(deposit_block_height, requests1);
+        execution_requests_map.insert(withdrawal_block_height, requests2);
+
+        let engine_client_network = MockEngineNetworkBuilder::new(genesis_hash)
+            .with_execution_requests(execution_requests_map)
+            .build();
+
+        // Derive threshold
+        let (polynomial, shares) = ops::generate_shares::<_, MinPk>(&mut OsRng, None, n, threshold);
+
+        // Create instances
+        let mut public_keys = HashSet::new();
+        for (idx, signer) in signers.into_iter().enumerate() {
+            // Create signer context
+            let public_key = signer.public_key();
+            public_keys.insert(public_key.clone());
+
+            // Configure engine
+            let uid = format!("validator-{public_key}");
+            let namespace = String::from("_SEISMIC_BFT");
+
+            let engine_client = engine_client_network.create_client(uid.clone());
+
+            let config = get_default_engine_config(
+                engine_client,
+                uid.clone(),
+                genesis_hash,
+                namespace,
+                signer,
+                polynomial.clone(),
+                shares[idx].clone(),
+                validators.clone(),
+            );
+            let engine = Engine::new(
+                context.with_label(&uid),
+                config,
+                oracle.control(public_key.clone()),
+            )
+            .await;
+
+            // Get networking
+            let (pending, recovered, resolver, broadcast, backfill) =
+                registrations.remove(&public_key).unwrap();
+
+            // Start engine
+            engine.start(pending, recovered, resolver, broadcast, backfill);
+        }
+
+        // Poll metrics
+        let mut num_nodes_height_reached = 0;
+        loop {
+            let metrics = context.encode();
+
+            // Iterate over all lines
+            let mut success = false;
+            for line in metrics.lines() {
+                // Ensure it is a metrics line
+                if !line.starts_with("validator-") {
+                    continue;
+                }
+
+                // Split metric and value
+                let mut parts = line.split_whitespace();
+                let metric = parts.next().unwrap();
+                let value = parts.next().unwrap();
+
+                // If ends with peers_blocked, ensure it is zero
+                if metric.ends_with("_peers_blocked") {
+                    let value = value.parse::<u64>().unwrap();
+                    assert_eq!(value, 0);
+                }
+
+                if metric.ends_with("finalizer_height") {
+                    let height = value.parse::<u64>().unwrap();
+                    if height == stop_height {
+                        num_nodes_height_reached += 1;
+                    }
+                }
+
+                if metric.ends_with("deposit_validator_balance") {
+                    let balance = value.parse::<u64>().unwrap();
+                    let bls_key_hex =
+                        common::parse_metric_substring(metric, "bls_key").expect("bls key missing");
+
+                    let deposit_req = deposit_reqs.get(&bls_key_hex).unwrap();
+
+                    let ed_pubkey_hex =
+                        common::parse_metric_substring(metric, "ed_key").expect("ed key missing");
+                    let creds =
+                        common::parse_metric_substring(metric, "creds").expect("creds missing");
+                    assert_eq!(creds, hex::encode(deposit_req.withdrawal_credentials));
+                    assert_eq!(ed_pubkey_hex, deposit_req.ed25519_pubkey.to_string());
+                    let bls_pubkey_hex = hex::encode(deposit_req.bls_pubkey);
+                    assert_eq!(bls_pubkey_hex, bls_key_hex);
+                    assert_eq!(balance, deposit_req.amount);
+                }
+
+                if metric.ends_with("withdrawal_validator_balance") {
+                    let bls_key_hex =
+                        common::parse_metric_substring(metric, "bls_key").expect("bls key missing");
+                    let withdrawal_req = withdrawal_reqs.get(&bls_key_hex).unwrap();
+                    let deposit_req = deposit_reqs.get(&bls_key_hex).unwrap();
+                    let ed_pubkey_hex =
+                        common::parse_metric_substring(metric, "ed_key").expect("ed key missing");
+                    let creds =
+                        common::parse_metric_substring(metric, "creds").expect("creds missing");
+
+                    let balance = value.parse::<u64>().unwrap();
+                    assert_eq!(creds, hex::encode(withdrawal_req.source_address));
+                    assert_eq!(ed_pubkey_hex, deposit_req.ed25519_pubkey.to_string());
+                    assert_eq!(bls_key_hex, hex::encode(withdrawal_req.validator_pubkey));
+                    assert_eq!(balance, deposit_req.amount - withdrawal_req.amount);
+                }
+                if num_nodes_height_reached >= n {
+                    success = true;
+                    break;
+                }
+            }
+            if success {
+                break;
+            }
+
+            // Still waiting for all validators to complete
+            context.sleep(Duration::from_secs(1)).await;
+        }
+
+        let withdrawals = engine_client_network.get_withdrawals();
+        assert_eq!(withdrawals.len(), withdrawal_reqs.len());
+
+        let expected_withdrawals: HashMap<Address, _> = withdrawal_reqs
+            .into_iter()
+            .map(|(_, withdrawal)| (withdrawal.source_address, withdrawal))
+            .collect();
+
+        for (_height, withdrawals) in withdrawals {
+            for withdrawal in withdrawals {
+                let expected_withdrawal = expected_withdrawals.get(&withdrawal.address).unwrap();
+                assert_eq!(withdrawal.amount, expected_withdrawal.amount);
+                assert_eq!(withdrawal.address, expected_withdrawal.source_address);
+            }
+        }
 
         // Check that all nodes have the same canonical chain
         assert!(

--- a/node/src/tests/execution_requests.rs
+++ b/node/src/tests/execution_requests.rs
@@ -1,4 +1,4 @@
-use crate::engine::Engine;
+use crate::engine::{Engine, VALIDATOR_MINIMUM_STAKE};
 use crate::test_harness::common;
 use crate::test_harness::common::get_default_engine_config;
 use crate::test_harness::mock_engine_client::MockEngineNetworkBuilder;
@@ -71,8 +71,7 @@ fn test_deposit_request_single() {
             .expect("failed to convert genesis hash");
 
         // Create a single deposit request using the helper
-        let deposit_requests = common::create_deposit_requests(1);
-        let test_deposit = deposit_requests[0].clone();
+        let test_deposit = common::create_deposit_request(VALIDATOR_MINIMUM_STAKE);
 
         // Convert to ExecutionRequest and then to Requests
         let execution_requests = vec![ExecutionRequest::Deposit(test_deposit.clone())];
@@ -245,8 +244,7 @@ fn test_deposit_request_top_up() {
             .expect("failed to convert genesis hash");
 
         // Create a single deposit request using the helper
-        let deposit_requests = common::create_deposit_requests(1);
-        let test_deposit1 = deposit_requests[0].clone();
+        let test_deposit1 = common::create_deposit_request(VALIDATOR_MINIMUM_STAKE);
         let mut test_deposit2 = test_deposit1.clone();
         test_deposit2.amount = 10_000_000_000;
         test_deposit2.index += 1;
@@ -442,8 +440,7 @@ fn test_deposit_and_withdrawal_request() {
             .expect("failed to convert genesis hash");
 
         // Create a single deposit request using the helper
-        let deposit_requests = common::create_deposit_requests(1);
-        let test_deposit = deposit_requests[0].clone();
+        let test_deposit = common::create_deposit_request(VALIDATOR_MINIMUM_STAKE);
 
         let withdrawal_address = Address::from_slice(&test_deposit.withdrawal_credentials[12..32]);
         let test_withdrawal = common::create_withdrawal_request(
@@ -582,6 +579,221 @@ fn test_deposit_and_withdrawal_request() {
             .expect("missing withdrawal");
         assert_eq!(withdrawals[0].amount, test_withdrawal.amount);
         assert_eq!(withdrawals[0].address, test_withdrawal.source_address);
+
+        // Check that all nodes have the same canonical chain
+        assert!(
+            engine_client_network
+                .verify_consensus(Some(stop_height))
+                .is_ok()
+        );
+
+        context.auditor().state()
+    })
+}
+
+#[test_traced("INFO")]
+fn test_partial_withdrawal_balance_below_minimum_stake() {
+    // Adds a deposit request to the block at height 5, and then adds a withdrawal request
+    // to the block at height 7.
+    // The withdrawal request will take the validator below the minimum stake, which means that
+    // the entire remaining balance should be withdrawn.
+    // We also add another withdraw request at height 8, which should be ignored, since there
+    // is no balance left.
+    let n = 10;
+    let link = Link {
+        latency: 80.0,
+        jitter: 10.0,
+        success_rate: 0.98,
+    };
+    // Create context
+    let threshold = quorum(n);
+    let cfg = deterministic::Config::default().with_seed(0);
+    let executor = Runner::from(cfg);
+    executor.start(|context| async move {
+        // Create simulated network
+        let (network, mut oracle) = Network::new(
+            context.with_label("network"),
+            simulated::Config {
+                max_size: 1024 * 1024,
+            },
+        );
+
+        // Start network
+        network.start();
+
+        // Register participants
+        let mut signers = Vec::new();
+        let mut validators = Vec::new();
+        for i in 0..n {
+            let signer = PrivateKey::from_seed(i as u64);
+            let pk = signer.public_key();
+            signers.push(signer);
+            validators.push(pk);
+        }
+        validators.sort();
+        signers.sort_by_key(|s| s.public_key());
+        let mut registrations = common::register_validators(&mut oracle, &validators).await;
+
+        // Link all validators
+        common::link_validators(&mut oracle, &validators, link, None).await;
+
+        // Create the engine clients
+        let genesis_hash =
+            from_hex_formatted(common::GENESIS_HASH).expect("failed to decode genesis hash");
+        let genesis_hash: [u8; 32] = genesis_hash
+            .try_into()
+            .expect("failed to convert genesis hash");
+
+        // Create a single deposit request using the helper
+        let test_deposit = common::create_deposit_request(VALIDATOR_MINIMUM_STAKE);
+
+        let withdrawal_address = Address::from_slice(&test_deposit.withdrawal_credentials[12..32]);
+        let test_withdrawal1 = common::create_withdrawal_request(
+            withdrawal_address,
+            test_deposit.bls_pubkey,
+            test_deposit.amount / 2,
+        );
+        let mut test_withdrawal2 = test_withdrawal1.clone();
+        test_withdrawal2.amount -= test_withdrawal1.amount / 2;
+
+        // Convert to ExecutionRequest and then to Requests
+        let execution_requests1 = vec![ExecutionRequest::Deposit(test_deposit.clone())];
+        let requests1 = common::execution_requests_to_requests(execution_requests1);
+
+        let execution_requests2 = vec![ExecutionRequest::Withdrawal(test_withdrawal1.clone())];
+        let requests2 = common::execution_requests_to_requests(execution_requests2);
+
+        let execution_requests3 = vec![ExecutionRequest::Withdrawal(test_withdrawal1.clone())];
+        let requests3 = common::execution_requests_to_requests(execution_requests3);
+
+        // Create execution requests map (add deposit to block 5)
+        let deposit_block_height = 5;
+        let withdrawal_block_height = 7;
+        let stop_height = deposit_block_height + 10;
+        let mut execution_requests_map = HashMap::new();
+        execution_requests_map.insert(deposit_block_height, requests1);
+        execution_requests_map.insert(withdrawal_block_height, requests2);
+        execution_requests_map.insert(withdrawal_block_height + 1, requests3);
+
+        let engine_client_network = MockEngineNetworkBuilder::new(genesis_hash)
+            .with_execution_requests(execution_requests_map)
+            .build();
+
+        // Derive threshold
+        let (polynomial, shares) = ops::generate_shares::<_, MinPk>(&mut OsRng, None, n, threshold);
+
+        // Create instances
+        let mut public_keys = HashSet::new();
+        for (idx, signer) in signers.into_iter().enumerate() {
+            // Create signer context
+            let public_key = signer.public_key();
+            public_keys.insert(public_key.clone());
+
+            // Configure engine
+            let uid = format!("validator-{public_key}");
+            let namespace = String::from("_SEISMIC_BFT");
+
+            let engine_client = engine_client_network.create_client(uid.clone());
+
+            let config = get_default_engine_config(
+                engine_client,
+                uid.clone(),
+                genesis_hash,
+                namespace,
+                signer,
+                polynomial.clone(),
+                shares[idx].clone(),
+                validators.clone(),
+            );
+            let engine = Engine::new(
+                context.with_label(&uid),
+                config,
+                oracle.control(public_key.clone()),
+            )
+                .await;
+
+            // Get networking
+            let (pending, recovered, resolver, broadcast, backfill) =
+                registrations.remove(&public_key).unwrap();
+
+            // Start engine
+            engine.start(pending, recovered, resolver, broadcast, backfill);
+        }
+
+        // Poll metrics
+        let mut num_nodes_height_reached = 0;
+        let mut num_nodes_processed_requests = 0;
+        loop {
+            let metrics = context.encode();
+
+            // Iterate over all lines
+            let mut success = false;
+            for line in metrics.lines() {
+                // Ensure it is a metrics line
+                if !line.starts_with("validator-") {
+                    continue;
+                }
+
+                // Split metric and value
+                let mut parts = line.split_whitespace();
+                let metric = parts.next().unwrap();
+                let value = parts.next().unwrap();
+
+                // If ends with peers_blocked, ensure it is zero
+                if metric.ends_with("_peers_blocked") {
+                    let value = value.parse::<u64>().unwrap();
+                    assert_eq!(value, 0);
+                }
+
+                if metric.ends_with("finalizer_height") {
+                    let height = value.parse::<u64>().unwrap();
+                    if height == stop_height {
+                        num_nodes_height_reached += 1;
+                    }
+                }
+
+                if metric.ends_with("withdrawal_validator_balance") {
+                    let balance = value.parse::<u64>().unwrap();
+                    // Parse the pubkey from the metric name using helper function
+                    if let Some(pubkey_hex) = common::parse_metric_substring(metric, "bls_key") {
+                        let ed_pubkey_hex = common::parse_metric_substring(metric, "ed_key")
+                            .expect("ed key missing");
+                        let creds =
+                            common::parse_metric_substring(metric, "creds").expect("creds missing");
+                        assert_eq!(creds, hex::encode(test_withdrawal1.source_address));
+                        assert_eq!(ed_pubkey_hex, test_deposit.ed25519_pubkey.to_string());
+                        let bls_pubkey_hex = hex::encode(test_deposit.bls_pubkey);
+                        assert_eq!(bls_pubkey_hex, pubkey_hex);
+                        assert_eq!(balance, 0);
+                        num_nodes_processed_requests += 1;
+                    } else {
+                        println!("{}: {} (failed to parse pubkey)", metric, value);
+                    }
+                }
+                if num_nodes_processed_requests >= n && num_nodes_height_reached >= n {
+                    success = true;
+                    break;
+                }
+            }
+            if success {
+                break;
+            }
+
+            // Still waiting for all validators to complete
+            context.sleep(Duration::from_secs(1)).await;
+        }
+
+        let withdrawals = engine_client_network.get_withdrawals();
+        // Make sure that test_withdrawal2 was ignored, only test_withdraw1 should be submitted
+        // to the execution layer.
+        assert_eq!(withdrawals.len(), 1);
+        let withdrawals = withdrawals
+            .get(&(withdrawal_block_height + VALIDATOR_WITHDRAWAL_PERIOD))
+            .expect("missing withdrawal");
+        // Even though the first withdrawal was only 50% of the deposited amount,
+        // since it put the validator under the minimum stake limit, the entire balance was withdrawn.
+        assert_eq!(withdrawals[0].amount, test_deposit.amount);
+        assert_eq!(withdrawals[0].address, test_withdrawal1.source_address);
 
         // Check that all nodes have the same canonical chain
         assert!(

--- a/node/src/tests/execution_requests.rs
+++ b/node/src/tests/execution_requests.rs
@@ -71,7 +71,7 @@ fn test_deposit_request_single() {
             .expect("failed to convert genesis hash");
 
         // Create a single deposit request using the helper
-        let test_deposit = common::create_deposit_request(0, VALIDATOR_MINIMUM_STAKE);
+        let test_deposit = common::create_deposit_request(n as u64, VALIDATOR_MINIMUM_STAKE);
 
         // Convert to ExecutionRequest and then to Requests
         let execution_requests = vec![ExecutionRequest::Deposit(test_deposit.clone())];
@@ -79,7 +79,7 @@ fn test_deposit_request_single() {
 
         // Create execution requests map (add deposit to block 5)
         let deposit_block_height = 5;
-        let stop_height = deposit_block_height + 5;
+        let stop_height = deposit_block_height + 7;
         let mut execution_requests_map = HashMap::new();
         execution_requests_map.insert(deposit_block_height, requests);
 
@@ -129,7 +129,8 @@ fn test_deposit_request_single() {
         }
 
         // Poll metrics
-        let mut num_nodes_finished = 0;
+        let mut num_nodes_processed_requests = 0;
+        let mut num_nodes_height_reached = 0;
         loop {
             let metrics = context.encode();
 
@@ -152,6 +153,13 @@ fn test_deposit_request_single() {
                     assert_eq!(value, 0);
                 }
 
+                if metric.ends_with("finalizer_height") {
+                    let height = value.parse::<u64>().unwrap();
+                    if height == stop_height {
+                        num_nodes_height_reached += 1;
+                    }
+                }
+
                 if metric.ends_with("validator_balance") {
                     let value = value.parse::<u64>().unwrap();
                     // Parse the pubkey from the metric name using helper function
@@ -165,14 +173,14 @@ fn test_deposit_request_single() {
                         let bls_pubkey_hex = hex::encode(test_deposit.bls_pubkey);
                         assert_eq!(bls_pubkey_hex, pubkey_hex);
                         assert_eq!(value, test_deposit.amount);
-                        num_nodes_finished += 1;
-                        if num_nodes_finished == n {
-                            success = true;
-                            break;
-                        }
+                        num_nodes_processed_requests += 1;
                     } else {
                         println!("{}: {} (failed to parse pubkey)", metric, value);
                     }
+                }
+                if num_nodes_processed_requests >= n && num_nodes_height_reached >= n {
+                    success = true;
+                    break;
                 }
             }
             if success {
@@ -244,7 +252,7 @@ fn test_deposit_request_top_up() {
             .expect("failed to convert genesis hash");
 
         // Create a single deposit request using the helper
-        let test_deposit1 = common::create_deposit_request(0, VALIDATOR_MINIMUM_STAKE);
+        let test_deposit1 = common::create_deposit_request(n as u64, VALIDATOR_MINIMUM_STAKE);
         let mut test_deposit2 = test_deposit1.clone();
         test_deposit2.amount = 10_000_000_000;
         test_deposit2.index += 1;
@@ -388,7 +396,7 @@ fn test_deposit_request_top_up() {
 }
 
 #[test_traced("INFO")]
-fn test_deposit_and_withdrawal_request() {
+fn test_deposit_and_withdrawal_request_single() {
     // Adds a deposit request to the block at height 5, and then adds a withdrawal request
     // to the block at height 7.
     // It is verified that the validator balance is correctly decremented after the withdrawal,
@@ -440,7 +448,7 @@ fn test_deposit_and_withdrawal_request() {
             .expect("failed to convert genesis hash");
 
         // Create a single deposit request using the helper
-        let test_deposit = common::create_deposit_request(0, VALIDATOR_MINIMUM_STAKE);
+        let test_deposit = common::create_deposit_request(n as u64, VALIDATOR_MINIMUM_STAKE);
 
         let withdrawal_address = Address::from_slice(&test_deposit.withdrawal_credentials[12..32]);
         let test_withdrawal = common::create_withdrawal_request(
@@ -645,7 +653,7 @@ fn test_partial_withdrawal_balance_below_minimum_stake() {
             .expect("failed to convert genesis hash");
 
         // Create a single deposit request using the helper
-        let test_deposit = common::create_deposit_request(0, VALIDATOR_MINIMUM_STAKE);
+        let test_deposit = common::create_deposit_request(n as u64, VALIDATOR_MINIMUM_STAKE);
 
         let withdrawal_address = Address::from_slice(&test_deposit.withdrawal_credentials[12..32]);
         let test_withdrawal1 = common::create_withdrawal_request(
@@ -859,7 +867,7 @@ fn test_deposit_less_than_min_stake_and_withdrawal() {
             .expect("failed to convert genesis hash");
 
         // Create a single deposit request using the helper
-        let test_deposit = common::create_deposit_request(0, VALIDATOR_MINIMUM_STAKE / 2);
+        let test_deposit = common::create_deposit_request(n as u64, VALIDATOR_MINIMUM_STAKE / 2);
 
         let withdrawal_address = Address::from_slice(&test_deposit.withdrawal_credentials[12..32]);
         let test_withdrawal = common::create_withdrawal_request(
@@ -1073,7 +1081,8 @@ fn test_deposit_and_withdrawal_request_multiple() {
         let mut deposit_reqs = HashMap::new();
         let mut withdrawal_reqs = HashMap::new();
         for i in 0..deposit_reqs.len() {
-            let test_deposit = common::create_deposit_request(i as u64, VALIDATOR_MINIMUM_STAKE);
+            let test_deposit =
+                common::create_deposit_request(n as u64 + i as u64, VALIDATOR_MINIMUM_STAKE);
 
             let withdrawal_address =
                 Address::from_slice(&test_deposit.withdrawal_credentials[12..32]);

--- a/node/src/tests/execution_requests.rs
+++ b/node/src/tests/execution_requests.rs
@@ -805,3 +805,215 @@ fn test_partial_withdrawal_balance_below_minimum_stake() {
         context.auditor().state()
     })
 }
+
+#[test_traced("INFO")]
+fn test_deposit_less_than_min_stake_and_withdrawal() {
+    // Adds a deposit request to the block at height 5, and then adds a withdrawal request
+    // to the block at height 7.
+    // The deposit request is less than the minimum stake, so the validator should not be added
+    // to the registry.
+    // The balance should still increase and the withdrawal should work as well.
+    let n = 10;
+    let link = Link {
+        latency: 80.0,
+        jitter: 10.0,
+        success_rate: 0.98,
+    };
+    // Create context
+    let threshold = quorum(n);
+    let cfg = deterministic::Config::default().with_seed(0);
+    let executor = Runner::from(cfg);
+    executor.start(|context| async move {
+        // Create simulated network
+        let (network, mut oracle) = Network::new(
+            context.with_label("network"),
+            simulated::Config {
+                max_size: 1024 * 1024,
+            },
+        );
+
+        // Start network
+        network.start();
+
+        // Register participants
+        let mut signers = Vec::new();
+        let mut validators = Vec::new();
+        for i in 0..n {
+            let signer = PrivateKey::from_seed(i as u64);
+            let pk = signer.public_key();
+            signers.push(signer);
+            validators.push(pk);
+        }
+        validators.sort();
+        signers.sort_by_key(|s| s.public_key());
+        let mut registrations = common::register_validators(&mut oracle, &validators).await;
+
+        // Link all validators
+        common::link_validators(&mut oracle, &validators, link, None).await;
+
+        // Create the engine clients
+        let genesis_hash =
+            from_hex_formatted(common::GENESIS_HASH).expect("failed to decode genesis hash");
+        let genesis_hash: [u8; 32] = genesis_hash
+            .try_into()
+            .expect("failed to convert genesis hash");
+
+        // Create a single deposit request using the helper
+        let test_deposit = common::create_deposit_request(VALIDATOR_MINIMUM_STAKE / 2);
+
+        let withdrawal_address = Address::from_slice(&test_deposit.withdrawal_credentials[12..32]);
+        let test_withdrawal = common::create_withdrawal_request(
+            withdrawal_address,
+            test_deposit.bls_pubkey,
+            test_deposit.amount,
+        );
+
+        // Convert to ExecutionRequest and then to Requests
+        let execution_requests1 = vec![ExecutionRequest::Deposit(test_deposit.clone())];
+        let requests1 = common::execution_requests_to_requests(execution_requests1);
+
+        let execution_requests2 = vec![ExecutionRequest::Withdrawal(test_withdrawal.clone())];
+        let requests2 = common::execution_requests_to_requests(execution_requests2);
+
+        // Create execution requests map (add deposit to block 5)
+        let deposit_block_height = 5;
+        let withdrawal_block_height = 7;
+        let stop_height = deposit_block_height + 10;
+        let mut execution_requests_map = HashMap::new();
+        execution_requests_map.insert(deposit_block_height, requests1);
+        execution_requests_map.insert(withdrawal_block_height, requests2);
+
+        let engine_client_network = MockEngineNetworkBuilder::new(genesis_hash)
+            .with_execution_requests(execution_requests_map)
+            .build();
+
+        // Derive threshold
+        let (polynomial, shares) = ops::generate_shares::<_, MinPk>(&mut OsRng, None, n, threshold);
+
+        // Create instances
+        let mut public_keys = HashSet::new();
+        for (idx, signer) in signers.into_iter().enumerate() {
+            // Create signer context
+            let public_key = signer.public_key();
+            public_keys.insert(public_key.clone());
+
+            // Configure engine
+            let uid = format!("validator-{public_key}");
+            let namespace = String::from("_SEISMIC_BFT");
+
+            let engine_client = engine_client_network.create_client(uid.clone());
+
+            let config = get_default_engine_config(
+                engine_client,
+                uid.clone(),
+                genesis_hash,
+                namespace,
+                signer,
+                polynomial.clone(),
+                shares[idx].clone(),
+                validators.clone(),
+            );
+            let engine = Engine::new(
+                context.with_label(&uid),
+                config,
+                oracle.control(public_key.clone()),
+            )
+                .await;
+
+            // Get networking
+            let (pending, recovered, resolver, broadcast, backfill) =
+                registrations.remove(&public_key).unwrap();
+
+            // Start engine
+            engine.start(pending, recovered, resolver, broadcast, backfill);
+        }
+
+        // Poll metrics
+        let mut num_nodes_height_reached = 0;
+        let mut num_nodes_processed_requests = 0;
+        loop {
+            let metrics = context.encode();
+
+            // Iterate over all lines
+            let mut success = false;
+            for line in metrics.lines() {
+                // Ensure it is a metrics line
+                if !line.starts_with("validator-") {
+                    continue;
+                }
+
+                // Split metric and value
+                let mut parts = line.split_whitespace();
+                let metric = parts.next().unwrap();
+                let value = parts.next().unwrap();
+
+                // If ends with peers_blocked, ensure it is zero
+                if metric.ends_with("_peers_blocked") {
+                    let value = value.parse::<u64>().unwrap();
+                    assert_eq!(value, 0);
+                }
+
+                if metric.ends_with("finalizer_height") {
+                    let height = value.parse::<u64>().unwrap();
+                    if height == stop_height {
+                        num_nodes_height_reached += 1;
+                    }
+                }
+
+                if metric.ends_with("deposit_validator_balance") {
+                    let balance = value.parse::<u64>().unwrap();
+                    let registry_flag = common::parse_metric_substring(metric, "registry").expect("registry flag missing");
+                    assert_eq!(balance, test_deposit.amount);
+                    // Make sure that the validator was not added to the registry
+                    assert_eq!(registry_flag, "false");
+                }
+
+                if metric.ends_with("withdrawal_validator_balance") {
+                    let balance = value.parse::<u64>().unwrap();
+                    // Parse the pubkey from the metric name using helper function
+                    if let Some(pubkey_hex) = common::parse_metric_substring(metric, "bls_key") {
+                        let ed_pubkey_hex = common::parse_metric_substring(metric, "ed_key")
+                            .expect("ed key missing");
+                        let creds =
+                            common::parse_metric_substring(metric, "creds").expect("creds missing");
+                        assert_eq!(creds, hex::encode(test_withdrawal.source_address));
+                        assert_eq!(ed_pubkey_hex, test_deposit.ed25519_pubkey.to_string());
+                        let bls_pubkey_hex = hex::encode(test_deposit.bls_pubkey);
+                        assert_eq!(bls_pubkey_hex, pubkey_hex);
+                        assert_eq!(balance, test_deposit.amount - test_withdrawal.amount);
+                        num_nodes_processed_requests += 1;
+                    } else {
+                        println!("{}: {} (failed to parse pubkey)", metric, value);
+                    }
+                }
+                if num_nodes_processed_requests >= n && num_nodes_height_reached >= n {
+                    success = true;
+                    break;
+                }
+            }
+            if success {
+                break;
+            }
+
+            // Still waiting for all validators to complete
+            context.sleep(Duration::from_secs(1)).await;
+        }
+
+        let withdrawals = engine_client_network.get_withdrawals();
+        assert_eq!(withdrawals.len(), 1);
+        let withdrawals = withdrawals
+            .get(&(withdrawal_block_height + VALIDATOR_WITHDRAWAL_PERIOD))
+            .expect("missing withdrawal");
+        assert_eq!(withdrawals[0].amount, test_withdrawal.amount);
+        assert_eq!(withdrawals[0].address, test_withdrawal.source_address);
+
+        // Check that all nodes have the same canonical chain
+        assert!(
+            engine_client_network
+                .verify_consensus(Some(stop_height))
+                .is_ok()
+        );
+
+        context.auditor().state()
+    })
+}


### PR DESCRIPTION
Adds more e2e tests for deposit and withdrawal requests.

Added tests:
- [Test](https://github.com/SeismicSystems/summit/blob/1ea65fd2a83693212812823c7c83821261a60b3c/node/src/tests/execution_requests.rs#L595) for partial withdraws: checking the flow where a partial withdraw puts a validator below the minimum stake, and making sure they are fully withdrawn
- [Test](https://github.com/SeismicSystems/summit/blob/1ea65fd2a83693212812823c7c83821261a60b3c/node/src/tests/execution_requests.rs#L810) for partial deposits: when a validator deposits less than the minimum stake, it should not be added to the registry. however, the balance should still be added to the validator state, and should be withdrawable (otherwise the funds will be lost, because the deposit contract burns them)
- [Test](https://github.com/SeismicSystems/summit/blob/1ea65fd2a83693212812823c7c83821261a60b3c/node/src/tests/execution_requests.rs#L1023) for several deposits and withdrawals in the same block