### PR TITLE
feat: add Header to Block

### DIFF
--- a/node/src/test_harness/mock_engine_client.rs
+++ b/node/src/test_harness/mock_engine_client.rs
@@ -682,16 +682,15 @@ mod tests {
 
         // Simulate consensus: client2 receives the block through Engine API
         // First, client2 validates the block (like receiving it from network)
-        let block_for_validation = Block {
-            payload: block1.clone(),
-            digest: summit_types::Digest::from([1u8; 32]), // Mock digest
-            parent: summit_types::Digest::from([0u8; 32]), // Genesis digest
-            height: 1,
-            timestamp: 1000,
-            block_value: alloy_primitives::U256::from(1_000_000_000_000_000_000u64),
-            execution_requests: Vec::new(),
-            view: 1,
-        };
+        let block_for_validation = Block::compute_digest(
+            summit_types::Digest::from([0u8; 32]), // Genesis digest
+            1,
+            1000,
+            block1.clone(),
+            Vec::new(),
+            alloy_primitives::U256::from(1_000_000_000_000_000_000u64),
+            1,
+        );
 
         // Client2 checks the payload (validates it)
         let validation_result = client2.check_payload(&block_for_validation).await;
@@ -752,16 +751,15 @@ mod tests {
             for client in [&client1, &client2, &client3] {
                 if client.client_id() != producer.client_id() {
                     // Each client validates the block (like receiving it from network)
-                    let block_for_validation = summit_types::Block {
-                        payload: new_block.clone(),
-                        digest: summit_types::Digest::from([round as u8; 32]), // Mock digest
-                        parent: summit_types::Digest::from([(round - 1) as u8; 32]), // Parent digest
-                        height: round as u64,
-                        timestamp: (round * 1000) as u64,
-                        block_value: U256::from(1_000_000_000_000_000_000u64),
-                        execution_requests: Vec::new(),
-                        view: 1,
-                    };
+                    let block_for_validation = summit_types::Block::compute_digest(
+                        summit_types::Digest::from([(round - 1) as u8; 32]), // Parent digest
+                        round as u64,
+                        (round * 1000) as u64,
+                        new_block.clone(),
+                        Vec::new(),
+                        U256::from(1_000_000_000_000_000_000u64),
+                        1,
+                    );
 
                     // Client validates the block
                     let validation_result = client.check_payload(&block_for_validation).await;
@@ -841,16 +839,15 @@ mod tests {
         client1.commit_hash(new_fork_choice).await;
 
         // Simulate network propagation to client2
-        let block_for_validation = Block {
-            payload: block.clone(),
-            digest: summit_types::Digest::from([1u8; 32]),
-            parent: summit_types::Digest::from([0u8; 32]),
-            height: 1,
-            timestamp: 1000,
-            block_value: alloy_primitives::U256::from(1_000_000_000_000_000_000u64),
-            execution_requests: Vec::new(),
-            view: 1,
-        };
+        let block_for_validation = Block::compute_digest(
+            summit_types::Digest::from([0u8; 32]),
+            1,
+            1000,
+            block.clone(),
+            Vec::new(),
+            alloy_primitives::U256::from(1_000_000_000_000_000_000u64),
+            1,
+        );
 
         client2.check_payload(&block_for_validation).await;
         client2.commit_hash(new_fork_choice).await;

--- a/syncer/src/finalizer.rs
+++ b/syncer/src/finalizer.rs
@@ -75,7 +75,7 @@ impl<R: Spawner + Clock + Metrics + Storage, Z: Reporter<Activity = Block>> Fina
             // Attempt to get the next block from the orchestrator.
             if let Some(block) = self.orchestrator.get(height).await {
                 // Sanity-check that the block height is the one we expect.
-                assert!(block.height == height, "block height mismatch");
+                assert_eq!(block.height(), height, "block height mismatch");
 
                 // Send the block to the application.
                 //


### PR DESCRIPTION
This change is part of the checkpointing initiative. Every X blocks, the validators will generate a checkpoint from the consensus state and come to consensus on the checkpoint hash.
For onboarding, we need to keep track of the checkpoint signatures. To reduce the size, we don't want to include the block payload in the signature.
Therefore, we add a `Header` type that will be contained in the `Block`.
- Instead of signing the payload directly, the header contains a digest of the payload, and then the header digest is signed (the same is done for the withdrawal requests).
- When we [receive](https://github.com/SeismicSystems/summit/blob/6003d6cae4a9a1813b09316ed0d9481227225175/types/src/block.rs#L384) a `Block` from the wire, we have to additionally [verify](https://github.com/SeismicSystems/summit/blob/6003d6cae4a9a1813b09316ed0d9481227225175/types/src/block.rs#L265) that the received payload and execution requests match the `payload_hash` and `execution_request_hash` that are included in the `Header`.