### PR TITLE
feat: add historical engine client that supports eth transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5335,6 +5335,7 @@ dependencies = [
  "commonware-runtime",
  "commonware-storage",
  "commonware-utils",
+ "ethereum_ssz",
  "futures",
  "governor",
  "metrics",

--- a/application/Cargo.toml
+++ b/application/Cargo.toml
@@ -42,6 +42,7 @@ serde_json = { workspace = true, optional = true }
 op-alloy-network = { version = "0.19.1", optional = true }
 serde = { workspace = true, optional = true }
 op-alloy-rpc-types-engine = { version = "0.19.1", optional = true }
+ethereum_ssz = { workspace = true, optional = true }
 
 [dev-dependencies]
 alloy-primitives.workspace = true
@@ -50,4 +51,4 @@ alloy-eips.workspace = true
 [features]
 prom = ["metrics"]
 base-bench = ["op-alloy-network", "op-alloy-rpc-types-engine", "serde", "serde_json"]
-bench = ["serde", "serde_json"]
+bench = ["serde", "serde_json", "ethereum_ssz"]

--- a/application/Cargo.toml
+++ b/application/Cargo.toml
@@ -49,4 +49,5 @@ alloy-eips.workspace = true
 
 [features]
 prom = ["metrics"]
-bench = ["op-alloy-network", "op-alloy-rpc-types-engine", "serde", "serde_json"]
+base-bench = ["op-alloy-network", "op-alloy-rpc-types-engine", "serde", "serde_json"]
+bench = ["serde", "serde_json"]

--- a/application/src/actor.rs
+++ b/application/src/actor.rs
@@ -280,7 +280,7 @@ impl<R: Storage + Metrics + Clock + Spawner + governor::clock::Clock + Rng, C: E
                         forkchoice_clone,
                         current,
                         withdrawals,
-                        parent.height() + 1,
+                        parent.height(),
                     )
                     .await
             }

--- a/application/src/actor.rs
+++ b/application/src/actor.rs
@@ -272,11 +272,26 @@ impl<R: Storage + Metrics + Clock + Spawner + governor::clock::Clock + Rng, C: E
 
         // Add pending withdrawals to the block
         let withdrawals = pending_withdrawals.into_iter().map(|w| w.inner).collect();
-        let payload_id = self
-            .engine_client
-            .start_building_block(forkchoice_clone, current, withdrawals)
-            .await
-            .ok_or(anyhow!("Unable to build payload"))?;
+        let payload_id = {
+            #[cfg(any(feature = "bench", feature = "base-bench"))]
+            {
+                self.engine_client
+                    .start_building_block(
+                        forkchoice_clone,
+                        current,
+                        withdrawals,
+                        parent.height() + 1,
+                    )
+                    .await
+            }
+            #[cfg(not(any(feature = "bench", feature = "base-bench")))]
+            {
+                self.engine_client
+                    .start_building_block(forkchoice_clone, current, withdrawals)
+                    .await
+            }
+        }
+        .ok_or(anyhow!("Unable to build payload"))?;
 
         self.context.sleep(Duration::from_millis(50)).await;
 

--- a/application/src/actor.rs
+++ b/application/src/actor.rs
@@ -276,12 +276,7 @@ impl<R: Storage + Metrics + Clock + Spawner + governor::clock::Clock + Rng, C: E
             #[cfg(any(feature = "bench", feature = "base-bench"))]
             {
                 self.engine_client
-                    .start_building_block(
-                        forkchoice_clone,
-                        current,
-                        withdrawals,
-                        parent.height(),
-                    )
+                    .start_building_block(forkchoice_clone, current, withdrawals, parent.height())
                     .await
             }
             #[cfg(not(any(feature = "bench", feature = "base-bench")))]

