### PR TITLE
fix: use parent_hash comparison instead of block_number for genesis check

### DIFF
--- a/node/src/bin/execute_blocks.rs
+++ b/node/src/bin/execute_blocks.rs
@@ -114,10 +114,15 @@ async fn main() -> Result<()> {
                 println!("Processing block {}: hash={:?}", block_number, block_hash);
 
                 // Convert block data to Summit Block for check_payload
-                let parent_digest: Digest = if block_number == 0 {
-                    genesis_hash.into()
-                } else {
-                    (*parent_hash).into()
+                // Use genesis_hash as parent if parent_hash points to genesis, otherwise use parent_hash
+                let parent_digest: Digest = {
+                    let parent_digest: Digest = (*parent_hash).into();
+                    let genesis_digest: Digest = genesis_hash.into();
+                    if parent_digest == genesis_digest {
+                        genesis_digest
+                    } else {
+                        parent_digest
+                    }
                 };
 
                 // use block number as view


### PR DESCRIPTION
Replace block_number == 0 check with parent_hash comparison to correctly
identify genesis block when processing starts from non-zero block numbers.
This ensures proper parent_digest selection regardless of start_block value.