### PR TITLE
feat: check/execute EL payload on certify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6051,6 +6051,7 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
+ "anyhow",
  "bytes",
  "commonware-codec",
  "commonware-consensus",

--- a/application/src/actor.rs
+++ b/application/src/actor.rs
@@ -31,6 +31,9 @@ use metrics::{counter, histogram};
 use summit_syncer::ingress::mailbox::Mailbox as SyncerMailbox;
 use summit_types::{Block, BlockAuxData, Digest, EngineClient};
 
+/// How long to wait before retrying check_payload when Reth returns SYNCING during certify.
+const CERTIFY_SYNCING_RETRY: Duration = Duration::from_millis(100);
+
 pub struct Actor<
     R: Storage + Metrics + Clock + Spawner + governor::clock::Clock + Rng,
     C: EngineClient,
@@ -215,6 +218,105 @@ impl<
                             } else {
                                 warn!("Asked to broadcast a block without one built");
                             }
+                        }
+
+                        Message::Certify {
+                            round,
+                            payload,
+                            mut response,
+                        } => {
+                            #[cfg(feature = "permissioned")]
+                            if self.paused.load(Ordering::Relaxed) {
+                                warn!("consensus paused, rejecting certify for round {round}");
+                                let _ = response.send(false);
+                                continue;
+                            }
+
+                            debug!("{rand_id} application: Handling message Certify for round {} (epoch {}, view {})",
+                                round, round.epoch(), round.view());
+
+                            let block_request = syncer.subscribe(Some(round), payload).await;
+
+                            self.context.with_label("certify").spawn({
+                                let mut finalizer_clone = finalizer.clone();
+                                let mut engine_client = self.engine_client.clone();
+                                let genesis_hash = self.genesis_hash;
+                                move |context| async move {
+                                    let work = async {
+                                        let Ok(block) = block_request.await else {
+                                            warn!(?round, "certify: failed to receive block from syncer");
+                                            return false;
+                                        };
+
+                                        // Wait for parent to be executed so its state is in Reth
+                                        // before check_payload runs on the child.
+                                        let parent_digest = block.parent();
+                                        if parent_digest != genesis_hash.into() {
+                                            let parent_height = block.height().saturating_sub(1);
+                                            let parent_executed = finalizer_clone
+                                                .notify_at_height(parent_height, parent_digest)
+                                                .await
+                                                .await
+                                                .unwrap_or(false);
+                                            if !parent_executed {
+                                                warn!(
+                                                    ?round,
+                                                    parent_height,
+                                                    ?parent_digest,
+                                                    "certify: parent block not executed by finalizer"
+                                                );
+                                                return false;
+                                            }
+                                        }
+
+                                        #[cfg(feature = "prom")]
+                                        let check_start = std::time::Instant::now();
+
+                                        let valid = loop {
+                                            let status = engine_client.check_payload(&block).await;
+                                            if status.is_syncing() {
+                                                warn!(
+                                                    ?round,
+                                                    height = block.height(),
+                                                    "certify: execution client returned SYNCING, retrying"
+                                                );
+                                                #[cfg(feature = "prom")]
+                                                counter!("certify_syncing_total").increment(1);
+                                                context.sleep(CERTIFY_SYNCING_RETRY).await;
+                                                continue;
+                                            }
+                                            break status.is_valid();
+                                        };
+
+                                        #[cfg(feature = "prom")]
+                                        {
+                                            let elapsed = check_start.elapsed().as_millis() as f64;
+                                            histogram!("certify_check_payload_duration_millis").record(elapsed);
+                                            if !valid {
+                                                counter!("certify_invalid_total").increment(1);
+                                            }
+                                        }
+
+                                        if !valid {
+                                            warn!(
+                                                ?round,
+                                                height = block.height(),
+                                                "certify: payload rejected by execution client"
+                                            );
+                                        }
+                                        valid
+                                    };
+
+                                    select! {
+                                        result = work => {
+                                            let _ = response.send(result);
+                                        },
+                                        _ = response.closed() => {
+                                            warn!("certify aborted for round {round}");
+                                        }
+                                    }
+                                }
+                            });
                         }
 
                         Message::Verify {
@@ -616,6 +718,14 @@ fn handle_verify<ES: Epocher>(
             "block parent mismatch: expected {}, received: {}",
             parent.digest(),
             block.parent()
+        );
+        return false;
+    }
+    if block.eth_parent_hash() != parent.eth_block_hash() {
+        warn!(
+            expected = ?parent.eth_block_hash(),
+            actual = ?block.eth_parent_hash(),
+            "eth_parent_hash mismatch"
         );
         return false;
     }

