### PR TITLE
feat: finalizer DB errors trigger a shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6009,7 +6009,7 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "summit"
-version = "0.0.1-alpha"
+version = "0.0.2-alpha"
 dependencies = [
  "alloy",
  "alloy-consensus",
@@ -6079,7 +6079,7 @@ dependencies = [
 
 [[package]]
 name = "summit-application"
-version = "0.0.1-alpha"
+version = "0.0.2-alpha"
 dependencies = [
  "anyhow",
  "commonware-consensus",
@@ -6101,7 +6101,7 @@ dependencies = [
 
 [[package]]
 name = "summit-finalizer"
-version = "0.0.1-alpha"
+version = "0.0.2-alpha"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6132,7 +6132,7 @@ dependencies = [
 
 [[package]]
 name = "summit-orchestrator"
-version = "0.0.1-alpha"
+version = "0.0.2-alpha"
 dependencies = [
  "bytes",
  "commonware-broadcast",
@@ -6158,7 +6158,7 @@ dependencies = [
 
 [[package]]
 name = "summit-rpc"
-version = "0.0.1-alpha"
+version = "0.0.2-alpha"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -6194,7 +6194,7 @@ dependencies = [
 
 [[package]]
 name = "summit-syncer"
-version = "0.0.1-alpha"
+version = "0.0.2-alpha"
 dependencies = [
  "bytes",
  "commonware-broadcast",
@@ -6223,7 +6223,7 @@ dependencies = [
 
 [[package]]
 name = "summit-types"
-version = "0.0.1-alpha"
+version = "0.0.2-alpha"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/finalizer/benches/consensus_state_write.rs
+++ b/finalizer/benches/consensus_state_write.rs
@@ -10,6 +10,7 @@ use summit_types::Block;
 use summit_types::account::{ValidatorAccount, ValidatorStatus};
 use summit_types::checkpoint::Checkpoint;
 use summit_types::consensus_state::ConsensusState;
+use tokio_util::sync::CancellationToken;
 
 use commonware_cryptography::bls12381::primitives::variant::MinPk;
 
@@ -96,7 +97,8 @@ fn main() {
             ),
         };
 
-        let mut db = FinalizerState::<_, MinPk>::new(context, config).await;
+        let mut db =
+            FinalizerState::<_, MinPk>::new(context, config, CancellationToken::new()).await;
 
         let mut write_times: Vec<(u64, u128)> = Vec::new();
         let mut checkpoint_times: Vec<(u64, u128)> = Vec::new();

--- a/finalizer/src/actor.rs
+++ b/finalizer/src/actor.rs
@@ -143,8 +143,12 @@ impl<
             page_cache: cfg.page_cache,
         };
 
-        let db =
-            FinalizerState::<R, V>::new(context.with_label("finalizer_state"), state_cfg).await;
+        let db = FinalizerState::<R, V>::new(
+            context.with_label("finalizer_state"),
+            state_cfg,
+            cfg.cancellation_token.clone(),
+        )
+        .await;
 
         // Check if the state exists in the database. Otherwise, use the initial state.
         // The initial state could be from the genesis or a checkpoint.

--- a/finalizer/src/db.rs
+++ b/finalizer/src/db.rs
@@ -10,6 +10,8 @@ use commonware_utils::sequence::FixedBytes;
 use summit_types::checkpoint::Checkpoint;
 use summit_types::consensus_state::ConsensusState;
 use summit_types::{Block, FinalizedHeader};
+use tokio_util::sync::CancellationToken;
+use tracing::error;
 
 pub use db::Config;
 
@@ -26,15 +28,29 @@ const LATEST_CHECKPOINT_EPOCH_KEY: [u8; 2] = [STATE_PREFIX, 2];
 
 pub struct FinalizerState<E: Clock + Storage + Metrics, V: Variant> {
     store: Db<E, FixedBytes<64>, Value<V>, EightCap>,
+    cancellation_token: CancellationToken,
 }
 
 impl<E: Clock + Storage + Metrics, V: Variant> FinalizerState<E, V> {
-    pub async fn new(context: E, cfg: Config<EightCap, ((), ())>) -> Self {
+    pub async fn new(
+        context: E,
+        cfg: Config<EightCap, ((), ())>,
+        cancellation_token: CancellationToken,
+    ) -> Self {
         let store = Db::<_, FixedBytes<64>, Value<V>, EightCap>::init(context, cfg)
             .await
             .expect("failed to initialize unified store");
 
-        Self { store }
+        Self {
+            store,
+            cancellation_token,
+        }
+    }
+
+    /// Log a database error and initiate graceful shutdown.
+    fn handle_db_error(&self, e: impl std::fmt::Display, op: &str) {
+        error!(%e, op, "fatal database error, initiating shutdown");
+        self.cancellation_token.cancel();
     }
 
     fn pad_key(key: &[u8]) -> FixedBytes<64> {
@@ -71,79 +87,86 @@ impl<E: Clock + Storage + Metrics, V: Variant> FinalizerState<E, V> {
     // State variable operations
     async fn get_latest_consensus_state_epoch(&self) -> u64 {
         let key = Self::pad_key(&LATEST_CONSENSUS_STATE_EPOCH_KEY);
-        if let Some(Value::U64(epoch)) = self
-            .store
-            .get(&key)
-            .await
-            .expect("failed to get latest consensus state epoch")
-        {
-            epoch
-        } else {
-            0
+        match self.store.get(&key).await {
+            Ok(Some(Value::U64(epoch))) => epoch,
+            Ok(_) => 0,
+            Err(e) => {
+                self.handle_db_error(e, "get_latest_consensus_state_epoch");
+                0
+            }
         }
     }
 
     async fn set_latest_consensus_state_epoch(&mut self, epoch: u64) {
         let key = Self::pad_key(&LATEST_CONSENSUS_STATE_EPOCH_KEY);
-        self.store
+        if let Err(e) = self
+            .store
             .write_batch([(key, Some(Value::U64(epoch)))])
             .await
-            .expect("failed to set latest consensus state epoch");
+        {
+            self.handle_db_error(e, "set_latest_consensus_state_epoch");
+        }
     }
 
     // FinalizedHeader epoch tracking operations
     async fn get_latest_finalized_header_epoch(&self) -> u64 {
         let key = Self::pad_key(&LATEST_FINALIZED_HEADER_EPOCH_KEY);
-        if let Some(Value::U64(epoch)) = self
-            .store
-            .get(&key)
-            .await
-            .expect("failed to get latest finalized header epoch")
-        {
-            epoch
-        } else {
-            0
+        match self.store.get(&key).await {
+            Ok(Some(Value::U64(epoch))) => epoch,
+            Ok(_) => 0,
+            Err(e) => {
+                self.handle_db_error(e, "get_latest_finalized_header_epoch");
+                0
+            }
         }
     }
 
     async fn set_latest_finalized_header_epoch(&mut self, epoch: u64) {
         let key = Self::pad_key(&LATEST_FINALIZED_HEADER_EPOCH_KEY);
-        self.store
+        if let Err(e) = self
+            .store
             .write_batch([(key, Some(Value::U64(epoch)))])
             .await
-            .expect("failed to set latest finalized header epoch");
+        {
+            self.handle_db_error(e, "set_latest_finalized_header_epoch");
+        }
     }
 
     // Checkpoint epoch tracking operations
     async fn get_latest_checkpoint_epoch(&self) -> u64 {
         let key = Self::pad_key(&LATEST_CHECKPOINT_EPOCH_KEY);
-        if let Some(Value::U64(epoch)) = self
-            .store
-            .get(&key)
-            .await
-            .expect("failed to get latest checkpoint epoch")
-        {
-            epoch
-        } else {
-            0
+        match self.store.get(&key).await {
+            Ok(Some(Value::U64(epoch))) => epoch,
+            Ok(_) => 0,
+            Err(e) => {
+                self.handle_db_error(e, "get_latest_checkpoint_epoch");
+                0
+            }
         }
     }
 
     async fn set_latest_checkpoint_epoch(&mut self, epoch: u64) {
         let key = Self::pad_key(&LATEST_CHECKPOINT_EPOCH_KEY);
-        self.store
+        if let Err(e) = self
+            .store
             .write_batch([(key, Some(Value::U64(epoch)))])
             .await
-            .expect("failed to set latest checkpoint epoch");
+        {
+            self.handle_db_error(e, "set_latest_checkpoint_epoch");
+        }
     }
 
     // ConsensusState blob operations
     pub async fn store_consensus_state(&mut self, epoch: u64, state: &ConsensusState) {
         let key = Self::make_consensus_state_key(epoch);
-        self.store
+        if let Err(e) = self
+            .store
             .write_batch([(key, Some(Value::ConsensusState(Box::new(state.clone()))))])
             .await
-            .expect("failed to store consensus state");
+        {
+            self.handle_db_error(e, "store_consensus_state");
+            return;
+        }
 
         // Update the latest epoch tracker
         let current_latest = self.get_latest_consensus_state_epoch().await;
@@ -154,38 +177,36 @@ impl<E: Clock + Storage + Metrics, V: Variant> FinalizerState<E, V> {
 
     pub async fn get_consensus_state(&self, epoch: u64) -> Option<ConsensusState> {
         let key = Self::make_consensus_state_key(epoch);
-        if let Some(Value::ConsensusState(state)) = self
-            .store
-            .get(&key)
-            .await
-            .expect("failed to get consensus state")
-        {
-            Some(*state)
-        } else {
-            None
+        match self.store.get(&key).await {
+            Ok(Some(Value::ConsensusState(state))) => Some(*state),
+            Ok(_) => None,
+            Err(e) => {
+                self.handle_db_error(e, "get_consensus_state");
+                None
+            }
         }
     }
 
     pub async fn get_latest_consensus_state(&self) -> Option<ConsensusState> {
         let key = Self::pad_key(&LATEST_CONSENSUS_STATE_EPOCH_KEY);
-        if let Some(Value::U64(latest_epoch)) = self
-            .store
-            .get(&key)
-            .await
-            .expect("failed to get latest consensus state epoch")
-        {
-            self.get_consensus_state(latest_epoch).await
-        } else {
-            None
+        match self.store.get(&key).await {
+            Ok(Some(Value::U64(latest_epoch))) => self.get_consensus_state(latest_epoch).await,
+            Ok(_) => None,
+            Err(e) => {
+                self.handle_db_error(e, "get_latest_consensus_state");
+                None
+            }
         }
     }
 
     pub async fn delete_consensus_state(&mut self, epoch: u64) {
-        let key = Self::make_consensus_state_key(epoch);
-        self.store
-            .write_batch([(key, None)])
+        if let Err(e) = self
+            .store
+            .write_batch([(Self::make_consensus_state_key(epoch), None)])
             .await
-            .expect("failed to delete consensus state");
+        {
+            self.handle_db_error(e, "delete_consensus_state");
+        }
     }
 
     // Checkpoint operations
@@ -197,7 +218,8 @@ impl<E: Clock + Storage + Metrics, V: Variant> FinalizerState<E, V> {
         last_block: Block,
     ) {
         let key = Self::make_checkpoint_key(epoch);
-        self.store
+        if let Err(e) = self
+            .store
             .write_batch([(
                 key,
                 Some(Value::Checkpoint(Box::new((
@@ -206,7 +228,10 @@ impl<E: Clock + Storage + Metrics, V: Variant> FinalizerState<E, V> {
                 )))),
             )])
             .await
-            .expect("failed to store finalized checkpoint");
+        {
+            self.handle_db_error(e, "store_finalized_checkpoint");
+            return;
+        }
 
         // Update the latest checkpoint epoch tracker
         let current_latest = self.get_latest_checkpoint_epoch().await;
@@ -218,24 +243,19 @@ impl<E: Clock + Storage + Metrics, V: Variant> FinalizerState<E, V> {
     #[allow(unused)]
     pub async fn get_finalized_checkpoint(&self, epoch: u64) -> Option<(Checkpoint, Block)> {
         let key = Self::make_checkpoint_key(epoch);
-        if let Some(Value::Checkpoint(checkpoint)) = self
-            .store
-            .get(&key)
-            .await
-            .expect("failed to get finalized checkpoint")
-        {
-            Some(*checkpoint)
-        } else {
-            None
+        match self.store.get(&key).await {
+            Ok(Some(Value::Checkpoint(checkpoint))) => Some(*checkpoint),
+            Ok(_) => None,
+            Err(e) => {
+                self.handle_db_error(e, "get_finalized_checkpoint");
+                None
+            }
         }
     }
 
     pub async fn get_latest_finalized_checkpoint(&self) -> (Option<(Checkpoint, Block)>, u64) {
-        // Get the latest checkpoint epoch (could be 0, which is valid)
         let latest_epoch = self.get_latest_checkpoint_epoch().await;
-
         let checkpoint = self.get_finalized_checkpoint(latest_epoch).await;
-
         (checkpoint, latest_epoch)
     }
 
@@ -246,10 +266,14 @@ impl<E: Clock + Storage + Metrics, V: Variant> FinalizerState<E, V> {
         header: &FinalizedHeader<bls12381_multisig::Scheme<PublicKey, V>>,
     ) {
         let key = Self::make_finalized_header_key(epoch);
-        self.store
+        if let Err(e) = self
+            .store
             .write_batch([(key, Some(Value::FinalizedHeader(Box::new(header.clone()))))])
             .await
-            .expect("failed to store finalized header");
+        {
+            self.handle_db_error(e, "store_finalized_header");
+            return;
+        }
 
         // Update the latest finalized header epoch tracker
         let current_latest = self.get_latest_finalized_header_epoch().await;
@@ -264,15 +288,13 @@ impl<E: Clock + Storage + Metrics, V: Variant> FinalizerState<E, V> {
         epoch: u64,
     ) -> Option<FinalizedHeader<bls12381_multisig::Scheme<PublicKey, V>>> {
         let key = Self::make_finalized_header_key(epoch);
-        if let Some(Value::FinalizedHeader(header)) = self
-            .store
-            .get(&key)
-            .await
-            .expect("failed to get finalized header")
-        {
-            Some(*header)
-        } else {
-            None
+        match self.store.get(&key).await {
+            Ok(Some(Value::FinalizedHeader(header))) => Some(*header),
+            Ok(_) => None,
+            Err(e) => {
+                self.handle_db_error(e, "get_finalized_header");
+                None
+            }
         }
     }
 
@@ -285,10 +307,9 @@ impl<E: Clock + Storage + Metrics, V: Variant> FinalizerState<E, V> {
 
     // Commit all pending changes to the database
     pub async fn commit(&mut self) {
-        self.store
-            .commit(None)
-            .await
-            .expect("failed to commit to database");
+        if let Err(e) = self.store.commit(None).await {
+            self.handle_db_error(e, "commit");
+        }
     }
 }
 
@@ -399,7 +420,7 @@ mod tests {
                 NZUsize!(9),
             ),
         };
-        FinalizerState::<E, V>::new(context, config).await
+        FinalizerState::<E, V>::new(context, config, CancellationToken::new()).await
     }
 
     fn create_dummy_signature() -> Signature<MinPk> {

--- a/types/src/consensus_state.rs
+++ b/types/src/consensus_state.rs
@@ -677,7 +677,7 @@ impl ConsensusState {
                     min_or_max_stake_changed = true;
                 }
                 ProtocolParam::EpochLength(length) => {
-                    let new_length = std::num::NonZeroU64::new(length)
+                    let new_length = NonZeroU64::new(length)
                         .expect("EpochLength must be nonzero (validated at parse time)");
                     self.epocher
                         .update_length(new_length)

--- a/types/src/engine_client.rs
+++ b/types/src/engine_client.rs
@@ -119,7 +119,7 @@ impl EngineClient for RethEngineClient {
                     .await
                     .expect("Failed to update fork choice after reconnect")
             }
-            Err(_) => panic!("Unable to get a response"),
+            Err(e) => panic!("failed to start building block: {e:?}"),
         };
 
         if res.is_invalid() {


### PR DESCRIPTION
Unrecoverable errors in the finalizer DB will panic via expects. This is okay, but the finalizer already holds a CancellationToken for triggering a graceful shutdown. This CancellationToken can be used to shut down the node after a unrecoverable DB error.