### PR TITLE
feat: add consensus state query to RPC server and handle requests in app finalizer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5407,9 +5407,9 @@ dependencies = [
  "commonware-utils",
  "dirs 6.0.0",
  "ethereum_ssz",
+ "futures",
  "serde",
  "serde_json",
- "tokio",
  "toml",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5310,6 +5310,7 @@ dependencies = [
  "summit-types",
  "tikv-jemalloc-ctl",
  "tokio",
+ "tokio-util",
  "toml",
  "tower",
  "tracing",
@@ -5364,6 +5365,7 @@ dependencies = [
  "serde",
  "summit-types",
  "tokio",
+ "tokio-util",
  "tracing",
 ]
 
@@ -5724,9 +5726,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.15"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
+checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
 dependencies = [
  "bytes",
  "futures-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5409,8 +5409,8 @@ dependencies = [
  "ethereum_ssz",
  "serde",
  "serde_json",
+ "tokio",
  "toml",
- "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5361,6 +5361,7 @@ dependencies = [
  "commonware-cryptography",
  "commonware-utils",
  "dirs 5.0.1",
+ "ethereum_ssz",
  "futures",
  "serde",
  "summit-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ reqwest = "0.12"
 socket2 = "0.6"
 tower = "0.5.2"
 tokio = "1.46.0"
+tokio-util = "0.7.16"
 
 ethereum_ssz = "0.9.0"
 ethereum_ssz_derive = "0.9.0"

--- a/application/src/actor.rs
+++ b/application/src/actor.rs
@@ -26,6 +26,7 @@ use std::{
 use tracing::{error, info, warn};
 
 use summit_syncer::ingress::Mailbox as SyncerMailbox;
+use summit_types::consensus_state_query::ConsensusStateQuery;
 use summit_types::{Block, BlockAuxData, Digest};
 
 type AuxDataRequest = (u64, oneshot::Sender<BlockAuxData>);
@@ -70,7 +71,10 @@ pub struct Actor<
 impl<R: Storage + Metrics + Clock + Spawner + governor::clock::Clock + Rng, C: EngineClient>
     Actor<R, C>
 {
-    pub async fn new(context: R, cfg: ApplicationConfig<C>) -> (Self, Mailbox, FinalizerMailbox) {
+    pub async fn new(
+        context: R,
+        cfg: ApplicationConfig<C>,
+    ) -> (Self, Mailbox, FinalizerMailbox, ConsensusStateQuery) {
         let (tx, rx) = mpsc::channel(cfg.mailbox_size);
 
         let genesis_hash = cfg.genesis_hash;
@@ -80,22 +84,23 @@ impl<R: Storage + Metrics + Clock + Spawner + governor::clock::Clock + Rng, C: E
             finalized_block_hash: genesis_hash.into(),
         }));
 
-        let (finalizer, finalizer_mailbox, tx_height_notify, tx_aux_data) = Finalizer::new(
-            context.with_label("finalizer"),
-            cfg.engine_client.clone(),
-            cfg.registry,
-            forkchoice.clone(),
-            cfg.partition_prefix,
-            cfg.validator_onboarding_limit_per_block,
-            cfg.validator_minimum_stake,
-            cfg.validator_withdrawal_period,
-            cfg.validator_max_withdrawals_per_block,
-            cfg.epoch_num_blocks,
-            genesis_hash,
-            cfg.protocol_version,
-            cfg.buffer_pool,
-        )
-        .await;
+        let (finalizer, finalizer_mailbox, consensus_state_query, tx_height_notify, tx_aux_data) =
+            Finalizer::new(
+                context.with_label("finalizer"),
+                cfg.engine_client.clone(),
+                cfg.registry,
+                forkchoice.clone(),
+                cfg.partition_prefix,
+                cfg.validator_onboarding_limit_per_block,
+                cfg.validator_minimum_stake,
+                cfg.validator_withdrawal_period,
+                cfg.validator_max_withdrawals_per_block,
+                cfg.epoch_num_blocks,
+                genesis_hash,
+                cfg.protocol_version,
+                cfg.buffer_pool,
+            )
+            .await;
 
         (
             Self {
@@ -111,6 +116,7 @@ impl<R: Storage + Metrics + Clock + Spawner + governor::clock::Clock + Rng, C: E
             },
             Mailbox::new(tx),
             finalizer_mailbox,
+            consensus_state_query,
         )
     }
 

--- a/application/src/finalizer.rs
+++ b/application/src/finalizer.rs
@@ -33,12 +33,13 @@ use std::{
 use summit_types::account::{ValidatorAccount, ValidatorStatus};
 use summit_types::checkpoint::Checkpoint;
 use summit_types::consensus_state::ConsensusState;
-use summit_types::consensus_state_query::{ConsensusStateQuery, ConsensusStateQueryMailbox};
+use summit_types::consensus_state_query::{
+    ConsensusStateQuery, ConsensusStateRequest, ConsensusStateResponse,
+};
 use summit_types::execution_request::ExecutionRequest;
 use summit_types::utils::{is_last_block_of_epoch, is_penultimate_block_of_epoch};
 use summit_types::{
     Block, BlockAuxData, BlockEnvelope, Digest, FinalizedHeader, PublicKey, Signature,
-    consensus_state_query,
 };
 use tracing::{info, warn};
 
@@ -70,7 +71,10 @@ pub struct Finalizer<
 
     state: ConsensusState,
 
-    state_query_mailbox: ConsensusStateQueryMailbox,
+    state_query_mailbox: mpsc::Receiver<(
+        ConsensusStateRequest,
+        oneshot::Sender<ConsensusStateResponse>,
+    )>,
 
     validator_onboarding_limit_per_block: usize,
 
@@ -130,7 +134,7 @@ impl<R: Storage + Metrics + Clock + Spawner + governor::clock::Clock + Rng, C: E
 
         let (tx_finalizer, rx_finalizer_mailbox) = mpsc::channel(1); // todo(dalton) there should only ever be one message in this channel since we block but lets verify this
 
-        let (state_query, state_query_mailbox) = consensus_state_query::new(1000);
+        let (state_query, state_query_mailbox) = ConsensusStateQuery::new(1000);
 
         let mut finalizer = Self {
             context,
@@ -201,6 +205,14 @@ impl<R: Storage + Metrics + Clock + Spawner + governor::clock::Clock + Rng, C: E
 
                         self.handle_execution_block(&ctx, notifier, envelope, &mut last_committed_timestamp).await;
                     },
+
+                    req = self.state_query_mailbox.next() => {
+                        let Some((request, sender)) = req else {
+                            warn!("All consensus state querries dropped");
+                            break;
+                        };
+                        self.handle_consensus_state_query(&ctx, request, sender).await;
+                    }
                 }
             }
         });
@@ -646,6 +658,20 @@ impl<R: Storage + Metrics + Clock + Spawner + governor::clock::Clock + Rng, C: E
             }
         };
         let _ = sender.send(aux_data);
+    }
+
+    async fn handle_consensus_state_query(
+        &self,
+        _ctx: &R,
+        consensus_state_request: ConsensusStateRequest,
+        sender: oneshot::Sender<ConsensusStateResponse>,
+    ) {
+        match consensus_state_request {
+            ConsensusStateRequest::GetCheckpoint => {
+                let checkpoint = self.db.get_finalized_checkpoint().await;
+                let _ = sender.send(ConsensusStateResponse::Checkpoint(checkpoint));
+            }
+        }
     }
 }
 