--- a/application/src/ingress.rs
+++ b/application/src/ingress.rs
@@ -26,6 +26,11 @@ pub enum Message {
         payload: Digest,
         response: oneshot::Sender<bool>,
     },
+    Certify {
+        round: Round,
+        payload: Digest,
+        response: oneshot::Sender<bool>,
+    },
 }
 
 #[derive(Clone)]
@@ -96,7 +101,18 @@ impl<P: PublicKey> Automaton for Mailbox<P> {
 }
 
 impl<P: PublicKey> CertifiableAutomaton for Mailbox<P> {
-    // Uses default certify() implementation which always returns true
+    async fn certify(&mut self, round: Round, payload: Self::Digest) -> oneshot::Receiver<bool> {
+        let (response, receiver) = oneshot::channel();
+        self.sender
+            .send(Message::Certify {
+                round,
+                payload,
+                response,
+            })
+            .await
+            .expect("Failed to send certify");
+        receiver
+    }
 }
 
 impl<P: PublicKey> Relay for Mailbox<P> {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,10 +43,11 @@ Summit is a modular consensus client implementing the Simplex protocol for EVM-b
  │                          │                                        │                                                
  │  • Propose(round, parent)│────────subscribe parent────────────────┤                                                
  │  • Verify(round, payload)│────────notify_at_height────────────────┤                                                
+ │  • Certify(round, blk)   │                                        │                                                
  │  • Broadcast(payload)    │────────get_aux_data────────────────────┤                                                
  │                          │                                        │                                                
  │  Implements:             │                                        │                                                
- │  - Automaton trait       │                                        │                                                
+ │  - CertifiableAutomaton  │                                        │                                                
  │  - Relay trait           │                                        │                                                
  │                          │                                        │                                                
  │  application/src/actor.rs│                                        │                                                
@@ -102,6 +103,7 @@ Summit is a modular consensus client implementing the Simplex protocol for EVM-b
              │                                                                                                        
              │ start_building_block(forkchoice, timestamp, withdrawals)                                               
              │ get_payload(payload_id)                                                                                
+             │ check_payload(block)                                                                                   
              │ commit_hash(forkchoice)                                                                                
              ▼                                                                                                        
      ┌──────────────────┐                                                                                             
@@ -184,13 +186,13 @@ Manages block synchronization and network state
 
 ### 4. Application (`application/`)
 
-Manages consensus state and validator set
+Implements the consensus interface — bridges Simplex's `Automaton`/`Relay`/`CertifiableAutomaton` traits with block production, structural validation, and payload validity gating.
 
 **Key Responsibilities:**
 - Propose blocks when selected as leader
-- Validate blocks received from network
-- Coordinate with execution client via Engine API
-- Maintain block cache for pending/finalized blocks
+- Validate received blocks structurally (`Automaton::verify`)
+- Gate certification on execution-payload validity (`CertifiableAutomaton::certify` calls `check_payload` against Reth)
+- Broadcast proposed blocks to peers (`Relay`)
 
 ### 5. Orchestrator (`orchestrator/`)
 
@@ -209,18 +211,20 @@ Coordinates consensus activities
 1. **Leader Selection**: Leader election is handled by the current Simplex instance
 2. **Block Building**: Application requests block from execution client via Engine API
 3. **Block Proposal**: Application broadcasts proposed block to network
-4. **Block Validation**: Application of peer validators validate block
-5. **Optimistic Execution**: Syncer sends notarized blocks to the finalizer for optimistic execution
-6. **Finalization**: Syncer sends finalized blocks to the finalizer for finalization
+4. **Structural Validation**: Peer validators run `Automaton::verify` and vote on notarization
+5. **Certification**: After notarization, peer validators run `CertifiableAutomaton::certify`, which calls `check_payload` against Reth; a 2f+1 quorum certifies the block
+6. **Optimistic Execution**: Syncer sends notarized blocks to the finalizer; finalizer calls `check_payload` and builds a fork state for blocks whose certify has not yet completed locally
+7. **Finalization**: Syncer sends finalized blocks to the finalizer; finalizer reuses the pre-built fork state when available, otherwise re-validates via `check_payload` (catch-up / sync)
 
 
 ### Block Reception Flow
 
 1. **Block Reception**: Syncer receives block from network
-2. **Block Caching**: Block stored in cache for validation
-3. **Block Validation**: Execution client validates block via Engine API
-5. **Optimistic Execution**: Finalizer optimistically executes notarized block
-5. **Block Finalization**: Finalizer applies finalized block
+2. **Block Caching**: Block stored in cache
+3. **Structural Validation**: Application validates block via `Automaton::verify`
+4. **Certification**: Application validates execution payload via `CertifiableAutomaton::certify` → `check_payload`
+5. **Optimistic Execution**: Finalizer optimistically executes notarized block (re-checks `check_payload` for blocks whose certify has not run locally; discards fork state if INVALID)
+6. **Block Finalization**: Finalizer applies finalized block; shuts down if a finalized block's payload is rejected by local Reth
 
 
 ### Synchronization Flow

--- a/docs/engine-api-integration.md
+++ b/docs/engine-api-integration.md
@@ -107,47 +107,81 @@ sequenceDiagram
     F->>Network: Broadcast block
 ```
 
-### Block Validation Flow
+### Block Validation and Certification Flow
+
+`check_payload` is invoked from two places: the Application's `certify` hook, and the Finalizer's block-execution path. Both serve the same goal — ensure the local Reth has validated the payload before any state mutation depends on it. Two call sites are needed because the Finalizer can process blocks for which the local `certify` never ran (described below).
+
+#### Certify (primary gate)
+
+After a block is notarized, Simplex calls `CertifiableAutomaton::certify` on each validator. Summit's implementation calls `check_payload` here. A `certify` quorum (2f+1) is required for a block to become "certified", and `find_parent` only returns certified blocks — so an invalid payload can never become the parent of a future block, and can never reach finalization under an honest 2f+1 majority.
 
 ```mermaid
 sequenceDiagram
-    participant N as Network
-    participant S as Syncer
+    participant Sx as Simplex
+    participant A as Application
+    participant F as Finalizer
     participant E as Engine Client
     participant R as Reth
 
-    N->>S: Receive block
-    S->>E: check_payload(block)
+    Note over Sx: Block notarized
+    Sx->>A: certify(round, payload)
+    A->>F: notify_at_height(parent_height, parent_digest)
+    Note over F: Wait until parent has been executed
+    F-->>A: parent executed
+    A->>E: check_payload(block)
     E->>R: engine_newPayloadV4(payload, ...)
     R-->>E: PayloadStatus
-    E-->>S: PayloadStatus
+    E-->>A: PayloadStatus
 
     alt PayloadStatus.Valid
-        Note over S: Participate in consensus
+        A-->>Sx: certify = true
     else PayloadStatus.Invalid
-        Note over S: Reject block
+        A-->>Sx: certify = false
     else PayloadStatus.Syncing
-        Note over S: Wait and retry
+        Note over A: Retry; view-timeout cancels if Reth never recovers
     end
 ```
+
+#### Finalizer (covers the case where local certify never ran)
+
+A block can reach the Finalizer for which this validator's `certify` did not run. Two situations:
+
+- **Lagging validator** — only 2f+1 *other* validators are required for the network to certify and finalize a block. A slower validator may receive a notarization or finalization for a block before its own `certify` completes (or starts).
+- **Syncing / catch-up** — when a node restarts or joins from a checkpoint, it fetches finalized blocks from peers and applies them directly through the Finalizer. The Simplex engine does not run for those historical epochs, so `certify` is never invoked for them.
+
+In both cases, the Finalizer must call `check_payload` itself before mutating consensus state or advancing Reth's head. Two paths:
+
+- **`handle_notarized_block`** — clones the parent state and executes the block to build a fork state. If `check_payload` returns INVALID, the fork state is discarded and `commit_hash` is not called. The block is left for `certify` to formally reject.
+- **`handle_finalized_block` (catch-up)** — no fork state exists for this block (the validator missed notarization or is syncing). The Finalizer executes against canonical state directly. If `check_payload` returns INVALID, the local Reth disagrees with a chain the rest of the network has finalized — the validator shuts down rather than commit an inconsistent state.
+
+When a fork state already exists at finalization (the common steady-state path), the Finalizer reuses it; `check_payload` was already called at notarization, so no duplicate work is needed.
 
 ### Finalization Flow
 
 ```mermaid
 sequenceDiagram
-    participant O as Orchestrator
+    participant Sx as Simplex
     participant F as Finalizer
     participant E as Engine Client
     participant R as Reth
 
-    Note over O: Block reaches finality
-    O->>F: Block finalized
+    Sx->>F: Block finalized
+
+    alt Fork state exists (already executed at notarization)
+        Note over F: Reuse pre-built fork state as canonical
+    else No fork state (catch-up / sync)
+        F->>E: check_payload(block)
+        E->>R: engine_newPayloadV4(payload, ...)
+        R-->>E: PayloadStatus
+        alt PayloadStatus.Invalid
+            Note over F: Local Reth disagrees with finalized chain — shutdown
+        end
+        Note over F: Execute block against canonical
+    end
+
     F->>E: commit_hash(new_forkchoice)
     E->>R: engine_forkchoiceUpdatedV3(forkchoice, None)
     R-->>E: ForkchoiceUpdatedResponse
-    E-->>F: ()
-
-    Note over R: Block committed to canonical chain
 ```
 
 ## Error Handling

--- a/docs/engine-api-integration.md
+++ b/docs/engine-api-integration.md
@@ -138,7 +138,7 @@ sequenceDiagram
     else PayloadStatus.Invalid
         A-->>Sx: certify = false
     else PayloadStatus.Syncing
-        Note over A: Retry; view-timeout cancels if Reth never recovers
+        Note over A: Retry — view-timeout cancels if Reth never recovers
     end
 ```
 

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -86,6 +86,18 @@ pub trait EngineClient: Clone + Send + Sync + 'static {
 - **Validation Isolation**: Execution client validates all state transitions
 - **Error Isolation**: Execution errors don't affect consensus state
 
+### Finalized Payload Validity
+
+Every finalized block is guaranteed to carry an execution payload accepted by at least 2f+1 validators' Reth instances:
+
+1. After notarization, Simplex requires a `certify` quorum (2f+1) before a block can be considered "certified".
+2. Each validator's `certify` hook calls `check_payload` against its local Reth and votes `certify = true` only if the result is `Valid`.
+3. `find_parent` only returns certified blocks, so future blocks cannot extend an uncertified ancestor. An invalid payload therefore cannot reach finalization under an honest 2f+1 majority.
+
+If a finalized block reaches a validator whose own Reth returns `Invalid` (local Reth corruption or a byzantine majority finalizing a payload this validator's Reth rejects), the validator shuts down rather than commit an inconsistent state.
+
+See [Engine API Integration](engine-api-integration.md) for the full call-site breakdown.
+
 ## Threat Model
 
 ### Covered Threats
@@ -123,7 +135,7 @@ pub trait EngineClient: Clone + Send + Sync + 'static {
 **Mitigation**:
 - Engine API isolation limits attack surface
 - IPC from within enclave to restrict access
-- Payload verification before consensus
+- Payload validity gated by `certify` quorum (2f+1) before a block can be extended or finalized
 
 **Threat**: State corruption or manipulation
 **Mitigation**:

--- a/finalizer/Cargo.toml
+++ b/finalizer/Cargo.toml
@@ -21,6 +21,7 @@ commonware-utils.workspace = true
 alloy-eips.workspace = true
 alloy-primitives.workspace = true
 alloy-rpc-types-engine.workspace = true
+anyhow.workspace = true
 bytes.workspace = true
 ethereum_ssz.workspace = true
 futures.workspace = true

--- a/finalizer/src/actor.rs
+++ b/finalizer/src/actor.rs
@@ -3,6 +3,7 @@ use crate::db::{Config as StateConfig, FinalizerState};
 use crate::{FinalizerConfig, FinalizerMailbox, FinalizerMessage};
 use alloy_primitives::Address;
 use alloy_rpc_types_engine::ForkchoiceState;
+use anyhow::{Result, anyhow};
 #[allow(unused)]
 use commonware_codec::{DecodeExt as _, ReadExt as _, Write as _};
 use commonware_consensus::Reporter;
@@ -313,7 +314,11 @@ impl<
                                     // I don't think we need this
                                 }
                                 Update::FinalizedBlock((block, finalization), ack_tx) => {
-                                    self.handle_finalized_block(ack_tx, block, finalization, &mut orchestrator_mailbox, &mut last_committed_timestamp).await;
+                                    if let Err(err) = self.handle_finalized_block(ack_tx, block, finalization, &mut orchestrator_mailbox, &mut last_committed_timestamp).await {
+                                        info!(?err, "finalizer triggering graceful shutdown");
+                                        self.cancellation_token.cancel();
+                                        break;
+                                    }
                                 }
                                 Update::NotarizedBlock(block) => {
                                     self.handle_notarized_block(block).await;
@@ -405,7 +410,7 @@ impl<
         >,
         orchestrator_mailbox: &mut summit_orchestrator::Mailbox,
         #[allow(unused_variables)] last_committed_timestamp: &mut Option<Instant>,
-    ) {
+    ) -> Result<()> {
         let height = block.height();
         let block_digest = block.digest();
 
@@ -435,7 +440,7 @@ impl<
                 ?block_digest,
                 "executing finalized block directly (no prior fork state)"
             );
-            execute_block(
+            let executed = execute_block(
                 &mut self.engine_client,
                 &self.context,
                 &block,
@@ -444,6 +449,29 @@ impl<
                 self.protocol_version_digest,
             )
             .await;
+            if !executed {
+                // Network finalized a block whose payload our local Reth rejects. Either
+                // our Reth has diverged (bug, corruption, restart loss) or a byzantine
+                // quorum certified an invalid payload. In either case, this validator
+                // cannot continue safely.
+                error!(
+                    target: "critical",
+                    height,
+                    ?block_digest,
+                    "finalized block payload rejected by execution client"
+                );
+                #[cfg(feature = "prom")]
+                counter!(
+                    "critical_errors_total",
+                    "reason" => "finalized_block_invalid",
+                    "severity" => "critical"
+                )
+                .increment(1);
+                return Err(anyhow!(
+                    "finalized block at height {height} with digest {block_digest:?} \
+                     was rejected by the execution client"
+                ));
+            }
         }
 
         #[cfg(debug_assertions)]
@@ -731,6 +759,7 @@ impl<
                 self.handle_notarized_block(child).await;
             }
         }