--- a/application/src/engine_client.rs
+++ b/application/src/engine_client.rs
@@ -330,14 +330,12 @@ pub mod ethereum_benchmarking {
     use serde::{Deserialize, Serialize};
     use std::fs;
     use std::path::PathBuf;
-    use summit_types::utils::benchmarking::BlockIndex;
     use summit_types::{Block, Digest};
 
     #[derive(Clone)]
     pub struct EthereumHistoricalEngineClient {
         provider: RootProvider,
         block_dir: PathBuf,
-        block_index: BlockIndex,
     }
 
     impl EthereumHistoricalEngineClient {
@@ -345,14 +343,9 @@ pub mod ethereum_benchmarking {
             let ipc = IpcConnect::new(engine_ipc_path);
             let provider = ProviderBuilder::default().connect_ipc(ipc).await.unwrap();
 
-            let index_path = block_dir.join("index.json");
-            let block_index =
-                BlockIndex::load_from_file(&index_path).expect("failed to load block index");
-
             Self {
                 provider,
                 block_dir,
-                block_index,
             }
         }
     }
@@ -360,48 +353,35 @@ pub mod ethereum_benchmarking {
     impl EngineClient for EthereumHistoricalEngineClient {
         async fn start_building_block(
             &self,
-            fork_choice_state: ForkchoiceState,
+            _fork_choice_state: ForkchoiceState,
             _timestamp: u64,
             _withdrawals: Vec<Withdrawal>,
-            #[cfg(any(feature = "bench", feature = "base-bench"))] _height: u64,
+            #[cfg(any(feature = "bench", feature = "base-bench"))] height: u64,
         ) -> Option<PayloadId> {
-            let block_num = self
-                .block_index
-                .get_block_number(&fork_choice_state.head_block_hash)?;
-            let next_block_num = block_num + 1;
-            if self.block_index.get_block_file(next_block_num).is_some() {
-                let bytes: [u8; 8] = next_block_num.to_le_bytes();
-                Some(PayloadId::new(bytes))
-            } else {
-                None
-            }
+            let next_block_num = height + 1;
+            Some(PayloadId::new(next_block_num.to_le_bytes()))
         }
 
         async fn get_payload(&self, payload_id: PayloadId) -> ExecutionPayloadEnvelopeV4 {
             let block_num = u64::from_le_bytes(payload_id.0.into());
-            let filename = self
-                .block_index
-                .get_block_file(block_num)
-                .expect("block not found in index");
-
+            let filename = format!("block-{block_num}");
             let file_path = self.block_dir.join(filename);
 
-            let json_data = fs::read_to_string(&file_path)
+            let data = fs::read(&file_path)
                 .map_err(|e| {
                     anyhow::anyhow!("Failed to read block file {}: {}", file_path.display(), e)
                 })
                 .expect("failed to read block file");
 
-            let block_data: EthereumBlockData = serde_json::from_str(&json_data)
-                .map_err(|e| anyhow::anyhow!("Failed to parse block data: {}", e))
-                .expect("failed to parse block data");
+            let block_data: ExecutionPayloadV3 =
+                ssz::Decode::from_ssz_bytes(&data).expect("failed to read block file");
 
             // Convert to ExecutionPayloadEnvelopeV4 with correct structure
             ExecutionPayloadEnvelopeV4 {
                 envelope_inner: ExecutionPayloadEnvelopeV3 {
-                    execution_payload: block_data.payload,
-                    block_value: U256::ZERO, // Historical blocks don't have block value
-                    blobs_bundle: Default::default(), // No blobs in historical blocks
+                    execution_payload: block_data,
+                    block_value: U256::ZERO,
+                    blobs_bundle: Default::default(),
                     should_override_builder: false,
                 },
                 execution_requests: Requests::default(),
@@ -460,6 +440,8 @@ pub mod ethereum_benchmarking {
                 view,
                 None,             // checkpoint_hash
                 [0u8; 32].into(), // prev_epoch_header_hash
+                Vec::new(),       // added_validators
+                Vec::new(),       // removed_validators
             )
         }
     }

--- a/application/src/engine_client.rs
+++ b/application/src/engine_client.rs
@@ -34,6 +34,7 @@ pub trait EngineClient: Clone + Send + Sync + 'static {
         fork_choice_state: ForkchoiceState,
         timestamp: u64,
         withdrawals: Vec<Withdrawal>,
+        #[cfg(any(feature = "bench", feature = "base-bench"))] height: u64,
     ) -> impl Future<Output = Option<PayloadId>> + Send;
 
     fn get_payload(
@@ -65,6 +66,7 @@ impl EngineClient for RethEngineClient {
         fork_choice_state: ForkchoiceState,
         timestamp: u64,
         withdrawals: Vec<Withdrawal>,
+        #[cfg(any(feature = "bench", feature = "base-bench"))] _height: u64,
     ) -> Option<PayloadId> {
         let payload_attributes = PayloadAttributes {
             timestamp,
@@ -165,6 +167,7 @@ pub mod benchmarking {
             fork_choice_state: ForkchoiceState,
             _timestamp: u64,
             _withdrawals: Vec<Withdrawal>,
+            #[cfg(any(feature = "bench", feature = "base-bench"))] _height: u64,
         ) -> Option<PayloadId> {
             let block_num = self
                 .block_index
@@ -360,6 +363,7 @@ pub mod ethereum_benchmarking {
             fork_choice_state: ForkchoiceState,
             _timestamp: u64,
             _withdrawals: Vec<Withdrawal>,
+            #[cfg(any(feature = "bench", feature = "base-bench"))] _height: u64,
         ) -> Option<PayloadId> {
             let block_num = self
                 .block_index

--- a/application/src/engine_client.rs
+++ b/application/src/engine_client.rs
@@ -409,8 +409,8 @@ pub mod ethereum_benchmarking {
             self.provider
                 .new_payload_v4(
                     block.payload.clone(),
-                    Vec::new(),                     // versioned_hashes - empty for historical blocks
-                    [1; 32].into(),                // parent_beacon_block_root
+                    Vec::new(),     // versioned_hashes - empty for historical blocks
+                    [1; 32].into(), // parent_beacon_block_root
                     block.execution_requests.clone(), // execution_requests
                 )
                 .await
@@ -454,6 +454,8 @@ pub mod ethereum_benchmarking {
                 execution_requests,
                 U256::ZERO, // block_value
                 view,
+                None,             // checkpoint_hash
+                [0u8; 32].into(), // prev_epoch_header_hash
             )
         }
     }

--- a/application/src/engine_client.rs
+++ b/application/src/engine_client.rs
@@ -115,7 +115,7 @@ impl EngineClient for RethEngineClient {
     }
 }
 
-#[cfg(feature = "bench")]
+#[cfg(feature = "base-bench")]
 pub mod benchmarking {
     use crate::engine_client::EngineClient;
     use alloy_eips::eip4895::Withdrawal;
@@ -180,9 +180,12 @@ pub mod benchmarking {
 
         async fn get_payload(&self, payload_id: PayloadId) -> ExecutionPayloadEnvelopeV4 {
             let block_num = u64::from_le_bytes(payload_id.0.into());
-            let filename = format!("block_{block_num}.json");
+            let filename = self
+                .block_index
+                .get_block_file(block_num)
+                .expect("block not found in index");
 
-            let file_path = self.block_dir.join(&filename);
+            let file_path = self.block_dir.join(filename);
 
             let json_data = fs::read_to_string(&file_path)
                 .map_err(|e| {
@@ -304,6 +307,153 @@ pub mod benchmarking {
                 [0u8; 32].into(),
                 Vec::new(), // added_validators
                 Vec::new(), // removed_validators
+            )
+        }
+    }
+}
+
+#[cfg(feature = "bench")]
+pub mod ethereum_benchmarking {
+    use crate::engine_client::EngineClient;
+    use alloy_eips::eip4895::Withdrawal;
+    use alloy_eips::eip7685::Requests;
+    use alloy_primitives::{B256, FixedBytes, U256};
+    use alloy_provider::{ProviderBuilder, RootProvider, ext::EngineApi};
+    use alloy_rpc_types_engine::{
+        ExecutionPayloadEnvelopeV3, ExecutionPayloadEnvelopeV4, ExecutionPayloadV3,
+        ForkchoiceState, PayloadId, PayloadStatus,
+    };
+    use alloy_transport_ipc::IpcConnect;
+    use serde::{Deserialize, Serialize};
+    use std::fs;
+    use std::path::PathBuf;
+    use summit_types::utils::benchmarking::BlockIndex;
+    use summit_types::{Block, Digest};
+
+    #[derive(Clone)]
+    pub struct EthereumHistoricalEngineClient {
+        provider: RootProvider,
+        block_dir: PathBuf,
+        block_index: BlockIndex,
+    }
+
+    impl EthereumHistoricalEngineClient {
+        pub async fn new(engine_ipc_path: String, block_dir: PathBuf) -> Self {
+            let ipc = IpcConnect::new(engine_ipc_path);
+            let provider = ProviderBuilder::default().connect_ipc(ipc).await.unwrap();
+
+            let index_path = block_dir.join("index.json");
+            let block_index =
+                BlockIndex::load_from_file(&index_path).expect("failed to load block index");
+
+            Self {
+                provider,
+                block_dir,
+                block_index,
+            }
+        }
+    }
+
+    impl EngineClient for EthereumHistoricalEngineClient {
+        async fn start_building_block(
+            &self,
+            fork_choice_state: ForkchoiceState,
+            _timestamp: u64,
+            _withdrawals: Vec<Withdrawal>,
+        ) -> Option<PayloadId> {
+            let block_num = self
+                .block_index
+                .get_block_number(&fork_choice_state.head_block_hash)?;
+            let next_block_num = block_num + 1;
+            if self.block_index.get_block_file(next_block_num).is_some() {
+                let bytes: [u8; 8] = next_block_num.to_le_bytes();
+                Some(PayloadId::new(bytes))
+            } else {
+                None
+            }
+        }
+
+        async fn get_payload(&self, payload_id: PayloadId) -> ExecutionPayloadEnvelopeV4 {
+            let block_num = u64::from_le_bytes(payload_id.0.into());
+            let filename = self
+                .block_index
+                .get_block_file(block_num)
+                .expect("block not found in index");
+
+            let file_path = self.block_dir.join(filename);
+
+            let json_data = fs::read_to_string(&file_path)
+                .map_err(|e| {
+                    anyhow::anyhow!("Failed to read block file {}: {}", file_path.display(), e)
+                })
+                .expect("failed to read block file");
+
+            let block_data: EthereumBlockData = serde_json::from_str(&json_data)
+                .map_err(|e| anyhow::anyhow!("Failed to parse block data: {}", e))
+                .expect("failed to parse block data");
+
+            // Convert to ExecutionPayloadEnvelopeV4 with correct structure
+            ExecutionPayloadEnvelopeV4 {
+                envelope_inner: ExecutionPayloadEnvelopeV3 {
+                    execution_payload: block_data.payload,
+                    block_value: U256::ZERO, // Historical blocks don't have block value
+                    blobs_bundle: Default::default(), // No blobs in historical blocks
+                    should_override_builder: false,
+                },
+                execution_requests: Requests::default(),
+            }
+        }
+
+        async fn check_payload(&self, block: &Block) -> PayloadStatus {
+            // For Ethereum, use standard engine_newPayloadV4 without Optimism-specific logic
+            self.provider
+                .new_payload_v4(
+                    block.payload.clone(),
+                    Vec::new(),                     // versioned_hashes - empty for historical blocks
+                    [1; 32].into(),                // parent_beacon_block_root
+                    block.execution_requests.clone(), // execution_requests
+                )
+                .await
+                .unwrap()
+        }
+
+        async fn commit_hash(&self, fork_choice_state: ForkchoiceState) {
+            self.provider
+                .fork_choice_updated_v3(fork_choice_state, None)
+                .await
+                .unwrap();
+        }
+    }
+
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct EthereumBlockData {
+        pub block_number: u64,
+        pub payload: ExecutionPayloadV3,
+        pub requests: FixedBytes<32>,
+        pub parent_beacon_block_root: B256,
+        pub versioned_hashes: Vec<B256>,
+    }
+
+    impl EthereumBlockData {
+        pub fn from_file(file_path: &PathBuf) -> anyhow::Result<Self> {
+            let json_data = fs::read_to_string(file_path)?;
+            let block_data: EthereumBlockData = serde_json::from_str(&json_data)?;
+            Ok(block_data)
+        }
+
+        pub fn to_block(self, parent: Digest, height: u64, timestamp: u64, view: u64) -> Block {
+            // Create execution requests from the stored requests hash
+            let execution_requests = Vec::new(); // Convert from self.requests if needed
+
+            // Compute and return the entire block
+            Block::compute_digest(
+                parent,
+                height,
+                timestamp,
+                self.payload,
+                execution_requests,
+                U256::ZERO, // block_value
+                view,
             )
         }
     }

--- a/application/src/engine_client.rs
+++ b/application/src/engine_client.rs
@@ -118,7 +118,7 @@ impl EngineClient for RethEngineClient {
 }
 
 #[cfg(feature = "base-bench")]
-pub mod benchmarking {
+pub mod base_benchmarking {
     use crate::engine_client::EngineClient;
     use alloy_eips::eip4895::Withdrawal;
     use alloy_eips::eip7685::Requests;
@@ -316,7 +316,7 @@ pub mod benchmarking {
 }
 
 #[cfg(feature = "bench")]
-pub mod ethereum_benchmarking {
+pub mod benchmarking {
     use crate::engine_client::EngineClient;
     use alloy_eips::eip4895::Withdrawal;
     use alloy_eips::eip7685::Requests;

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -10,11 +10,12 @@ path = "src/bin/testnet.rs"
 [[bin]]
 name = "block-fetcher"
 path = "src/bin/block_fetcher.rs"
-required-features = ["base-bench"]
+required-features = ["bench", "base-bench"]
 
 [[bin]]
 name = "execute-blocks"
 path = "src/bin/execute_blocks.rs"
+required-features = ["bench", "base-bench"]
 
 [dependencies]
 summit-types.workspace = true

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -10,12 +10,12 @@ path = "src/bin/testnet.rs"
 [[bin]]
 name = "block-fetcher"
 path = "src/bin/block_fetcher.rs"
-required-features = ["bench", "base-bench"]
+required-features = ["bench"]
 
 [[bin]]
 name = "execute-blocks"
 path = "src/bin/execute_blocks.rs"
-required-features = ["bench", "base-bench"]
+required-features = ["bench"]
 
 [dependencies]
 summit-types.workspace = true

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -10,16 +10,15 @@ path = "src/bin/testnet.rs"
 [[bin]]
 name = "block-fetcher"
 path = "src/bin/block_fetcher.rs"
-required-features = ["bench"]
+required-features = ["base-bench"]
 
 [[bin]]
 name = "execute-blocks"
 path = "src/bin/execute_blocks.rs"
-required-features = ["bench"]
 
 [dependencies]
 summit-types.workspace = true
-summit-application.workspace = true
+summit-application = { workspace = true, features = [] }
 summit-rpc = { path = "../rpc" }
 summit-syncer.workspace = true
 
@@ -104,4 +103,5 @@ prom = [
   "procfs",
 ]
 jemalloc = ["dep:tikv-jemalloc-ctl"]
-bench = []
+base-bench = ["summit-application/base-bench", "summit-types/base-bench"]
+bench = ["summit-application/bench", "summit-types/bench"]

--- a/node/src/args.rs
+++ b/node/src/args.rs
@@ -21,9 +21,9 @@ use std::{
 };
 use summit_application::engine_client::RethEngineClient;
 #[cfg(feature = "bench")]
-use summit_application::engine_client::benchmarking::EthHistoricalEngineClient;
+use summit_application::engine_client::benchmarking::EthereumHistoricalEngineClient;
 #[cfg(feature = "base-bench")]
-use summit_application::engine_client::benchmarking::HistoricalEngineClient;
+use summit_application::engine_client::base_benchmarking::HistoricalEngineClient;
 
 use summit_types::{Genesis, PublicKey, utils::get_expanded_path};
 use tracing::{Level, error};

--- a/node/src/args.rs
+++ b/node/src/args.rs
@@ -20,10 +20,10 @@ use std::{
     str::FromStr as _,
 };
 use summit_application::engine_client::RethEngineClient;
-#[cfg(feature = "bench")]
-use summit_application::engine_client::benchmarking::EthereumHistoricalEngineClient;
 #[cfg(feature = "base-bench")]
 use summit_application::engine_client::base_benchmarking::HistoricalEngineClient;
+#[cfg(feature = "bench")]
+use summit_application::engine_client::benchmarking::EthereumHistoricalEngineClient;
 
 use summit_types::{Genesis, PublicKey, utils::get_expanded_path};
 use tracing::{Level, error};

--- a/node/src/args.rs
+++ b/node/src/args.rs
@@ -20,7 +20,7 @@ use std::{
     str::FromStr as _,
 };
 use summit_application::engine_client::RethEngineClient;
-#[cfg(feature = "bench")]
+#[cfg(feature = "base-bench")]
 use summit_application::engine_client::benchmarking::HistoricalEngineClient;
 use summit_types::{Genesis, PublicKey, utils::get_expanded_path};
 use tracing::{Level, error};
@@ -66,7 +66,7 @@ pub struct RunFlags {
     #[arg(long, default_value_t = DEFAULT_ENGINE_IPC_PATH.into())]
     pub engine_ipc_path: String,
     /// Path to the directory containing historical blocks for benchmarking
-    #[cfg(feature = "bench")]
+    #[cfg(feature = "base-bench")]
     #[arg(long)]
     pub bench_block_dir: Option<String>,
     /// Port Consensus runs on
@@ -174,7 +174,7 @@ impl Command {
             let engine_ipc_path = get_expanded_path(&flags.engine_ipc_path)
                 .expect("failed to expand engine ipc path");
 
-            #[cfg(feature = "bench")]
+            #[cfg(feature = "base-bench")]
             let engine_client = {
                 let block_dir = flags
                     .bench_block_dir
@@ -187,7 +187,7 @@ impl Command {
                 )
                 .await
             };
-            #[cfg(not(feature = "bench"))]
+            #[cfg(not(feature = "base-bench"))]
             let engine_client =
                 RethEngineClient::new(engine_ipc_path.to_string_lossy().to_string()).await;
 

--- a/node/src/args.rs
+++ b/node/src/args.rs
@@ -66,7 +66,7 @@ pub struct RunFlags {
     #[arg(long, default_value_t = DEFAULT_ENGINE_IPC_PATH.into())]
     pub engine_ipc_path: String,
     /// Path to the directory containing historical blocks for benchmarking
-    #[cfg(feature = "base-bench")]
+    #[cfg(any(feature = "base-bench", feature = "bench"))]
     #[arg(long)]
     pub bench_block_dir: Option<String>,
     /// Port Consensus runs on

--- a/node/src/args.rs
+++ b/node/src/args.rs
@@ -20,8 +20,11 @@ use std::{
     str::FromStr as _,
 };
 use summit_application::engine_client::RethEngineClient;
+#[cfg(feature = "bench")]
+use summit_application::engine_client::benchmarking::EthHistoricalEngineClient;
 #[cfg(feature = "base-bench")]
 use summit_application::engine_client::benchmarking::HistoricalEngineClient;
+
 use summit_types::{Genesis, PublicKey, utils::get_expanded_path};
 use tracing::{Level, error};
 
@@ -187,11 +190,25 @@ impl Command {
                 )
                 .await
             };
-            #[cfg(not(feature = "base-bench"))]
+
+            #[cfg(feature = "bench")]
+            let engine_client = {
+                let block_dir = flags
+                    .bench_block_dir
+                    .as_ref()
+                    .map(|p| get_expanded_path(p).expect("Invalid block directory path"))
+                    .expect("bench_block_dir is required when using bench feature");
+                EthereumHistoricalEngineClient::new(
+                    engine_ipc_path.to_string_lossy().to_string(),
+                    block_dir,
+                )
+                .await
+            };
+
+            #[cfg(not(any(feature = "bench", feature = "base-bench")))]
             let engine_client =
                 RethEngineClient::new(engine_ipc_path.to_string_lossy().to_string()).await;
 
-            // let engine_client = RethEngineClient::new(engine_url.clone(), &engine_jwt);
             let config = EngineConfig::get_engine_config(
                 engine_client,
                 signer,

--- a/node/src/bin/execute_blocks.rs
+++ b/node/src/bin/execute_blocks.rs
@@ -78,21 +78,27 @@ async fn main() -> Result<()> {
         safe_block_hash: genesis_hash.into(),
         finalized_block_hash: genesis_hash.into(),
     };
+    let mut block_number = 0;
     for _ in 0..num_blocks {
         #[cfg(any(feature = "bench", feature = "base-bench"))]
-        let result = client.start_building_block(forkchoice, 0, vec![], 0).await;
+        let result = client.start_building_block(forkchoice, 0, vec![], block_number).await;
         #[cfg(not(any(feature = "bench", feature = "base-bench")))]
         let result = client.start_building_block(forkchoice, 0, vec![]).await;
-        
+
         match result {
             Some(payload_id) => {
                 let payload = client.get_payload(payload_id).await;
+                let block_num = u64::from_le_bytes(payload_id.0.into());
 
-                let block_number = payload
+                block_number = payload
                     .execution_payload
                     .payload_inner
                     .payload_inner
                     .block_number;
+
+                // TODO(matthias): we do this because the block number is always
+                // one higher than the block
+                block_number -= 1;
                 let block_hash = payload
                     .execution_payload
                     .payload_inner

--- a/node/src/bin/execute_blocks.rs
+++ b/node/src/bin/execute_blocks.rs
@@ -42,7 +42,8 @@ async fn main() -> Result<()> {
                 .value_name("PATH")
                 .help("Engine API IPC socket path")
                 .required(true),
-        ).arg(
+        )
+        .arg(
             Arg::new("start-block")
                 .long("start-block")
                 .value_name("COUNT")

--- a/node/src/bin/execute_blocks.rs
+++ b/node/src/bin/execute_blocks.rs
@@ -79,7 +79,12 @@ async fn main() -> Result<()> {
         finalized_block_hash: genesis_hash.into(),
     };
     for _ in 0..num_blocks {
-        match client.start_building_block(forkchoice, 0, vec![]).await {
+        #[cfg(any(feature = "bench", feature = "base-bench"))]
+        let result = client.start_building_block(forkchoice, 0, vec![], 0).await;
+        #[cfg(not(any(feature = "bench", feature = "base-bench")))]
+        let result = client.start_building_block(forkchoice, 0, vec![]).await;
+        
+        match result {
             Some(payload_id) => {
                 let payload = client.get_payload(payload_id).await;
 

--- a/node/src/bin/execute_blocks.rs
+++ b/node/src/bin/execute_blocks.rs
@@ -10,7 +10,7 @@ use summit_application::engine_client::benchmarking::HistoricalEngineClient;
 use summit_application::engine_client::ethereum_benchmarking::EthereumHistoricalEngineClient;
 use summit_types::{Block, Digest};
 
-#[cfg(feature = "base-bench")]
+#[cfg(all(feature = "base-bench", not(feature = "bench")))]
 const GENESIS_HASH: &str = "0xf712aa9241cc24369b143cf6dce85f0902a9731e70d66818a3a5845b296c73dd";
 #[cfg(feature = "bench")]
 const GENESIS_HASH: &str = "0x655cc1ecc77fe1eab4b1e62a1f461b7fddc9b06109b5ab3e9dc68c144b30c773";

--- a/node/src/bin/execute_blocks.rs
+++ b/node/src/bin/execute_blocks.rs
@@ -5,9 +5,9 @@ use commonware_utils::from_hex_formatted;
 use std::path::PathBuf;
 use summit_application::engine_client::EngineClient;
 #[cfg(feature = "base-bench")]
-use summit_application::engine_client::benchmarking::HistoricalEngineClient;
+use summit_application::engine_client::base_benchmarking::HistoricalEngineClient;
 #[cfg(feature = "bench")]
-use summit_application::engine_client::ethereum_benchmarking::EthereumHistoricalEngineClient;
+use summit_application::engine_client::benchmarking::EthereumHistoricalEngineClient;
 use summit_types::{Block, Digest};
 
 #[cfg(all(feature = "base-bench", not(feature = "bench")))]

--- a/node/src/bin/execute_blocks.rs
+++ b/node/src/bin/execute_blocks.rs
@@ -88,17 +88,8 @@ async fn main() -> Result<()> {
         match result {
             Some(payload_id) => {
                 let payload = client.get_payload(payload_id).await;
-                let block_num = u64::from_le_bytes(payload_id.0.into());
+                block_number = u64::from_le_bytes(payload_id.0.into());
 
-                block_number = payload
-                    .execution_payload
-                    .payload_inner
-                    .payload_inner
-                    .block_number;
-
-                // TODO(matthias): we do this because the block number is always
-                // one higher than the block
-                block_number -= 1;
                 let block_hash = payload
                     .execution_payload
                     .payload_inner

--- a/node/src/bin/execute_blocks.rs
+++ b/node/src/bin/execute_blocks.rs
@@ -42,13 +42,19 @@ async fn main() -> Result<()> {
                 .value_name("PATH")
                 .help("Engine API IPC socket path")
                 .required(true),
+        ).arg(
+            Arg::new("start-block")
+                .long("start-block")
+                .value_name("COUNT")
+                .help("Block number of the first block")
+                .default_value("0"),
         )
         .arg(
             Arg::new("num-blocks")
                 .long("num-blocks")
                 .value_name("COUNT")
                 .help("Number of blocks to process")
-                .default_value("50000"),
+                .default_value("1000"),
         )
         .get_matches();
 
@@ -58,6 +64,7 @@ async fn main() -> Result<()> {
         .get_one::<String>("engine-ipc-path")
         .unwrap()
         .to_string();
+    let start_block: u64 = matches.get_one::<String>("start-block").unwrap().parse()?;
     let num_blocks: u64 = matches.get_one::<String>("num-blocks").unwrap().parse()?;
 
     #[allow(unused)]
@@ -78,15 +85,15 @@ async fn main() -> Result<()> {
         safe_block_hash: genesis_hash.into(),
         finalized_block_hash: genesis_hash.into(),
     };
-    let mut block_number = 0;
+    let mut block_number = start_block;
     for _ in 0..num_blocks {
+        println!("Block number: {}", block_number);
         #[cfg(any(feature = "bench", feature = "base-bench"))]
         let result = client
             .start_building_block(forkchoice, 0, vec![], block_number)
             .await;
         #[cfg(not(any(feature = "bench", feature = "base-bench")))]
         let result = client.start_building_block(forkchoice, 0, vec![]).await;
-
         match result {
             Some(payload_id) => {
                 let payload = client.get_payload(payload_id).await;
@@ -120,6 +127,7 @@ async fn main() -> Result<()> {
                 let payload_status = client.check_payload(&summit_block).await;
                 println!("  Payload status: {:?}", payload_status);
 
+                println!("forkchoice: {:?}", block_hash);
                 forkchoice = ForkchoiceState {
                     head_block_hash: block_hash,
                     safe_block_hash: block_hash,

--- a/node/src/bin/execute_blocks.rs
+++ b/node/src/bin/execute_blocks.rs
@@ -4,10 +4,16 @@ use clap::{Arg, Command};
 use commonware_utils::from_hex_formatted;
 use std::path::PathBuf;
 use summit_application::engine_client::EngineClient;
+#[cfg(feature = "base-bench")]
 use summit_application::engine_client::benchmarking::HistoricalEngineClient;
+#[cfg(feature = "bench")]
+use summit_application::engine_client::ethereum_benchmarking::EthereumHistoricalEngineClient;
 use summit_types::{Block, Digest};
 
+#[cfg(feature = "base-bench")]
 const GENESIS_HASH: &str = "0xf712aa9241cc24369b143cf6dce85f0902a9731e70d66818a3a5845b296c73dd";
+#[cfg(feature = "bench")]
+const GENESIS_HASH: &str = "0x655cc1ecc77fe1eab4b1e62a1f461b7fddc9b06109b5ab3e9dc68c144b30c773";
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -54,7 +60,12 @@ async fn main() -> Result<()> {
         .to_string();
     let num_blocks: u64 = matches.get_one::<String>("num-blocks").unwrap().parse()?;
 
-    let client = HistoricalEngineClient::new(engine_ipc_path, block_dir).await;
+    #[allow(unused)]
+    #[cfg(feature = "base-bench")]
+    let client = HistoricalEngineClient::new(engine_ipc_path.clone(), block_dir.clone()).await;
+    #[allow(unused)]
+    #[cfg(feature = "bench")]
+    let client = EthereumHistoricalEngineClient::new(engine_ipc_path, block_dir).await;
 
     // Load and commit blocks to Reth
     let genesis_hash: [u8; 32] = from_hex_formatted(genesis_hash_str)

--- a/node/src/bin/execute_blocks.rs
+++ b/node/src/bin/execute_blocks.rs
@@ -81,7 +81,9 @@ async fn main() -> Result<()> {
     let mut block_number = 0;
     for _ in 0..num_blocks {
         #[cfg(any(feature = "bench", feature = "base-bench"))]
-        let result = client.start_building_block(forkchoice, 0, vec![], block_number).await;
+        let result = client
+            .start_building_block(forkchoice, 0, vec![], block_number)
+            .await;
         #[cfg(not(any(feature = "bench", feature = "base-bench")))]
         let result = client.start_building_block(forkchoice, 0, vec![]).await;
 

--- a/node/src/bin/testnet.rs
+++ b/node/src/bin/testnet.rs
@@ -160,7 +160,7 @@ fn get_node_flags(node: usize) -> RunFlags {
         db_prefix: format!("{node}-quarts"),
         genesis_path: "./example_genesis.toml".into(),
         engine_ipc_path: format!("/tmp/reth_engine_api{node}.ipc"),
-        #[cfg(feature = "base-bench")]
+        #[cfg(any(feature = "base-bench", feature = "bench"))]
         bench_block_dir: None,
     }
 }

--- a/node/src/bin/testnet.rs
+++ b/node/src/bin/testnet.rs
@@ -160,7 +160,7 @@ fn get_node_flags(node: usize) -> RunFlags {
         db_prefix: format!("{node}-quarts"),
         genesis_path: "./example_genesis.toml".into(),
         engine_ipc_path: format!("/tmp/reth_engine_api{node}.ipc"),
-        #[cfg(feature = "bench")]
+        #[cfg(feature = "base-bench")]
         bench_block_dir: None,
     }
 }

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -25,4 +25,5 @@ tracing.workspace = true
 serde_json = { workspace = true, optional = true }
 
 [features]
+base-bench = ["serde_json"]
 bench = ["serde_json"]

--- a/types/src/checkpoint.rs
+++ b/types/src/checkpoint.rs
@@ -133,6 +133,9 @@ mod tests {
             deposit_queue: VecDeque::new(),
             withdrawal_queue: VecDeque::new(),
             validator_accounts: HashMap::new(),
+            pending_checkpoint: None,
+            added_validators: Vec::new(),
+            removed_validators: Vec::new(),
         };
 
         let checkpoint = Checkpoint::new(&state);
@@ -221,6 +224,9 @@ mod tests {
             deposit_queue,
             withdrawal_queue,
             validator_accounts,
+            pending_checkpoint: None,
+            added_validators: Vec::new(),
+            removed_validators: Vec::new(),
         };
 
         let checkpoint = Checkpoint::new(&state);
@@ -249,6 +255,9 @@ mod tests {
             deposit_queue: VecDeque::new(),
             withdrawal_queue: VecDeque::new(),
             validator_accounts: HashMap::new(),
+            pending_checkpoint: None,
+            added_validators: Vec::new(),
+            removed_validators: Vec::new(),
         };
 
         let checkpoint = Checkpoint::new(&state);
@@ -344,6 +353,9 @@ mod tests {
             deposit_queue,
             withdrawal_queue,
             validator_accounts,
+            pending_checkpoint: None,
+            added_validators: Vec::new(),
+            removed_validators: Vec::new(),
         };
 
         let checkpoint = Checkpoint::new(&state);
@@ -377,6 +389,9 @@ mod tests {
             deposit_queue: VecDeque::new(),
             withdrawal_queue: VecDeque::new(),
             validator_accounts: HashMap::new(),
+            pending_checkpoint: None,
+            added_validators: Vec::new(),
+            removed_validators: Vec::new(),
         };
 
         let checkpoint = Checkpoint::new(&state);

--- a/types/src/utils.rs
+++ b/types/src/utils.rs
@@ -26,7 +26,6 @@ pub fn is_penultimate_block_of_epoch(height: u64, epoch_num_blocks: u64) -> bool
     height > 0 && (height + 1) % epoch_num_blocks == 0
 }
 
-
 #[cfg(any(feature = "base-bench", feature = "bench"))]
 pub mod benchmarking {
     use alloy_primitives::B256;

--- a/types/src/utils.rs
+++ b/types/src/utils.rs
@@ -26,7 +26,8 @@ pub fn is_penultimate_block_of_epoch(height: u64, epoch_num_blocks: u64) -> bool
     height > 0 && (height + 1) % epoch_num_blocks == 0
 }
 
-#[cfg(feature = "bench")]
+
+#[cfg(any(feature = "base-bench", feature = "bench"))]
 pub mod benchmarking {
     use alloy_primitives::B256;
     use anyhow::{anyhow, bail};


### PR DESCRIPTION
Changes:
- Adds `EthereumHistoricalEngineClient` that can is used for benchmarks with pre-built blocks
- Introduces a `bench` feature. If the summit binary is compiled with this feature, it will use the `EthereumHistoricalEngineClient`
- Moves the pending checkpoint and added and removed validators into the consensus state