--- a/application/src/finalizer.rs
+++ b/application/src/finalizer.rs
@@ -33,10 +33,12 @@ use std::{
 use summit_types::account::{ValidatorAccount, ValidatorStatus};
 use summit_types::checkpoint::Checkpoint;
 use summit_types::consensus_state::ConsensusState;
+use summit_types::consensus_state_query::{ConsensusStateQuery, ConsensusStateQueryMailbox};
 use summit_types::execution_request::ExecutionRequest;
 use summit_types::utils::{is_last_block_of_epoch, is_penultimate_block_of_epoch};
 use summit_types::{
     Block, BlockAuxData, BlockEnvelope, Digest, FinalizedHeader, PublicKey, Signature,
+    consensus_state_query,
 };
 use tracing::{info, warn};
 
@@ -67,6 +69,8 @@ pub struct Finalizer<
     db: FinalizerState<R>,
 
     state: ConsensusState,
+
+    state_query_mailbox: ConsensusStateQueryMailbox,
 
     validator_onboarding_limit_per_block: usize,
 
@@ -104,6 +108,7 @@ impl<R: Storage + Metrics + Clock + Spawner + governor::clock::Clock + Rng, C: E
     ) -> (
         Self,
         FinalizerMailbox,
+        ConsensusStateQuery,
         mpsc::Sender<(u64, oneshot::Sender<()>)>,
         mpsc::Sender<AuxDataRequest>,
     ) {
@@ -125,6 +130,8 @@ impl<R: Storage + Metrics + Clock + Spawner + governor::clock::Clock + Rng, C: E
 
         let (tx_finalizer, rx_finalizer_mailbox) = mpsc::channel(1); // todo(dalton) there should only ever be one message in this channel since we block but lets verify this
 
+        let (state_query, state_query_mailbox) = consensus_state_query::new(1000);
+
         let mut finalizer = Self {
             context,
             height_notifier: HeightNotifier::new(),
@@ -136,6 +143,7 @@ impl<R: Storage + Metrics + Clock + Spawner + governor::clock::Clock + Rng, C: E
             rx_finalizer_mailbox,
             db,
             state: ConsensusState::default(),
+            state_query_mailbox,
             validator_onboarding_limit_per_block,
             validator_minimum_stake,
             validator_withdrawal_period,
@@ -155,6 +163,7 @@ impl<R: Storage + Metrics + Clock + Spawner + governor::clock::Clock + Rng, C: E
         (
             finalizer,
             FinalizerMailbox::new(tx_finalizer),
+            state_query,
             tx_height_notify,
             tx_aux_data,
         )

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -39,8 +39,9 @@ clap.workspace = true
 dirs.workspace = true
 
 tokio = { version = "1.45.1", features = ["sync"] }
+tokio-util.workspace = true
 
-# testnet bin deps 
+# testnet bin deps
 alloy-node-bindings.workspace = true
 alloy-network = { workspace = true }
 alloy-primitives.workspace = true
@@ -49,7 +50,6 @@ alloy-rpc-client.workspace = true
 alloy-rpc-types-engine = { version = "1.0.9", features = ["serde"] }
 op-alloy-consensus = { version = "0.19.1", default-features = false, features = ["alloy-compat"] }
 tracing-subscriber = "0.3.19"
-
 
 serde.workspace = true
 serde_json.workspace = true

--- a/node/src/args.rs
+++ b/node/src/args.rs
@@ -155,17 +155,18 @@ impl Command {
             let cloned_token = cancel_token.clone();
 
             // use the context async move to spawn a new runtime
-            let key_path = flags.key_path.clone();
             let genesis_path = flags.genesis_path.clone();
             let rpc_port = flags.rpc_port;
-            let rpc_handle = context.with_label("rpc").spawn(move |_context| async move {
-                let genesis_sender = Command::check_sender(genesis_path, genesis_tx);
-                if let Err(e) =
-                    start_rpc_server_for_genesis(genesis_sender, rpc_port, cloned_token).await
-                {
-                    error!("RPC server failed: {}", e);
-                }
-            });
+            let _rpc_handle = context
+                .with_label("rpc_genesis")
+                .spawn(move |_context| async move {
+                    let genesis_sender = Command::check_sender(genesis_path, genesis_tx);
+                    if let Err(e) =
+                        start_rpc_server_for_genesis(genesis_sender, rpc_port, cloned_token).await
+                    {
+                        error!("RPC server failed: {}", e);
+                    }
+                });
 
             // Wait for genesis if needed
             let _ = genesis_rx.await;
@@ -312,10 +313,20 @@ impl Command {
             // Create network
             let p2p = network.start();
             // create engine
-            let engine = Engine::new(context.with_label("engine"), config).await;
+            let (engine, consensus_state_query) =
+                Engine::new(context.with_label("engine"), config).await;
 
             // Start engine
             let engine = engine.start(pending, resolver, broadcaster, backfiller);
+
+            // Start RPC server
+            let key_path = flags.key_path.clone();
+            let rpc_port = flags.rpc_port;
+            let rpc_handle = context.with_label("rpc").spawn(move |_context| async move {
+                if let Err(e) = start_rpc_server(consensus_state_query, key_path, rpc_port).await {
+                    error!("RPC server failed: {}", e);
+                }
+            });
 
             // Wait for any task to error
             if let Err(e) = try_join_all(vec![p2p, engine, rpc_handle]).await {
@@ -334,10 +345,9 @@ pub fn run_node_with_runtime(context: tokio::Context, flags: RunFlags) -> Handle
         let cancel_token = CancellationToken::new();
         let cloned_token = cancel_token.clone();
         // use the context async move to spawn a new runtime
-        let key_path = flags.key_path.clone();
         let rpc_port = flags.rpc_port;
         let genesis_path = flags.genesis_path.clone();
-        let rpc_handle = context
+        let _rpc_handle = context
             .with_label("rpc_genesis")
             .spawn(move |_context| async move {
                 let genesis_sender = Command::check_sender(genesis_path, genesis_tx);
@@ -426,10 +436,22 @@ pub fn run_node_with_runtime(context: tokio::Context, flags: RunFlags) -> Handle
         // Create network
         let p2p = network.start();
         // create engine
-        let engine = Engine::new(context.with_label("engine"), config).await;
+        let (engine, consensus_state_query) =
+            Engine::new(context.with_label("engine"), config).await;
 
         // Start engine
         let engine = engine.start(pending, resolver, broadcaster, backfiller);
+
+        // Start RPC server
+        let key_path = flags.key_path.clone();
+        let rpc_port = flags.rpc_port;
+        let rpc_handle = context
+            .with_label("rpc_genesis")
+            .spawn(move |_context| async move {
+                if let Err(e) = start_rpc_server(consensus_state_query, key_path, rpc_port).await {
+                    error!("RPC server failed: {}", e);
+                }
+            });
 
         // Wait for any task to error
         if let Err(e) = try_join_all(vec![p2p, engine, rpc_handle]).await {

--- a/node/src/args.rs
+++ b/node/src/args.rs
@@ -161,8 +161,7 @@ impl Command {
             let rpc_handle = context.with_label("rpc").spawn(move |_context| async move {
                 let genesis_sender = Command::check_sender(genesis_path, genesis_tx);
                 if let Err(e) =
-                    start_rpc_server_for_genesis(key_path, genesis_sender, rpc_port, cloned_token)
-                        .await
+                    start_rpc_server_for_genesis(genesis_sender, rpc_port, cloned_token).await
                 {
                     error!("RPC server failed: {}", e);
                 }
@@ -343,8 +342,7 @@ pub fn run_node_with_runtime(context: tokio::Context, flags: RunFlags) -> Handle
             .spawn(move |_context| async move {
                 let genesis_sender = Command::check_sender(genesis_path, genesis_tx);
                 if let Err(e) =
-                    start_rpc_server_for_genesis(key_path, genesis_sender, rpc_port, cloned_token)
-                        .await
+                    start_rpc_server_for_genesis(genesis_sender, rpc_port, cloned_token).await
                 {
                     error!("RPC server failed: {}", e);
                 }

--- a/node/src/args.rs
+++ b/node/src/args.rs
@@ -10,7 +10,8 @@ use clap::{Args, Parser, Subcommand};
 use commonware_cryptography::Signer;
 use commonware_p2p::authenticated;
 use commonware_runtime::{Handle, Metrics as _, Runner, Spawner as _, tokio};
-use summit_rpc::{PathSender, start_rpc_server};
+use summit_rpc::{PathSender, start_rpc_server, start_rpc_server_for_genesis};
+use tokio_util::sync::CancellationToken;
 
 use futures::{channel::oneshot, future::try_join_all};
 use governor::Quota;
@@ -101,7 +102,7 @@ pub struct RunFlags {
     /// Path to the genesis file
     #[arg(
         long,
-        default_value_t = String::from("./example_genesis.toml")
+        default_value_t = String::from("./example_genesis_.toml")
     )]
     pub genesis_path: String,
 }
@@ -150,19 +151,28 @@ impl Command {
         executor.start(|context| async move {
             let (genesis_tx, genesis_rx) = oneshot::channel();
 
+            let cancel_token = CancellationToken::new();
+            let cloned_token = cancel_token.clone();
+
             // use the context async move to spawn a new runtime
             let key_path = flags.key_path.clone();
             let genesis_path = flags.genesis_path.clone();
             let rpc_port = flags.rpc_port;
             let rpc_handle = context.with_label("rpc").spawn(move |_context| async move {
                 let genesis_sender = Command::check_sender(genesis_path, genesis_tx);
-                if let Err(e) = start_rpc_server(key_path, genesis_sender, rpc_port).await {
+                if let Err(e) =
+                    start_rpc_server_for_genesis(key_path, genesis_sender, rpc_port, cloned_token)
+                        .await
+                {
                     error!("RPC server failed: {}", e);
                 }
             });
 
             // Wait for genesis if needed
             let _ = genesis_rx.await;
+            // Shut down the genesis rpc server after receiving the genesis file
+            cancel_token.cancel();
+
             let genesis =
                 Genesis::load_from_file(&flags.genesis_path).expect("Can not find genesis file");
 
@@ -316,28 +326,34 @@ impl Command {
     }
 }
 
-pub fn run_node_with_runtime(
-    context: commonware_runtime::tokio::Context,
-    flags: RunFlags,
-) -> Handle<()> {
+pub fn run_node_with_runtime(context: tokio::Context, flags: RunFlags) -> Handle<()> {
     context.spawn(async move |context| {
         let signer = expect_signer(&flags.key_path);
 
         let (genesis_tx, genesis_rx) = oneshot::channel();
 
+        let cancel_token = CancellationToken::new();
+        let cloned_token = cancel_token.clone();
         // use the context async move to spawn a new runtime
         let key_path = flags.key_path.clone();
         let rpc_port = flags.rpc_port;
         let genesis_path = flags.genesis_path.clone();
-        let rpc_handle = context.with_label("rpc").spawn(move |_context| async move {
-            let genesis_sender = Command::check_sender(genesis_path, genesis_tx);
-            if let Err(e) = start_rpc_server(key_path, genesis_sender, rpc_port).await {
-                tracing::error!("RPC server failed: {}", e);
-            }
-        });
+        let rpc_handle = context
+            .with_label("rpc_genesis")
+            .spawn(move |_context| async move {
+                let genesis_sender = Command::check_sender(genesis_path, genesis_tx);
+                if let Err(e) =
+                    start_rpc_server_for_genesis(key_path, genesis_sender, rpc_port, cloned_token)
+                        .await
+                {
+                    error!("RPC server failed: {}", e);
+                }
+            });
 
         // Wait for genesis if needed
         let _ = genesis_rx.await;
+        // Shut down the genesis rpc server after receiving the genesis file
+        cancel_token.cancel();
 
         let genesis =
             Genesis::load_from_file(&flags.genesis_path).expect("Can not find genesis file");
@@ -356,7 +372,6 @@ pub fn run_node_with_runtime(
         let engine_client =
             RethEngineClient::new(engine_ipc_path.to_string_lossy().to_string()).await;
 
-        // let engine_client = RethEngineClient::new(engine_url.clone(), &engine_jwt);
         let config = EngineConfig::get_engine_config(
             engine_client,
             signer,

--- a/node/src/engine.rs
+++ b/node/src/engine.rs
@@ -14,6 +14,7 @@ use summit_application::ApplicationConfig;
 use summit_application::engine_client::EngineClient;
 use summit_application::finalizer::FinalizerMailbox;
 use summit_application::registry::Registry;
+use summit_types::consensus_state_query::ConsensusStateQuery;
 use summit_types::{Block, Digest, PrivateKey, PublicKey};
 use tracing::{error, warn};
 
@@ -69,29 +70,30 @@ pub struct Engine<
 impl<E: Clock + GClock + Rng + CryptoRng + Spawner + Storage + Metrics, C: EngineClient>
     Engine<E, C>
 {
-    pub async fn new(context: E, cfg: EngineConfig<C>) -> Self {
+    pub async fn new(context: E, cfg: EngineConfig<C>) -> (Self, ConsensusStateQuery) {
         let registry = Registry::new(cfg.participants.clone());
         let buffer_pool = PoolRef::new(BUFFER_POOL_PAGE_SIZE, BUFFER_POOL_CAPACITY);
 
         // create application
-        let (application, application_mailbox, finalizer_mailbox) = summit_application::Actor::new(
-            context.with_label("application"),
-            ApplicationConfig {
-                engine_client: cfg.engine_client,
-                registry: registry.clone(),
-                mailbox_size: cfg.mailbox_size,
-                partition_prefix: cfg.partition_prefix.clone(),
-                genesis_hash: cfg.genesis_hash,
-                validator_onboarding_limit_per_block: VALIDATOR_ONBOARDING_LIMIT_PER_BLOCK,
-                validator_minimum_stake: VALIDATOR_MINIMUM_STAKE,
-                validator_withdrawal_period: VALIDATOR_WITHDRAWAL_PERIOD,
-                validator_max_withdrawals_per_block: VALIDATOR_MAX_WITHDRAWALS_PER_BLOCK,
-                epoch_num_blocks: EPOCH_NUM_BLOCKS,
-                protocol_version: PROTOCOL_VERSION,
-                buffer_pool: buffer_pool.clone(),
-            },
-        )
-        .await;
+        let (application, application_mailbox, finalizer_mailbox, consensus_state_query) =
+            summit_application::Actor::new(
+                context.with_label("application"),
+                ApplicationConfig {
+                    engine_client: cfg.engine_client,
+                    registry: registry.clone(),
+                    mailbox_size: cfg.mailbox_size,
+                    partition_prefix: cfg.partition_prefix.clone(),
+                    genesis_hash: cfg.genesis_hash,
+                    validator_onboarding_limit_per_block: VALIDATOR_ONBOARDING_LIMIT_PER_BLOCK,
+                    validator_minimum_stake: VALIDATOR_MINIMUM_STAKE,
+                    validator_withdrawal_period: VALIDATOR_WITHDRAWAL_PERIOD,
+                    validator_max_withdrawals_per_block: VALIDATOR_MAX_WITHDRAWALS_PER_BLOCK,
+                    epoch_num_blocks: EPOCH_NUM_BLOCKS,
+                    protocol_version: PROTOCOL_VERSION,
+                    buffer_pool: buffer_pool.clone(),
+                },
+            )
+            .await;
 
         // create the buffer
         let (buffer, buffer_mailbox) = buffered::Engine::new(
@@ -149,16 +151,19 @@ impl<E: Clock + GClock + Rng + CryptoRng + Spawner + Storage + Metrics, C: Engin
             },
         );
 
-        Self {
-            context,
-            application,
-            buffer,
-            buffer_mailbox,
-            syncer,
-            syncer_mailbox,
-            simplex,
-            finalizer_mailbox,
-        }
+        (
+            Self {
+                context,
+                application,
+                buffer,
+                buffer_mailbox,
+                syncer,
+                syncer_mailbox,
+                simplex,
+                finalizer_mailbox,
+            },
+            consensus_state_query,
+        )
     }
 
     /// Start the `simplex` consensus engine.

--- a/node/src/test_harness/common.rs
+++ b/node/src/test_harness/common.rs
@@ -135,7 +135,8 @@ pub fn run_until_height(
 
         // Create instances
         let mut public_keys = HashSet::new();
-        for (_idx, signer) in signers.into_iter().enumerate() {
+        let mut consensus_state_queries = HashMap::new();
+        for (idx, signer) in signers.into_iter().enumerate() {
             // Create signer context
             let public_key = signer.public_key();
             public_keys.insert(public_key.clone());
@@ -155,8 +156,9 @@ pub fn run_until_height(
                 validators.clone(),
             );
 
-            let (engine, _consensus_state_query) =
+            let (engine, consensus_state_query) =
                 Engine::new(context.with_label(&uid), config).await;
+            consensus_state_queries.insert(idx, consensus_state_query);
 
             // Get networking
             let (pending, resolver, broadcast, backfill) =

--- a/node/src/test_harness/common.rs
+++ b/node/src/test_harness/common.rs
@@ -155,7 +155,8 @@ pub fn run_until_height(
                 validators.clone(),
             );
 
-            let engine = Engine::new(context.with_label(&uid), config).await;
+            let (engine, _consensus_state_query) =
+                Engine::new(context.with_label(&uid), config).await;
 
             // Get networking
             let (pending, resolver, broadcast, backfill) =

--- a/node/src/tests/checkpointing.rs
+++ b/node/src/tests/checkpointing.rs
@@ -64,7 +64,8 @@ fn test_checkpoint_created() {
 
         // Create instances
         let mut public_keys = HashSet::new();
-        for signer in signers.into_iter() {
+        let mut consensus_state_queries = HashMap::new();
+        for (idx, signer) in signers.into_iter().enumerate() {
             // Create signer context
             let public_key = signer.public_key();
             public_keys.insert(public_key.clone());
@@ -83,8 +84,9 @@ fn test_checkpoint_created() {
                 signer,
                 validators.clone(),
             );
-            let (engine, _consensus_state_query) =
+            let (engine, consensus_state_query) =
                 Engine::new(context.with_label(&uid), config).await;
+            consensus_state_queries.insert(idx, consensus_state_query);
 
             // Get networking
             let (pending, resolver, broadcast, backfill) =
@@ -205,7 +207,8 @@ fn test_previous_header_hash_matches() {
 
         // Create instances
         let mut public_keys = HashSet::new();
-        for signer in signers.into_iter() {
+        let mut consensus_state_queries = HashMap::new();
+        for (idx, signer) in signers.into_iter().enumerate() {
             // Create signer context
             let public_key = signer.public_key();
             public_keys.insert(public_key.clone());
@@ -224,8 +227,9 @@ fn test_previous_header_hash_matches() {
                 signer,
                 validators.clone(),
             );
-            let (engine, _consensus_state_query) =
+            let (engine, consensus_state_query) =
                 Engine::new(context.with_label(&uid), config).await;
+            consensus_state_queries.insert(idx, consensus_state_query);
 
             // Get networking
             let (pending, resolver, broadcast, backfill) =

--- a/node/src/tests/checkpointing.rs
+++ b/node/src/tests/checkpointing.rs
@@ -83,7 +83,8 @@ fn test_checkpoint_created() {
                 signer,
                 validators.clone(),
             );
-            let engine = Engine::new(context.with_label(&uid), config).await;
+            let (engine, _consensus_state_query) =
+                Engine::new(context.with_label(&uid), config).await;
 
             // Get networking
             let (pending, resolver, broadcast, backfill) =
@@ -223,7 +224,8 @@ fn test_previous_header_hash_matches() {
                 signer,
                 validators.clone(),
             );
-            let engine = Engine::new(context.with_label(&uid), config).await;
+            let (engine, _consensus_state_query) =
+                Engine::new(context.with_label(&uid), config).await;
 
             // Get networking
             let (pending, resolver, broadcast, backfill) =

--- a/node/src/tests/checkpointing.rs
+++ b/node/src/tests/checkpointing.rs
@@ -12,6 +12,7 @@ use commonware_utils::from_hex_formatted;
 use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 use summit_types::PrivateKey;
+use summit_types::consensus_state::ConsensusState;
 
 #[test_traced("INFO")]
 fn test_checkpoint_created() {
@@ -143,6 +144,14 @@ fn test_checkpoint_created() {
             // Still waiting for all validators to complete
             context.sleep(Duration::from_secs(1)).await;
         }
+
+        let consensus_state_query = consensus_state_queries.get(&0).unwrap();
+        let checkpoint = consensus_state_query
+            .get_latest_checkpoint()
+            .await
+            .expect("failed to query checkpoint");
+        let _consensus_state =
+            ConsensusState::try_from(&checkpoint).expect("failed to parse consensus state");
 
         // Check that all nodes have the same canonical chain
         assert!(
@@ -301,6 +310,14 @@ fn test_previous_header_hash_matches() {
             // Still waiting for all validators to complete
             context.sleep(Duration::from_secs(1)).await;
         }
+
+        let consensus_state_query = consensus_state_queries.get(&0).unwrap();
+        let checkpoint = consensus_state_query
+            .get_latest_checkpoint()
+            .await
+            .expect("failed to query checkpoint");
+        let _consensus_state =
+            ConsensusState::try_from(&checkpoint).expect("failed to parse consensus state");
 
         // Check that all nodes have the same canonical chain
         assert!(

--- a/node/src/tests/execution_requests.rs
+++ b/node/src/tests/execution_requests.rs
@@ -107,7 +107,8 @@ fn test_deposit_request_single() {
                 signer,
                 validators.clone(),
             );
-            let engine = Engine::new(context.with_label(&uid), config).await;
+            let (engine, _consensus_state_query) =
+                Engine::new(context.with_label(&uid), config).await;
 
             // Get networking
             let (pending, resolver, broadcast, backfill) =
@@ -290,7 +291,8 @@ fn test_deposit_request_top_up() {
                 signer,
                 validators.clone(),
             );
-            let engine = Engine::new(context.with_label(&uid), config).await;
+            let (engine, _consensus_state_query) =
+                Engine::new(context.with_label(&uid), config).await;
 
             // Get networking
             let (pending, resolver, broadcast, backfill) =
@@ -485,7 +487,8 @@ fn test_deposit_and_withdrawal_request_single() {
                 signer,
                 validators.clone(),
             );
-            let engine = Engine::new(context.with_label(&uid), config).await;
+            let (engine, _consensus_state_query) =
+                Engine::new(context.with_label(&uid), config).await;
 
             // Get networking
             let (pending, resolver, broadcast, backfill) =
@@ -694,7 +697,8 @@ fn test_partial_withdrawal_balance_below_minimum_stake() {
                 signer,
                 validators.clone(),
             );
-            let engine = Engine::new(context.with_label(&uid), config).await;
+            let (engine, _consensus_state_query) =
+                Engine::new(context.with_label(&uid), config).await;
 
             // Get networking
             let (pending, resolver, broadcast, backfill) =
@@ -901,7 +905,8 @@ fn test_deposit_less_than_min_stake_and_withdrawal() {
                 signer,
                 validators.clone(),
             );
-            let engine = Engine::new(context.with_label(&uid), config).await;
+            let (engine, _consensus_state_query) =
+                Engine::new(context.with_label(&uid), config).await;
 
             // Get networking
             let (pending, resolver, broadcast, backfill) =
@@ -1123,7 +1128,8 @@ fn test_deposit_and_withdrawal_request_multiple() {
                 signer,
                 validators.clone(),
             );
-            let engine = Engine::new(context.with_label(&uid), config).await;
+            let (engine, _consensus_state_query) =
+                Engine::new(context.with_label(&uid), config).await;
 
             // Get networking
             let (pending, resolver, broadcast, backfill) =
@@ -1332,7 +1338,8 @@ fn test_deposit_request_invalid_signature() {
                 signer,
                 validators.clone(),
             );
-            let engine = Engine::new(context.with_label(&uid), config).await;
+            let (engine, _consensus_state_query) =
+                Engine::new(context.with_label(&uid), config).await;
 
             // Get networking
             let (pending, resolver, broadcast, backfill) =

--- a/node/src/tests/execution_requests.rs
+++ b/node/src/tests/execution_requests.rs
@@ -88,7 +88,8 @@ fn test_deposit_request_single() {
 
         // Create instances
         let mut public_keys = HashSet::new();
-        for signer in signers.into_iter() {
+        let mut consensus_state_queries = HashMap::new();
+        for (idx, signer) in signers.into_iter().enumerate() {
             // Create signer context
             let public_key = signer.public_key();
             public_keys.insert(public_key.clone());
@@ -107,8 +108,9 @@ fn test_deposit_request_single() {
                 signer,
                 validators.clone(),
             );
-            let (engine, _consensus_state_query) =
+            let (engine, consensus_state_query) =
                 Engine::new(context.with_label(&uid), config).await;
+            consensus_state_queries.insert(idx, consensus_state_query);
 
             // Get networking
             let (pending, resolver, broadcast, backfill) =
@@ -272,7 +274,8 @@ fn test_deposit_request_top_up() {
 
         // Create instances
         let mut public_keys = HashSet::new();
-        for signer in signers.into_iter() {
+        let mut consensus_state_queries = HashMap::new();
+        for (idx, signer) in signers.into_iter().enumerate() {
             // Create signer context
             let public_key = signer.public_key();
             public_keys.insert(public_key.clone());
@@ -291,8 +294,9 @@ fn test_deposit_request_top_up() {
                 signer,
                 validators.clone(),
             );
-            let (engine, _consensus_state_query) =
+            let (engine, consensus_state_query) =
                 Engine::new(context.with_label(&uid), config).await;
+            consensus_state_queries.insert(idx, consensus_state_query);
 
             // Get networking
             let (pending, resolver, broadcast, backfill) =
@@ -468,7 +472,8 @@ fn test_deposit_and_withdrawal_request_single() {
 
         // Create instances
         let mut public_keys = HashSet::new();
-        for signer in signers.into_iter() {
+        let mut consensus_state_queries = HashMap::new();
+        for (idx, signer) in signers.into_iter().enumerate() {
             // Create signer context
             let public_key = signer.public_key();
             public_keys.insert(public_key.clone());
@@ -487,8 +492,9 @@ fn test_deposit_and_withdrawal_request_single() {
                 signer,
                 validators.clone(),
             );
-            let (engine, _consensus_state_query) =
+            let (engine, consensus_state_query) =
                 Engine::new(context.with_label(&uid), config).await;
+            consensus_state_queries.insert(idx, consensus_state_query);
 
             // Get networking
             let (pending, resolver, broadcast, backfill) =
@@ -678,7 +684,8 @@ fn test_partial_withdrawal_balance_below_minimum_stake() {
 
         // Create instances
         let mut public_keys = HashSet::new();
-        for signer in signers.into_iter() {
+        let mut consensus_state_queries = HashMap::new();
+        for (idx, signer) in signers.into_iter().enumerate() {
             // Create signer context
             let public_key = signer.public_key();
             public_keys.insert(public_key.clone());
@@ -697,8 +704,9 @@ fn test_partial_withdrawal_balance_below_minimum_stake() {
                 signer,
                 validators.clone(),
             );
-            let (engine, _consensus_state_query) =
+            let (engine, consensus_state_query) =
                 Engine::new(context.with_label(&uid), config).await;
+            consensus_state_queries.insert(idx, consensus_state_query);
 
             // Get networking
             let (pending, resolver, broadcast, backfill) =
@@ -886,7 +894,8 @@ fn test_deposit_less_than_min_stake_and_withdrawal() {
 
         // Create instances
         let mut public_keys = HashSet::new();
-        for signer in signers.into_iter() {
+        let mut consensus_state_queries = HashMap::new();
+        for (idx, signer) in signers.into_iter().enumerate() {
             // Create signer context
             let public_key = signer.public_key();
             public_keys.insert(public_key.clone());
@@ -905,8 +914,9 @@ fn test_deposit_less_than_min_stake_and_withdrawal() {
                 signer,
                 validators.clone(),
             );
-            let (engine, _consensus_state_query) =
+            let (engine, consensus_state_query) =
                 Engine::new(context.with_label(&uid), config).await;
+            consensus_state_queries.insert(idx, consensus_state_query);
 
             // Get networking
             let (pending, resolver, broadcast, backfill) =
@@ -1109,7 +1119,8 @@ fn test_deposit_and_withdrawal_request_multiple() {
 
         // Create instances
         let mut public_keys = HashSet::new();
-        for signer in signers.into_iter() {
+        let mut consensus_state_queries = HashMap::new();
+        for (idx, signer) in signers.into_iter().enumerate() {
             // Create signer context
             let public_key = signer.public_key();
             public_keys.insert(public_key.clone());
@@ -1128,8 +1139,9 @@ fn test_deposit_and_withdrawal_request_multiple() {
                 signer,
                 validators.clone(),
             );
-            let (engine, _consensus_state_query) =
+            let (engine, consensus_state_query) =
                 Engine::new(context.with_label(&uid), config).await;
+            consensus_state_queries.insert(idx, consensus_state_query);
 
             // Get networking
             let (pending, resolver, broadcast, backfill) =
@@ -1319,7 +1331,8 @@ fn test_deposit_request_invalid_signature() {
 
         // Create instances
         let mut public_keys = HashSet::new();
-        for signer in signers.into_iter() {
+        let mut consensus_state_queries = HashMap::new();
+        for (idx, signer) in signers.into_iter().enumerate() {
             // Create signer context
             let public_key = signer.public_key();
             public_keys.insert(public_key.clone());
@@ -1338,8 +1351,9 @@ fn test_deposit_request_invalid_signature() {
                 signer,
                 validators.clone(),
             );
-            let (engine, _consensus_state_query) =
+            let (engine, consensus_state_query) =
                 Engine::new(context.with_label(&uid), config).await;
+            consensus_state_queries.insert(idx, consensus_state_query);
 
             // Get networking
             let (pending, resolver, broadcast, backfill) =

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -17,6 +17,7 @@ summit-types = { workspace = true }
 commonware-cryptography = { workspace = true }
 commonware-utils = { workspace = true }
 commonware-codec = { workspace = true }
+ethereum_ssz.workspace = true
 dirs = "5.0.1"
 serde = { workspace = true }
 tracing.workspace = true

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -10,6 +10,7 @@ path = "src/lib.rs"
 [dependencies]
 anyhow = { workspace = true }
 tokio = { workspace = true, features = ["net"] }
+tokio-util.workspace = true
 futures.workspace = true
 axum = { version = "0.8.4"}
 summit-types = { workspace = true }

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -1,10 +1,10 @@
 pub mod routes;
 use std::sync::Mutex;
 
+use crate::routes::RpcRoutes;
 use futures::channel::oneshot;
 use tokio::net::TcpListener;
-
-use crate::routes::RpcRoutes;
+use tokio_util::sync::CancellationToken;
 
 pub struct PathSender {
     path: String,
@@ -46,5 +46,28 @@ pub async fn start_rpc_server(
 
     axum::serve(listener, server).await?;
 
+    Ok(())
+}
+
+pub async fn start_rpc_server_for_genesis(
+    key_path: String,
+    genesis: PathSender,
+    port: u16,
+    cancel_token: CancellationToken,
+) -> anyhow::Result<()> {
+    let state = RpcState::new(key_path, genesis);
+
+    let server = RpcRoutes::mount_for_genesis(state);
+
+    let listener = TcpListener::bind(format!("0.0.0.0:{port}")).await?;
+
+    println!("Genesis RPC Server listening on http://0.0.0.0:{port}");
+
+    axum::serve(listener, server)
+        .with_graceful_shutdown(async move {
+            cancel_token.cancelled().await;
+            println!("Genesis RPC server stopped");
+        })
+        .await?;
     Ok(())
 }

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -3,21 +3,30 @@ use std::sync::Mutex;
 
 use crate::routes::RpcRoutes;
 use futures::channel::oneshot;
+use summit_types::consensus_state_query::ConsensusStateQuery;
 use tokio::net::TcpListener;
 use tokio_util::sync::CancellationToken;
 
 pub struct RpcState {
     key_path: String,
+    consensus_state_query: ConsensusStateQuery,
 }
 
 impl RpcState {
-    pub fn new(key_path: String) -> Self {
-        Self { key_path }
+    pub fn new(key_path: String, consensus_state_query: ConsensusStateQuery) -> Self {
+        Self {
+            key_path,
+            consensus_state_query,
+        }
     }
 }
 
-pub async fn start_rpc_server(key_path: String, port: u16) -> anyhow::Result<()> {
-    let state = RpcState::new(key_path);
+pub async fn start_rpc_server(
+    consensus_state_query: ConsensusStateQuery,
+    key_path: String,
+    port: u16,
+) -> anyhow::Result<()> {
+    let state = RpcState::new(key_path, consensus_state_query);
 
     let server = RpcRoutes::mount(state);
 

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -6,6 +6,30 @@ use futures::channel::oneshot;
 use tokio::net::TcpListener;
 use tokio_util::sync::CancellationToken;
 
+pub struct RpcState {
+    key_path: String,
+}
+
+impl RpcState {
+    pub fn new(key_path: String) -> Self {
+        Self { key_path }
+    }
+}
+
+pub async fn start_rpc_server(key_path: String, port: u16) -> anyhow::Result<()> {
+    let state = RpcState::new(key_path);
+
+    let server = RpcRoutes::mount(state);
+
+    let listener = TcpListener::bind(format!("0.0.0.0:{port}")).await?;
+
+    println!("RPC Server listening on http://0.0.0.0:{port}");
+
+    axum::serve(listener, server).await?;
+
+    Ok(())
+}
+
 pub struct PathSender {
     path: String,
     sender: Mutex<Option<oneshot::Sender<()>>>,
@@ -20,42 +44,22 @@ impl PathSender {
     }
 }
 
-pub struct RpcState {
-    key_path: String,
+pub struct GenesisRpcState {
     genesis: PathSender,
 }
 
-impl RpcState {
-    pub fn new(key_path: String, genesis: PathSender) -> Self {
-        Self { key_path, genesis }
+impl GenesisRpcState {
+    pub fn new(genesis: PathSender) -> Self {
+        Self { genesis }
     }
 }
 
-pub async fn start_rpc_server(
-    key_path: String,
-    genesis: PathSender,
-    port: u16,
-) -> anyhow::Result<()> {
-    let state = RpcState::new(key_path, genesis);
-
-    let server = RpcRoutes::mount(state);
-
-    let listener = TcpListener::bind(format!("0.0.0.0:{port}")).await?;
-
-    println!("RPC Server listening on http://0.0.0.0:{port}");
-
-    axum::serve(listener, server).await?;
-
-    Ok(())
-}
-
 pub async fn start_rpc_server_for_genesis(
-    key_path: String,
     genesis: PathSender,
     port: u16,
     cancel_token: CancellationToken,
 ) -> anyhow::Result<()> {
-    let state = RpcState::new(key_path, genesis);
+    let state = GenesisRpcState::new(genesis);
 
     let server = RpcRoutes::mount_for_genesis(state);
 

--- a/rpc/src/routes.rs
+++ b/rpc/src/routes.rs
@@ -22,6 +22,14 @@ impl RpcRoutes {
         Router::new()
             .route("/health", get(Self::handle_health_check))
             .route("/get_public_key", get(Self::handle_get_pub_key))
+            .with_state(state)
+    }
+
+    pub fn mount_for_genesis(state: RpcState) -> Router {
+        // todo(dalton): Add cors
+        let state = Arc::new(state);
+
+        Router::new()
             .route("/send_genesis", post(Self::handle_send_genesis))
             .with_state(state)
     }
@@ -72,9 +80,13 @@ impl RpcRoutes {
         // Signal that file is ready
         if let Some(sender) = sender.lock().expect("poisoned").take() {
             let _ = sender.send(());
-            Ok(format!("{kind} file written and node notified"))
+            Ok(format!(
+                "{kind} file written at location {path} and node notified"
+            ))
         } else {
-            Ok(format!("{kind} file written (no notification needed)"))
+            Ok(format!(
+                "{kind} file written at location {path} (no notification needed)"
+            ))
         }
     }
 }

--- a/rpc/src/routes.rs
+++ b/rpc/src/routes.rs
@@ -10,7 +10,7 @@ use commonware_cryptography::Signer;
 use commonware_utils::from_hex_formatted;
 use summit_types::{PrivateKey, utils::get_expanded_path};
 
-use crate::{PathSender, RpcState};
+use crate::{GenesisRpcState, PathSender, RpcState};
 
 pub(crate) struct RpcRoutes;
 
@@ -25,7 +25,7 @@ impl RpcRoutes {
             .with_state(state)
     }
 
-    pub fn mount_for_genesis(state: RpcState) -> Router {
+    pub fn mount_for_genesis(state: GenesisRpcState) -> Router {
         // todo(dalton): Add cors
         let state = Arc::new(state);
 
@@ -56,7 +56,7 @@ impl RpcRoutes {
     }
 
     async fn handle_send_genesis(
-        State(state): State<Arc<RpcState>>,
+        State(state): State<Arc<GenesisRpcState>>,
         body: String,
     ) -> Result<String, String> {
         Self::handle_send_file(&state.genesis, body, "genesis")

--- a/rpc/src/routes.rs
+++ b/rpc/src/routes.rs
@@ -7,7 +7,8 @@ use axum::{
 };
 use commonware_codec::DecodeExt as _;
 use commonware_cryptography::Signer;
-use commonware_utils::from_hex_formatted;
+use commonware_utils::{from_hex_formatted, hex};
+use ssz::Encode;
 use summit_types::{PrivateKey, utils::get_expanded_path};
 
 use crate::{GenesisRpcState, PathSender, RpcState};
@@ -22,6 +23,7 @@ impl RpcRoutes {
         Router::new()
             .route("/health", get(Self::handle_health_check))
             .route("/get_public_key", get(Self::handle_get_pub_key))
+            .route("/get_checkpoint", get(Self::handle_get_checkpoint))
             .with_state(state)
     }
 
@@ -53,6 +55,16 @@ impl RpcRoutes {
         let pk = PrivateKey::decode(&*key).map_err(|_| "unable to decode private key")?;
 
         Ok(pk)
+    }
+
+    async fn handle_get_checkpoint(State(state): State<Arc<RpcState>>) -> Result<String, String> {
+        let maybe_checkpoint = state.consensus_state_query.get_latest_checkpoint().await;
+        let Some(checkpoint) = maybe_checkpoint else {
+            return Err("checkpoint not found".into());
+        };
+
+        let encoded = checkpoint.as_ssz_bytes();
+        Ok(hex(&encoded))
     }
 
     async fn handle_send_genesis(

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -14,6 +14,7 @@ alloy-eips.workspace = true
 alloy-primitives.workspace = true
 alloy-consensus.workspace = true
 
+tokio.workspace = true
 anyhow.workspace = true
 dirs.workspace = true
 ethereum_ssz.workspace = true
@@ -21,7 +22,6 @@ serde.workspace = true
 toml.workspace = true
 
 bytes.workspace = true
-tracing.workspace = true
 serde_json = { workspace = true, optional = true }
 
 [features]

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -14,7 +14,7 @@ alloy-eips.workspace = true
 alloy-primitives.workspace = true
 alloy-consensus.workspace = true
 
-tokio.workspace = true
+futures.workspace = true
 anyhow.workspace = true
 dirs.workspace = true
 ethereum_ssz.workspace = true

--- a/types/src/checkpoint.rs
+++ b/types/src/checkpoint.rs
@@ -118,10 +118,7 @@ impl TryFrom<&Checkpoint> for ConsensusState {
         let computed_digest = hasher.finalize();
 
         if computed_digest != checkpoint.digest {
-            return Err(Error::Invalid(
-                "Checkpoint",
-                "Digest verification failed",
-            ));
+            return Err(Error::Invalid("Checkpoint", "Digest verification failed"));
         }
 
         ConsensusState::read(&mut checkpoint.data.as_ref())

--- a/types/src/checkpoint.rs
+++ b/types/src/checkpoint.rs
@@ -1,7 +1,7 @@
 use crate::Digest;
 use crate::consensus_state::ConsensusState;
 use bytes::{Buf, BufMut, Bytes};
-use commonware_codec::{Encode, EncodeSize, Error, Read, Write};
+use commonware_codec::{Encode, EncodeSize, Error, Read, ReadExt, Write};
 use commonware_cryptography::{Hasher, Sha256};
 use ssz::{Decode, Encode as SszEncode};
 
@@ -105,6 +105,26 @@ impl Read for Checkpoint {
 
         Self::from_ssz_bytes(buf.copy_to_bytes(len as usize).chunk())
             .map_err(|_| Error::Invalid("Checkpoint", "Unable to decode SSZ bytes for checkpoint"))
+    }
+}
+
+impl TryFrom<&Checkpoint> for ConsensusState {
+    type Error = Error;
+
+    fn try_from(checkpoint: &Checkpoint) -> Result<Self, Self::Error> {
+        // Verify the digest matches the data
+        let mut hasher = Sha256::new();
+        hasher.update(&checkpoint.data);
+        let computed_digest = hasher.finalize();
+
+        if computed_digest != checkpoint.digest {
+            return Err(Error::Invalid(
+                "Checkpoint",
+                "Digest verification failed",
+            ));
+        }
+
+        ConsensusState::read(&mut checkpoint.data.as_ref())
     }
 }
 
@@ -418,6 +438,161 @@ mod tests {
             encode_len,
             pure_ssz.len() + ssz::BYTES_PER_LENGTH_OFFSET,
             "EncodeSize should be SSZ + 4-byte prefix"
+        );
+    }
+
+    #[test]
+    fn test_try_from_checkpoint_to_consensus_state() {
+        use std::collections::{HashMap, VecDeque};
+
+        let original_state = ConsensusState {
+            latest_height: 42,
+            next_withdrawal_index: 99,
+            deposit_queue: VecDeque::new(),
+            withdrawal_queue: VecDeque::new(),
+            validator_accounts: HashMap::new(),
+            pending_checkpoint: None,
+            added_validators: Vec::new(),
+            removed_validators: Vec::new(),
+        };
+
+        let checkpoint = Checkpoint::new(&original_state);
+        let converted_state = ConsensusState::try_from(&checkpoint).unwrap();
+
+        assert_eq!(converted_state.latest_height, original_state.latest_height);
+        assert_eq!(
+            converted_state.next_withdrawal_index,
+            original_state.next_withdrawal_index
+        );
+        assert_eq!(
+            converted_state.deposit_queue.len(),
+            original_state.deposit_queue.len()
+        );
+        assert_eq!(
+            converted_state.withdrawal_queue.len(),
+            original_state.withdrawal_queue.len()
+        );
+        assert_eq!(
+            converted_state.validator_accounts.len(),
+            original_state.validator_accounts.len()
+        );
+    }
+
+    #[test]
+    fn test_try_from_checkpoint_with_corrupted_digest() {
+        use std::collections::{HashMap, VecDeque};
+
+        let original_state = ConsensusState {
+            latest_height: 42,
+            next_withdrawal_index: 99,
+            deposit_queue: VecDeque::new(),
+            withdrawal_queue: VecDeque::new(),
+            validator_accounts: HashMap::new(),
+            pending_checkpoint: None,
+            added_validators: Vec::new(),
+            removed_validators: Vec::new(),
+        };
+
+        let mut checkpoint = Checkpoint::new(&original_state);
+        // Corrupt the digest
+        checkpoint.digest = [0xFF; 32].into();
+
+        let result = ConsensusState::try_from(&checkpoint);
+        assert!(result.is_err());
+
+        if let Err(commonware_codec::Error::Invalid(entity, message)) = result {
+            assert_eq!(entity, "Checkpoint");
+            assert_eq!(message, "Digest verification failed");
+        } else {
+            panic!("Expected Invalid error with digest verification message");
+        }
+    }
+
+    #[test]
+    fn test_try_from_checkpoint_with_populated_state() {
+        use crate::account::{ValidatorAccount, ValidatorStatus};
+        use crate::execution_request::DepositRequest;
+        use crate::withdrawal::PendingWithdrawal;
+        use alloy_eips::eip4895::Withdrawal;
+        use alloy_primitives::Address;
+
+        // Create sample data for the populated state
+        let deposit1 = DepositRequest {
+            pubkey: parse_public_key(
+                "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+            ),
+            withdrawal_credentials: [1u8; 32],
+            amount: 32_000_000_000, // 32 ETH in gwei
+            signature: [42u8; 64],
+            index: 100,
+        };
+
+        let pending_withdrawal = PendingWithdrawal {
+            inner: Withdrawal {
+                index: 0,
+                validator_index: 1,
+                address: Address::from([3u8; 20]),
+                amount: 8_000_000_000, // 8 ETH in gwei
+            },
+            withdrawal_height: 500,
+            pubkey: [5u8; 32],
+        };
+
+        let validator_account1 = ValidatorAccount {
+            withdrawal_credentials: Address::from([7u8; 20]),
+            balance: 32_000_000_000, // 32 ETH
+            pending_withdrawal_amount: 0,
+            status: ValidatorStatus::Active,
+            last_deposit_index: 100,
+        };
+
+        // Create populated state
+        let mut deposit_queue = VecDeque::new();
+        deposit_queue.push_back(deposit1);
+
+        let mut withdrawal_queue = VecDeque::new();
+        withdrawal_queue.push_back(pending_withdrawal);
+
+        let mut validator_accounts = HashMap::new();
+        validator_accounts.insert([10u8; 32], validator_account1);
+
+        let original_state = ConsensusState {
+            latest_height: 1000,
+            next_withdrawal_index: 200,
+            deposit_queue,
+            withdrawal_queue,
+            validator_accounts,
+            pending_checkpoint: None,
+            added_validators: Vec::new(),
+            removed_validators: Vec::new(),
+        };
+
+        let checkpoint = Checkpoint::new(&original_state);
+        let converted_state = ConsensusState::try_from(&checkpoint).unwrap();
+
+        // Verify all fields match
+        assert_eq!(converted_state.latest_height, original_state.latest_height);
+        assert_eq!(
+            converted_state.next_withdrawal_index,
+            original_state.next_withdrawal_index
+        );
+        assert_eq!(converted_state.deposit_queue.len(), 1);
+        assert_eq!(converted_state.withdrawal_queue.len(), 1);
+        assert_eq!(converted_state.validator_accounts.len(), 1);
+
+        // Verify specific content
+        assert_eq!(converted_state.deposit_queue[0].amount, 32_000_000_000);
+        assert_eq!(
+            converted_state.withdrawal_queue[0].inner.amount,
+            8_000_000_000
+        );
+        assert_eq!(
+            converted_state
+                .validator_accounts
+                .get(&[10u8; 32])
+                .unwrap()
+                .balance,
+            32_000_000_000
         );
     }
 }

--- a/types/src/consensus_state_query.rs
+++ b/types/src/consensus_state_query.rs
@@ -1,5 +1,6 @@
 use crate::checkpoint::Checkpoint;
-use tokio::sync::{mpsc, oneshot};
+use futures::SinkExt;
+use futures::channel::{mpsc, oneshot};
 
 pub enum ConsensusStateRequest {
     GetCheckpoint,
@@ -8,25 +9,6 @@ pub enum ConsensusStateRequest {
 pub enum ConsensusStateResponse {
     Checkpoint(Option<Checkpoint>),
 }
-
-pub fn new(buffer_size: usize) -> (ConsensusStateQuery, ConsensusStateQueryMailbox) {
-    let (sender, receiver) = mpsc::channel(buffer_size);
-    (
-        ConsensusStateQuery { sender },
-        ConsensusStateQueryMailbox { receiver },
-    )
-}
-
-/// Receives queries about the consensus state..
-#[derive(Debug)]
-pub struct ConsensusStateQueryMailbox {
-    receiver: mpsc::Receiver<(
-        ConsensusStateRequest,
-        oneshot::Sender<ConsensusStateResponse>,
-    )>,
-}
-
-impl ConsensusStateQueryMailbox {}
 
 /// Used to send queries to the application finalizer to query the consensus state.
 #[derive(Clone, Debug)]
@@ -38,10 +20,35 @@ pub struct ConsensusStateQuery {
 }
 
 impl ConsensusStateQuery {
-    pub async fn get_latest_checkpoint(&self) -> Option<Checkpoint> {
+    pub fn new(
+        buffer_size: usize,
+    ) -> (
+        ConsensusStateQuery,
+        mpsc::Receiver<(
+            ConsensusStateRequest,
+            oneshot::Sender<ConsensusStateResponse>,
+        )>,
+    ) {
+        let (sender, receiver) = mpsc::channel(buffer_size);
+        (ConsensusStateQuery { sender }, receiver)
+    }
+
+    pub async fn get_latest_checkpoint_mut(&mut self) -> Option<Checkpoint> {
         let (tx, rx) = oneshot::channel();
         let req = ConsensusStateRequest::GetCheckpoint;
         let _ = self.sender.send((req, tx)).await;
+
+        let res = rx
+            .await
+            .expect("consensus state query response sender dropped");
+        let ConsensusStateResponse::Checkpoint(maybe_checkpoint) = res;
+        maybe_checkpoint
+    }
+
+    pub async fn get_latest_checkpoint(&self) -> Option<Checkpoint> {
+        let (tx, rx) = oneshot::channel();
+        let req = ConsensusStateRequest::GetCheckpoint;
+        let _ = self.sender.clone().send((req, tx)).await;
 
         let res = rx
             .await

--- a/types/src/consensus_state_query.rs
+++ b/types/src/consensus_state_query.rs
@@ -1,0 +1,52 @@
+use crate::checkpoint::Checkpoint;
+use tokio::sync::{mpsc, oneshot};
+
+pub enum ConsensusStateRequest {
+    GetCheckpoint,
+}
+
+pub enum ConsensusStateResponse {
+    Checkpoint(Option<Checkpoint>),
+}
+
+pub fn new(buffer_size: usize) -> (ConsensusStateQuery, ConsensusStateQueryMailbox) {
+    let (sender, receiver) = mpsc::channel(buffer_size);
+    (
+        ConsensusStateQuery { sender },
+        ConsensusStateQueryMailbox { receiver },
+    )
+}
+
+/// Receives queries about the consensus state..
+#[derive(Debug)]
+pub struct ConsensusStateQueryMailbox {
+    receiver: mpsc::Receiver<(
+        ConsensusStateRequest,
+        oneshot::Sender<ConsensusStateResponse>,
+    )>,
+}
+
+impl ConsensusStateQueryMailbox {}
+
+/// Used to send queries to the application finalizer to query the consensus state.
+#[derive(Clone, Debug)]
+pub struct ConsensusStateQuery {
+    sender: mpsc::Sender<(
+        ConsensusStateRequest,
+        oneshot::Sender<ConsensusStateResponse>,
+    )>,
+}
+
+impl ConsensusStateQuery {
+    pub async fn get_latest_checkpoint(&self) -> Option<Checkpoint> {
+        let (tx, rx) = oneshot::channel();
+        let req = ConsensusStateRequest::GetCheckpoint;
+        let _ = self.sender.send((req, tx)).await;
+
+        let res = rx
+            .await
+            .expect("consensus state query response sender dropped");
+        let ConsensusStateResponse::Checkpoint(maybe_checkpoint) = res;
+        maybe_checkpoint
+    }
+}

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -2,6 +2,7 @@ pub mod account;
 mod block;
 pub mod checkpoint;
 pub mod consensus_state;
+pub mod consensus_state_query;
 pub mod execution_request;
 pub mod genesis;
 pub mod header;


### PR DESCRIPTION
This makes the consensus state available to the RPC server (currently only the checkpoint, but more data can be added easily).
This will make it possible to request a checkpoint via RPC. 

Changes:
- Adds a [ConsensusStateQuery](https://github.com/SeismicSystems/summit/blob/519e0b8188fc4fe82f919c42a6fca7f3ead2810f/types/src/consensus_state_query.rs#L15) that can be used to send queries about the consensus state to the application finalizer
- Created two different modes for the RPC server
    - genesis mode: only has the route to accept the genesis file
    - normal mode: all routes except the genesis file route
- The RPC server will now be started in genesis mode at the beginning, and then shutdown once the genesis file is found or received
- After the engine is started, the RPC server will be started in normal mode. This makes is possible to pass a `ConsensusStateQuery` into the RPC server.
- Tests the `ConsensusStateQuery` in the checkpoint e2e tests by querying a checkpoint