+        Ok(())
     }
 
     async fn handle_notarized_block(&mut self, block: Block) {
@@ -746,6 +775,18 @@ impl<
                 debug!(
                     height,
                     "ignoring notarized block at or below canonical height"
+                );
+                continue;
+            }
+            if self
+                .fork_states
+                .get(&height)
+                .is_some_and(|f| f.contains_key(&block_digest))
+            {
+                debug!(
+                    height,
+                    ?block_digest,
+                    "skipping already-processed notarized block"
                 );
                 continue;
             }
@@ -801,8 +842,11 @@ impl<
                 continue;
             };
 
-            // Execute the block into the cloned parent state
-            execute_block(
+            // Execute the block into the cloned parent state. If the payload is invalid,
+            // discard the block: certify will reject it on every honest validator, no
+            // certify quorum will form, and no descendant can build on it (find_parent
+            // gates on certified). The fork is dead; skip fork-state creation.
+            let executed = execute_block(
                 &mut self.engine_client,
                 &self.context,
                 &block,
@@ -811,6 +855,16 @@ impl<
                 self.protocol_version_digest,
             )
             .await;
+            if !executed {
+                warn!(
+                    height,
+                    ?block_digest,
+                    "discarding notarized block with invalid payload"
+                );
+                #[cfg(feature = "prom")]
+                counter!("notarized_block_invalid_total").increment(1);
+                continue;
+            }
 
             // Store the new fork state
             self.fork_states.entry(height).or_default().insert(
@@ -1303,10 +1357,12 @@ impl<
 /// Core execution logic that applies a block's state transitions to any ConsensusState.
 ///
 /// This method:
-/// - Calls check_payload on the engine client (validates and optimistically executes the block on the EVM)
-/// - Applies consensus-layer state transitions (deposits, withdrawals, validators)
-/// - Updates the forkchoice head
-/// - Creates checkpoints at epoch boundaries
+/// - Calls check_payload on the engine client to validate the block on the EVM.
+/// - On invalid payload, returns `false` without mutating `state`. The caller decides
+///   the policy (discard a notarized fork, shut down on a finalized block, etc.).
+/// - On valid payload: applies consensus-layer state transitions (deposits, withdrawals,
+///   validators), updates the forkchoice head, creates checkpoints at epoch boundaries,
+///   and returns `true`.
 ///
 /// This does NOT handle epoch transitions (activate validators, increment epoch).
 /// Epoch transitions only happen at finalization since the last block of an epoch
@@ -1321,7 +1377,7 @@ async fn execute_block<
     state: &mut ConsensusState,
     consts: &ProtocolConsts,
     protocol_version_digest: Digest,
-) {
+) -> bool {
     #[cfg(feature = "prom")]
     let block_processing_start = Instant::now();
 
@@ -1353,62 +1409,49 @@ async fn execute_block<
 
     // Validate block against execution layer state
     // Note: withdrawals are validated in the application layer before voting
-    if payload_status.is_valid() {
-        let eth_hash = block.eth_block_hash();
-        let tx_count = block.payload.payload_inner.payload_inner.transactions.len();
-        info!(
-            new_height,
-            epoch = state.get_epoch(),
-            tx_count,
-            eth_hash = hex(&eth_hash),
-            "committing block to execution layer"
-        );
+    if !payload_status.is_valid() {
+        return false;
+    }
 
-        state.set_forkchoice_head(eth_hash.into());
+    let eth_hash = block.eth_block_hash();
+    let tx_count = block.payload.payload_inner.payload_inner.transactions.len();
+    info!(
+        new_height,
+        epoch = state.get_epoch(),
+        tx_count,
+        eth_hash = hex(&eth_hash),
+        "committing block to execution layer"
+    );
 
-        // Parse execution requests
-        #[cfg(feature = "prom")]
-        let parse_requests_start = Instant::now();
-        parse_execution_requests(
-            context,
-            block,
-            new_height,
-            state,
-            protocol_version_digest,
-            consts,
-        )
-        .await;
+    state.set_forkchoice_head(eth_hash.into());
 
-        #[cfg(feature = "prom")]
-        {
-            let parse_requests_duration = parse_requests_start.elapsed().as_millis() as f64;
-            histogram!("parse_execution_requests_duration_millis").record(parse_requests_duration);
-        }
+    // Parse execution requests
+    #[cfg(feature = "prom")]
+    let parse_requests_start = Instant::now();
+    parse_execution_requests(
+        context,
+        block,
+        new_height,
+        state,
+        protocol_version_digest,
+        consts,
+    )
+    .await;
 
-        // Add validators that deposited to the validator set
-        #[cfg(feature = "prom")]
-        let process_requests_start = Instant::now();
-        process_execution_requests(context, block, new_height, state, consts).await;
-        #[cfg(feature = "prom")]
-        {
-            let process_requests_duration = process_requests_start.elapsed().as_millis() as f64;
-            histogram!("process_execution_requests_duration_millis")
-                .record(process_requests_duration);
-        }
-    } else {
-        let payload_valid = payload_status.is_valid();
-        let parent_matches = state.get_forkchoice().head_block_hash == block.eth_parent_hash();
-        let eth_block_hash = block.eth_block_hash();
-        warn!(
-            target: "critical",
-            new_height,
-            payload_valid,
-            parent_matches,
-            ?eth_block_hash,
-            "block validation failed, not executing but keeping in chain"
-        );
-        #[cfg(feature = "prom")]
-        counter!("critical_errors_total", "reason" => "block_validation_failed", "severity" => "critical").increment(1);
+    #[cfg(feature = "prom")]
+    {
+        let parse_requests_duration = parse_requests_start.elapsed().as_millis() as f64;
+        histogram!("parse_execution_requests_duration_millis").record(parse_requests_duration);
+    }
+
+    // Add validators that deposited to the validator set
+    #[cfg(feature = "prom")]
+    let process_requests_start = Instant::now();
+    process_execution_requests(context, block, new_height, state, consts).await;
+    #[cfg(feature = "prom")]
+    {
+        let process_requests_duration = process_requests_start.elapsed().as_millis() as f64;
+        histogram!("process_execution_requests_duration_millis").record(process_requests_duration);
     }
 
     state.set_latest_height(new_height);
@@ -1458,6 +1501,8 @@ async fn execute_block<
     // (epoch transitions, forkchoice updates) don't alter the captured value.
     let el_block_number = block.payload.payload_inner.payload_inner.block_number;
     state.capture_state_root(el_block_number);
+
+    true
 }
 
 async fn parse_execution_requests<

--- a/finalizer/src/actor.rs
+++ b/finalizer/src/actor.rs
@@ -450,8 +450,8 @@ impl<
             )
             .await;
             if !executed {
-                // Network finalized a block whose payload our local Reth rejects. Either
-                // our Reth has diverged (bug, corruption, restart loss) or a byzantine
+                // Network finalized a block whose payload the local Reth instance rejects. Either
+                // Reth has diverged (bug, corruption, restart loss) or a byzantine
                 // quorum certified an invalid payload. In either case, this validator
                 // cannot continue safely.
                 error!(

--- a/node/src/tests/execution_requests/withdrawals.rs
+++ b/node/src/tests/execution_requests/withdrawals.rs
@@ -4,7 +4,7 @@ use alloy_primitives::Bytes;
 use alloy_primitives::hex;
 use commonware_codec::Write;
 
-#[test_traced("INFO")]
+#[test_traced("DEBUG")]
 fn test_grouped_withdrawal_requests_in_single_eip7685_entry() {
     // Adds two deposits so both validators are active, then submits two withdrawal requests
     // packed into a single type-0x01 EIP-7685 entry.

--- a/node/src/tests/execution_requests/withdrawals.rs
+++ b/node/src/tests/execution_requests/withdrawals.rs
@@ -4,7 +4,7 @@ use alloy_primitives::Bytes;
 use alloy_primitives::hex;
 use commonware_codec::Write;
 
-#[test_traced("DEBUG")]
+#[test_traced("INFO")]
 fn test_grouped_withdrawal_requests_in_single_eip7685_entry() {
     // Adds two deposits so both validators are active, then submits two withdrawal requests
     // packed into a single type-0x01 EIP-7685 entry.

--- a/types/src/engine_client.rs
+++ b/types/src/engine_client.rs
@@ -292,7 +292,7 @@ impl EngineClient for BadBlockEngineClient {
     }
 
     async fn check_payload(&mut self, block: &Block) -> PayloadStatus {
-        let parent_beacon_block_root = if block.height().is_multiple_of(self.bad_block_timing) {
+        let parent_beacon_block_root = if block.view().is_multiple_of(self.bad_block_timing) {
             [1; 32].into()
         } else {
             block.header.parent_beacon_block_root.into()


### PR DESCRIPTION
Currently the EL payload is not verified by Simplex. This is an optimization to avoid EL payload execution on the consensus hot path. Instead, the EL payload of notarized/finalized blocks is verified when the blocks are executed by the finalizer actor.
If a block contains an invalid EL payload, Reth will reject and skip it. The block stays in Summit's chain in case it was a finalized block. Summit keeps track of Reth's forkchoice.
The consequence of this is that Summit's height might be larger than Reth's height.

This PR explores an alternative approach, where the EL payload is verified in `CertifiableAutomaton::certify`. This will prevent finalizations of blocks with invalid EL payload.
Benchmarks show that this will reduce the blocks per second by around 5.9%.

Changes:
- Call `check_payload` in `CertifiableAutomaton::certify`
- Discard notarized blocks in the finalizer actor if the EL payload is invalid (no chance of finalization)
- Throw an error and initiate shutdown in the finalizer actor if a finalized block contains an invalid EL payload