### PR TITLE
fix(syncer): remove duplicate notify_subscribers calls

### DIFF
--- a/syncer/src/actor.rs
+++ b/syncer/src/actor.rs
@@ -458,7 +458,6 @@ where
                                 // If found, persist the block and send to application
                                 self.cache_block(round, commitment, block.clone()).await;
                                 application.report(Update::NotarizedBlock(block.clone())).await;
-                                self.notify_subscribers(commitment, &block).await;
                             } else {
                                 debug!(?round, "notarized block missing");
                                 resolver.fetch(Request::<B>::Notarized { round }).await;
@@ -804,7 +803,6 @@ where
                                     // Cache the notarization and block
                                     self.cache_block(round, commitment, block.clone()).await;
                                     self.cache.put_notarization(round, commitment, notarization).await;
-                                    self.notify_subscribers(commitment, &block).await;
                                 },
                             }
                         },


### PR DESCRIPTION
The [cache_block()]https://github.com/SeismicSystems/summit/blob/ca596c1496635e7b574d07f35f3dc8710425c12d/syncer/src/actor.rs#L933-L937 function already calls [notify_subscribers()]https://github.com/SeismicSystems/summit/blob/ca596c1496635e7b574d07f35f3dc8710425c12d/syncer/src/actor.rs#L828-L834 internally, so the explicit calls after it were redundant. While not a bug (the second call was a no-op since subscribers are removed on first call), this removes unnecessary BTreeMap lookups and async function calls.