### PR TITLE
feat: store a checkpoint for each epoch

### DIFF
--- a/finalizer/src/actor.rs
+++ b/finalizer/src/actor.rs
@@ -872,11 +872,12 @@ impl<
         sender: oneshot::Sender<ConsensusStateResponse>,
     ) {
         match consensus_state_request {
+            ConsensusStateRequest::GetLatestCheckpoint => {
+                let checkpoint = self.db.get_latest_finalized_checkpoint().await;
+                let _ = sender.send(ConsensusStateResponse::LatestCheckpoint(checkpoint));
+            }
             ConsensusStateRequest::GetCheckpoint(epoch) => {
-                let checkpoint = match epoch {
-                    Some(epoch) => self.db.get_finalized_checkpoint(epoch).await,
-                    None => self.db.get_latest_finalized_checkpoint().await,
-                };
+                let checkpoint = self.db.get_finalized_checkpoint(epoch).await;
                 let _ = sender.send(ConsensusStateResponse::Checkpoint(checkpoint));
             }
             ConsensusStateRequest::GetLatestHeight => {

--- a/finalizer/src/db.rs
+++ b/finalizer/src/db.rs
@@ -209,17 +209,13 @@ impl<E: Clock + Storage + Metrics, V: Variant> FinalizerState<E, V> {
         }
     }
 
-    pub async fn get_latest_finalized_checkpoint(&self) -> Option<Checkpoint> {
-        // Check if we have any checkpoints stored by checking if the tracker key exists
-        let key = Self::pad_key(&LATEST_CHECKPOINT_EPOCH_KEY);
-        self.store
-            .get(&key)
-            .await
-            .expect("failed to get latest checkpoint epoch")?;
-
+    pub async fn get_latest_finalized_checkpoint(&self) -> (Option<Checkpoint>, u64) {
         // Get the latest checkpoint epoch (could be 0, which is valid)
         let latest_epoch = self.get_latest_checkpoint_epoch().await;
-        self.get_finalized_checkpoint(latest_epoch).await
+
+        let checkpoint = self.get_finalized_checkpoint(latest_epoch).await;
+
+        (checkpoint, latest_epoch)
     }
 
     // FinalizedHeader operations
@@ -694,7 +690,7 @@ mod tests {
 
             // Test that no finalized checkpoint exists initially
             assert!(db.get_finalized_checkpoint(0).await.is_none());
-            assert!(db.get_latest_finalized_checkpoint().await.is_none());
+            assert!(db.get_latest_finalized_checkpoint().await.0.is_none());
 
             // Store finalized checkpoint for epoch 0
             db.store_finalized_checkpoint(0, &finalized_checkpoint1)
@@ -709,7 +705,7 @@ mod tests {
             assert_eq!(retrieved_finalized.digest, finalized_checkpoint1.digest);
 
             // Test that latest checkpoint returns epoch 0 checkpoint
-            let latest = db.get_latest_finalized_checkpoint().await.unwrap();
+            let latest = db.get_latest_finalized_checkpoint().await.0.unwrap();
             assert_eq!(latest.digest, finalized_checkpoint1.digest);
 
             // Store checkpoint for epoch 1
@@ -725,7 +721,7 @@ mod tests {
             assert_ne!(checkpoint0.digest, checkpoint1.digest);
 
             // Latest should now return epoch 1 checkpoint
-            let latest = db.get_latest_finalized_checkpoint().await.unwrap();
+            let latest = db.get_latest_finalized_checkpoint().await.0.unwrap();
             assert_eq!(latest.digest, finalized_checkpoint2.digest);
         });
     }
@@ -757,7 +753,7 @@ mod tests {
             db.commit().await;
 
             // Latest should be epoch 5
-            let latest = db.get_latest_finalized_checkpoint().await.unwrap();
+            let latest = db.get_latest_finalized_checkpoint().await.0.unwrap();
             assert_eq!(latest.digest, checkpoint5.digest);
 
             // Store epoch 3 (older than current latest)
@@ -765,7 +761,7 @@ mod tests {
             db.commit().await;
 
             // Latest should still be epoch 5, not 3
-            let latest = db.get_latest_finalized_checkpoint().await.unwrap();
+            let latest = db.get_latest_finalized_checkpoint().await.0.unwrap();
             assert_eq!(latest.digest, checkpoint5.digest);
 
             // Store epoch 7 (newer than current latest)
@@ -773,7 +769,7 @@ mod tests {
             db.commit().await;
 
             // Latest should now be epoch 7
-            let latest = db.get_latest_finalized_checkpoint().await.unwrap();
+            let latest = db.get_latest_finalized_checkpoint().await.0.unwrap();
             assert_eq!(latest.digest, checkpoint7.digest);
 
             // All checkpoints should still be individually accessible
@@ -820,7 +816,7 @@ mod tests {
             assert_ne!(retrieved.digest, checkpoint1.digest);
 
             // Latest should still point to epoch 2
-            let latest = db.get_latest_finalized_checkpoint().await.unwrap();
+            let latest = db.get_latest_finalized_checkpoint().await.0.unwrap();
             assert_eq!(latest.digest, checkpoint2.digest);
         });
     }
@@ -870,8 +866,9 @@ mod tests {
             assert!(db.get_finalized_checkpoint(4).await.is_none());
 
             // Latest should return epoch 5 (highest stored epoch)
-            let latest = db.get_latest_finalized_checkpoint().await.unwrap();
-            assert_eq!(latest.digest, checkpoint5.digest);
+            let (latest, epoch) = db.get_latest_finalized_checkpoint().await;
+            assert_eq!(latest.unwrap().digest, checkpoint5.digest);
+            assert_eq!(epoch, 5u64);
         });
     }
 }

--- a/finalizer/src/ingress.rs
+++ b/finalizer/src/ingress.rs
@@ -75,9 +75,9 @@ impl<S: Scheme, B: ConsensusBlock + Committable> FinalizerMailbox<S, B> {
         receiver
     }
 
-    pub async fn get_latest_checkpoint(&mut self) -> Option<Checkpoint> {
+    pub async fn get_latest_checkpoint(&mut self) -> (Option<Checkpoint>, u64) {
         let (response, rx) = oneshot::channel();
-        let request = ConsensusStateRequest::GetCheckpoint(None);
+        let request = ConsensusStateRequest::GetLatestCheckpoint;
         let _ = self
             .sender
             .send(FinalizerMessage::QueryState { request, response })
@@ -87,7 +87,7 @@ impl<S: Scheme, B: ConsensusBlock + Committable> FinalizerMailbox<S, B> {
             .await
             .expect("consensus state query response sender dropped");
 
-        let ConsensusStateResponse::Checkpoint(maybe_checkpoint) = res else {
+        let ConsensusStateResponse::LatestCheckpoint(maybe_checkpoint) = res else {
             unreachable!("request and response variants must match");
         };
 
@@ -96,7 +96,7 @@ impl<S: Scheme, B: ConsensusBlock + Committable> FinalizerMailbox<S, B> {
 
     pub async fn get_checkpoint(&mut self, epoch: u64) -> Option<Checkpoint> {
         let (response, rx) = oneshot::channel();
-        let request = ConsensusStateRequest::GetCheckpoint(Some(epoch));
+        let request = ConsensusStateRequest::GetCheckpoint(epoch);
         let _ = self
             .sender
             .send(FinalizerMessage::QueryState { request, response })

--- a/node/src/tests/checkpointing.rs
+++ b/node/src/tests/checkpointing.rs
@@ -188,6 +188,7 @@ fn test_checkpoint_created() {
             .clone()
             .get_latest_checkpoint()
             .await
+            .0
             .expect("failed to query checkpoint");
         let _consensus_state =
             ConsensusState::try_from(&checkpoint).expect("failed to parse consensus state");
@@ -390,6 +391,7 @@ fn test_previous_header_hash_matches() {
             .clone()
             .get_latest_checkpoint()
             .await
+            .0
             .expect("failed to query checkpoint");
         let _consensus_state =
             ConsensusState::try_from(&checkpoint).expect("failed to parse consensus state");
@@ -646,7 +648,12 @@ fn test_node_joins_later_with_checkpoint() {
         // Wait for the validators to checkpoint
         let consensus_state_query = consensus_state_queries.get(&0).unwrap();
         let checkpoint = loop {
-            if let Some(checkpoint) = consensus_state_query.clone().get_latest_checkpoint().await {
+            if let Some(checkpoint) = consensus_state_query
+                .clone()
+                .get_latest_checkpoint()
+                .await
+                .0
+            {
                 break checkpoint;
             }
             context.sleep(Duration::from_secs(1)).await;
@@ -893,7 +900,12 @@ fn test_node_joins_later_with_checkpoint_not_in_genesis() {
         // Wait for the validators to checkpoint
         let consensus_state_query = consensus_state_queries.get(&0).unwrap();
         let checkpoint = loop {
-            if let Some(checkpoint) = consensus_state_query.clone().get_latest_checkpoint().await {
+            if let Some(checkpoint) = consensus_state_query
+                .clone()
+                .get_latest_checkpoint()
+                .await
+                .0
+            {
                 break checkpoint;
             }
             context.sleep(Duration::from_secs(1)).await;

--- a/node/src/tests/syncer.rs
+++ b/node/src/tests/syncer.rs
@@ -133,7 +133,12 @@ fn test_node_joins_later_no_checkpoint_in_genesis() {
         // Wait for the validators to checkpoint
         let consensus_state_query = consensus_state_queries.get(&0).unwrap();
         let _checkpoint = loop {
-            if let Some(checkpoint) = consensus_state_query.clone().get_latest_checkpoint().await {
+            if let Some(checkpoint) = consensus_state_query
+                .clone()
+                .get_latest_checkpoint()
+                .await
+                .0
+            {
                 break checkpoint;
             }
             context.sleep(Duration::from_secs(1)).await;
@@ -367,7 +372,12 @@ fn test_node_joins_later_no_checkpoint_not_in_genesis() {
         // Wait for the validators to checkpoint
         let consensus_state_query = consensus_state_queries.get(&0).unwrap();
         let _checkpoint = loop {
-            if let Some(checkpoint) = consensus_state_query.clone().get_latest_checkpoint().await {
+            if let Some(checkpoint) = consensus_state_query
+                .clone()
+                .get_latest_checkpoint()
+                .await
+                .0
+            {
                 break checkpoint;
             }
             context.sleep(Duration::from_secs(1)).await;

--- a/rpc/src/routes.rs
+++ b/rpc/src/routes.rs
@@ -194,7 +194,7 @@ impl RpcRoutes {
             .clone()
             .get_latest_checkpoint()
             .await;
-        let Some(checkpoint) = maybe_checkpoint else {
+        let (Some(checkpoint), _) = maybe_checkpoint else {
             return Err("checkpoint not found".into());
         };
 

--- a/types/src/consensus_state_query.rs
+++ b/types/src/consensus_state_query.rs
@@ -5,12 +5,14 @@ use futures::channel::{mpsc, oneshot};
 
 #[allow(clippy::large_enum_variant)]
 pub enum ConsensusStateRequest {
-    GetCheckpoint(Option<u64>),
+    GetLatestCheckpoint,
+    GetCheckpoint(u64),
     GetLatestHeight,
     GetValidatorBalance(PublicKey),
 }
 
 pub enum ConsensusStateResponse {
+    LatestCheckpoint((Option<Checkpoint>, u64)), // (Checkpoint, Epoch#)
     Checkpoint(Option<Checkpoint>),
     LatestHeight(u64),
     ValidatorBalance(Option<u64>),
@@ -39,29 +41,29 @@ impl ConsensusStateQuery {
         (ConsensusStateQuery { sender }, receiver)
     }
 
-    pub async fn get_latest_checkpoint_mut(&mut self) -> Option<Checkpoint> {
+    pub async fn get_latest_checkpoint_mut(&mut self) -> (Option<Checkpoint>, u64) {
         let (tx, rx) = oneshot::channel();
-        let req = ConsensusStateRequest::GetCheckpoint(None);
+        let req = ConsensusStateRequest::GetLatestCheckpoint;
         let _ = self.sender.send((req, tx)).await;
 
         let res = rx
             .await
             .expect("consensus state query response sender dropped");
-        let ConsensusStateResponse::Checkpoint(maybe_checkpoint) = res else {
+        let ConsensusStateResponse::LatestCheckpoint(maybe_checkpoint) = res else {
             unreachable!("request and response variants must match");
         };
         maybe_checkpoint
     }
 
-    pub async fn get_latest_checkpoint(&self) -> Option<Checkpoint> {
+    pub async fn get_latest_checkpoint(&self) -> (Option<Checkpoint>, u64) {
         let (tx, rx) = oneshot::channel();
-        let req = ConsensusStateRequest::GetCheckpoint(None);
+        let req = ConsensusStateRequest::GetLatestCheckpoint;
         let _ = self.sender.clone().send((req, tx)).await;
 
         let res = rx
             .await
             .expect("consensus state query response sender dropped");
-        let ConsensusStateResponse::Checkpoint(maybe_checkpoint) = res else {
+        let ConsensusStateResponse::LatestCheckpoint(maybe_checkpoint) = res else {
             unreachable!("request and response variants must match");
         };
         maybe_checkpoint
@@ -69,7 +71,7 @@ impl ConsensusStateQuery {
 
     pub async fn get_checkpoint(&self, epoch: u64) -> Option<Checkpoint> {
         let (tx, rx) = oneshot::channel();
-        let req = ConsensusStateRequest::GetCheckpoint(Some(epoch));
+        let req = ConsensusStateRequest::GetCheckpoint(epoch);
         let _ = self.sender.clone().send((req, tx)).await;
 
         let res = rx


### PR DESCRIPTION
Stores finalized checkpoints for every epoch instead of just the latest one.