### PR TITLE
chore: update eth_genesis_hash for new seismic-reth dev genesis

### DIFF
--- a/example_genesis.toml
+++ b/example_genesis.toml
@@ -1,4 +1,4 @@
-eth_genesis_hash = "0x3aade273783123091d493c481baa1e9e9bcde4b9cb87b29ae5398d83b88af441"
+eth_genesis_hash = "0x8f975717e2a125a79a2b1e46dbd226382c6e09343ea13f334a5dcd0dc2ec15c2"
 leader_timeout_ms = 2000
 notarization_timeout_ms = 4000
 nullify_timeout_ms = 4000


### PR DESCRIPTION
## Summary
- Updates `eth_genesis_hash` in `example_genesis.toml` from `0x3aade2...` to `0x8f975717...` to match the updated seismic-reth dev genesis

## Context
seismic-reth's `dev.json` was updated with a new account (`0x1000000000000000000000000000000000000006`) for the ops/governance RPC feature (SeismicSystems/seismic-reth#356), which changed the genesis hash. Without this update, Summit's finalizer gets stuck in a loop because reth reports as "syncing" forever — it receives a forkchoice update pointing to a hash it doesn't recognize.