### PR TITLE
fix: update added_validators and removed_validators on stake-bound force-removals

### DIFF
--- a/finalizer/src/actor.rs
+++ b/finalizer/src/actor.rs
@@ -22,7 +22,7 @@ use metrics::{counter, histogram};
 #[cfg(debug_assertions)]
 use prometheus_client::metrics::gauge::Gauge;
 use rand::Rng;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::marker::PhantomData;
 use std::num::NonZero;
 use std::time::Instant;
@@ -1853,6 +1853,46 @@ async fn process_execution_requests<
                         state.set_account(node_pubkey_bytes, account);
                     }
                 }
+            }
+        }
+
+        // Stage stake-bound force-removals for the upcoming epoch boundary.
+        //
+        // Protocol-param changes themselves don't take effect until the last block of
+        // the epoch (see `apply_protocol_parameter_changes`), but we need any validator
+        // that will fall below the new minimum stake to be visible in
+        // `removed_validators` *before* the proposer builds the last block's header.
+        // Otherwise the header's delta won't include them and a checkpoint verifier
+        // walking from genesis will reconstruct a different committee than live nodes.
+        //
+        // We only push to `removed_validators` here. Balance zeroing, withdrawal
+        // scheduling, and status flips stay in the last-block path so the new bounds
+        // are only "effective" in the new epoch.
+        if state.has_pending_stake_bound_change() {
+            let prospective_min = state.prospective_minimum_stake();
+            let force_removed: Vec<PublicKey> = state
+                .validator_accounts_iter()
+                .filter_map(|(key, account)| {
+                    if account.balance < prospective_min {
+                        PublicKey::decode(&key[..]).ok()
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+            let already_removed: HashSet<PublicKey> =
+                state.get_removed_validators().iter().cloned().collect();
+            for public_key in force_removed {
+                if already_removed.contains(&public_key) {
+                    continue;
+                }
+                info!(
+                    validator = hex::encode(public_key.as_ref()),
+                    prospective_min,
+                    current_epoch = state.get_epoch(),
+                    "staging force-removal at penultimate block for header delta"
+                );
+                state.push_removed_validator(public_key);
             }
         }
     }

--- a/finalizer/src/actor.rs
+++ b/finalizer/src/actor.rs
@@ -1880,22 +1880,30 @@ async fn process_execution_requests<
         // Stage stake-bound force-removals for the upcoming epoch boundary.
         //
         // Protocol-param changes themselves don't take effect until the last block of
-        // the epoch (see `apply_protocol_parameter_changes`), but we need any validator
-        // that will fall below the new minimum stake to be visible in
-        // `removed_validators` *before* the proposer builds the last block's header.
-        // Otherwise the header's delta won't include them and a checkpoint verifier
-        // walking from genesis will reconstruct a different committee than live nodes.
+        // the epoch (see `apply_protocol_parameter_changes`), but any validator that
+        // will fall below the new minimum stake must show up in the last block's
+        // header delta. Otherwise a checkpoint verifier walking from genesis would
+        // reconstruct a different committee than live nodes.
         //
-        // We only push to `removed_validators` here. Balance zeroing, withdrawal
-        // scheduling, and status flips stay in the last-block path so the new bounds
-        // are only "effective" in the new epoch.
+        // We split by activation status:
+        //   - Active validators: push to `removed_validators` so the delta lands in
+        //     the last block's header.
+        //   - Joining validators (joining_epoch > current_epoch): cancel the pending
+        //     activation via `remove_added_validator`. They were never in any
+        //     header's `added_validators` (next_epoch < joining_epoch up to now), so
+        //     no `removed_validators` delta is needed; cancelling the activation
+        //     keeps live state and verifier-reconstructed state in agreement.
+        //
+        // Balance zeroing, withdrawal scheduling, and status flips stay in the
+        // last-block path so the new bounds are only "effective" in the new epoch.
         if state.has_pending_stake_bound_change() {
             let prospective_min = state.prospective_minimum_stake();
-            let force_removed: Vec<PublicKey> = state
+            let current_epoch = state.get_epoch();
+            let candidates: Vec<([u8; 32], u64)> = state
                 .validator_accounts_iter()
                 .filter_map(|(key, account)| {
                     if account.balance < prospective_min {
-                        PublicKey::decode(&key[..]).ok()
+                        Some((*key, account.joining_epoch))
                     } else {
                         None
                     }
@@ -1903,14 +1911,36 @@ async fn process_execution_requests<
                 .collect();
             let already_removed: HashSet<PublicKey> =
                 state.get_removed_validators().iter().cloned().collect();
-            for public_key in force_removed {
+            for (key, joining_epoch) in candidates {
+                let Ok(public_key) = PublicKey::decode(&key[..]) else {
+                    continue;
+                };
+
+                if joining_epoch > current_epoch {
+                    // This is a joining validator. Cancel the pending activation instead of
+                    // staging a removal. The validator has not yet been emitted in
+                    // any header's `added_validators`, so removing the pending
+                    // activation is sufficient to keep verifier reconstruction
+                    // aligned with the live committee.
+                    if state.remove_added_validator(joining_epoch, &public_key) {
+                        info!(
+                            validator = hex::encode(public_key.as_ref()),
+                            joining_epoch,
+                            current_epoch,
+                            prospective_min,
+                            "cancelling Joining validator's pending activation at penultimate block (below new min stake)"
+                        );
+                    }
+                    continue;
+                }
+
                 if already_removed.contains(&public_key) {
                     continue;
                 }
                 info!(
                     validator = hex::encode(public_key.as_ref()),
                     prospective_min,
-                    current_epoch = state.get_epoch(),
+                    current_epoch,
                     "staging force-removal at penultimate block for header delta"
                 );
                 state.push_removed_validator(public_key);

--- a/finalizer/src/actor.rs
+++ b/finalizer/src/actor.rs
@@ -1696,6 +1696,27 @@ async fn parse_execution_requests<
                         ExecutionRequest::ProtocolParam(protocol_param_request) => {
                             info!("Received protocol param request: {protocol_param_request:?}");
 
+                            // Buffer protocol param requests landing on the last block of
+                            // an epoch. Stake bound force removals are staged at the
+                            // penultimate block so they can appear in the last block's
+                            // removed_validators header delta. A request arriving on the
+                            // last block itself misses that window, so we defer it via
+                            // the pending execution request queue, mirroring how
+                            // withdrawal requests are handled. The request will replay
+                            // at the first block of the next epoch and apply naturally
+                            // at the next epoch boundary.
+                            if is_last_block_of_epoch(state.get_epocher(), new_height) {
+                                info!(
+                                    new_height,
+                                    current_epoch = state.get_epoch(),
+                                    "buffering protocol param request on last block of epoch: {protocol_param_request:?}"
+                                );
+                                let mut deferred_request = vec![0xFF];
+                                protocol_param_request.write(&mut deferred_request);
+                                state.push_pending_execution_request(deferred_request.into());
+                                continue;
+                            }
+
                             match ProtocolParam::try_from(protocol_param_request) {
                                 Ok(protocol_param) => {
                                     info!("Adding protocol param change: {protocol_param:?}");

--- a/node/src/tests/execution_requests/protocol_params.rs
+++ b/node/src/tests/execution_requests/protocol_params.rs
@@ -1499,9 +1499,247 @@ fn test_removed_validators_at_epoch_boundary_stake_bound() {
 
         let removed_validators = &finalized_header.header.removed_validators;
         assert!(
-            removed_validators.iter().any(|pk| *pk == kicked_pubkey),
+            removed_validators.contains(&kicked_pubkey),
             "force-removed validator (stake-bound) should be in removed_validators of \
              epoch 0's finalized header, but removed_validators = {removed_validators:?}"
+        );
+
+        context.auditor().state()
+    })
+}
+
+/// Verifies that when stake-bound enforcement force-removes a Joining validator
+/// (one whose activation is still pending in `added_validators`), the pending
+/// activation is cancelled so the finalized header does not carry a stale
+/// `added_validators` entry. Without the cancellation, a header-walking verifier
+/// (verify_checkpoint_chain) would reconstruct the validator into the committee
+/// even though the live node excluded it.
+///
+/// Setup (DEFAULT_BLOCKS_PER_EPOCH = 10, VALIDATOR_NUM_WARM_UP_EPOCHS = 2):
+/// - 5 genesis validators, each at 32 ETH. min_stake = 32 ETH, max_stake = 40 ETH.
+/// - Block 3: validators 0..=4 each top up 8 ETH → 40 ETH (safely above the new min).
+/// - Block 5: a brand-new validator deposits 32 ETH. Processed at penultimate of
+///   epoch 0 (block 8): account created with status = Joining, joining_epoch = 0 + 2 = 2.
+///   `state.add_validator(2, ...)` is called.
+/// - Block 15: protocol-param request raises min_stake to 36 ETH.
+/// - Penultimate of epoch 1 (block 18): stake-bound staging detects the Joining
+///   validator (balance 32 < prospective_min 36). The correct behavior is to
+///   *cancel* the pending activation via `remove_added_validator(2, pk)` so the
+///   activation never lands in any header.
+/// - Last block of epoch 1 (block 19) is the header that would normally activate
+///   the validator (`next_epoch == joining_epoch == 2`).
+///
+/// Assertion: epoch 1's finalized header does NOT contain the joining validator
+/// in `added_validators`.
+#[test_traced("INFO")]
+fn test_joining_validator_activation_cancelled_on_stake_bound_force_removal() {
+    let n: u32 = 5;
+    let min_stake = 32_000_000_000; // 32 ETH
+    let max_stake = 40_000_000_000; // 40 ETH
+    let new_validator_amount = 32_000_000_000u64; // below new min after the raise
+    let link = Link {
+        latency: Duration::from_millis(80),
+        jitter: Duration::from_millis(10),
+        success_rate: 0.98,
+    };
+
+    let cfg = deterministic::Config::default().with_seed(0);
+    let executor = Runner::from(cfg);
+    executor.start(|context| async move {
+        let (network, mut oracle) = Network::new(
+            context.with_label("network"),
+            simulated::Config {
+                max_size: 1024 * 1024,
+                disconnect_on_block: false,
+                tracked_peer_sets: NZUsize!(n as usize * 10),
+            },
+        );
+
+        network.start();
+
+        let mut key_stores = Vec::new();
+        let mut validators = Vec::new();
+        for i in 0..n {
+            let mut rng = StdRng::seed_from_u64(i as u64);
+            let node_key = PrivateKey::random(&mut rng);
+            let node_public_key = node_key.public_key();
+            let consensus_key = bls12381::PrivateKey::random(&mut rng);
+            let consensus_public_key = consensus_key.public_key();
+            let key_store = KeyStore {
+                node_key,
+                consensus_key,
+            };
+            key_stores.push(key_store);
+            validators.push((node_public_key, consensus_public_key));
+        }
+        validators.sort_by(|lhs, rhs| lhs.0.cmp(&rhs.0));
+        key_stores.sort_by_key(|ks| ks.node_key.public_key());
+
+        let node_public_keys: Vec<_> = validators.iter().map(|(pk, _)| pk.clone()).collect();
+        let mut registrations = common::register_validators(&oracle, &node_public_keys).await;
+
+        common::link_validators(&mut oracle, &node_public_keys, link, None).await;
+
+        let genesis_hash =
+            from_hex_formatted(common::GENESIS_HASH).expect("failed to decode genesis hash");
+        let genesis_hash: [u8; 32] = genesis_hash
+            .try_into()
+            .expect("failed to convert genesis hash");
+
+        // Block 3: top-up deposits for genesis validators so each ends up at exactly
+        // 40 ETH (= max), safely above the new min.
+        let topup_amount = 8_000_000_000u64;
+        let mut topup_deposits = Vec::new();
+        for i in 0..n as u64 {
+            let (deposit, _, _) = common::create_deposit_request(
+                i,
+                topup_amount,
+                common::get_domain(),
+                Some(key_stores[i as usize].node_key.clone()),
+                None,
+            );
+            topup_deposits.push(ExecutionRequest::Deposit(deposit));
+        }
+        let topup_requests = common::execution_requests_to_requests(topup_deposits);
+
+        // Block 5: brand-new validator deposit. The index n is unused so far, so its
+        // seeded key won't collide with any genesis validator.
+        let new_validator_index = n as u64;
+        let (new_deposit, new_validator_private_key, _) = common::create_deposit_request(
+            new_validator_index,
+            new_validator_amount,
+            common::get_domain(),
+            None,
+            None,
+        );
+        let new_validator_pubkey = new_validator_private_key.public_key();
+        let new_deposit_requests =
+            common::execution_requests_to_requests(vec![ExecutionRequest::Deposit(new_deposit)]);
+
+        // Block 15 (mid-epoch 1): raise min_stake to 36 ETH.
+        let new_min_stake = 36_000_000_000u64;
+        let min_param = common::create_protocol_param_request(0x00, new_min_stake);
+        let param_requests =
+            common::execution_requests_to_requests(vec![ExecutionRequest::ProtocolParam(
+                min_param,
+            )]);
+
+        let topup_block_height = 3;
+        let new_deposit_block_height = 5;
+        let protocol_param_block_height = 15;
+        // Last block of epoch 1 = 19. Stop at 20 so block 19 is finalized.
+        let last_block_epoch_1 = last_block_in_epoch(DEFAULT_BLOCKS_PER_EPOCH, 1);
+        let stop_height = last_block_epoch_1 + 1;
+
+        let mut execution_requests_map = HashMap::new();
+        execution_requests_map.insert(topup_block_height, topup_requests);
+        execution_requests_map.insert(new_deposit_block_height, new_deposit_requests);
+        execution_requests_map.insert(protocol_param_block_height, param_requests);
+
+        let engine_client_network = MockEngineNetworkBuilder::new(genesis_hash)
+            .with_execution_requests(execution_requests_map)
+            .with_stop_at(stop_height)
+            .build();
+        let mut initial_state = get_initial_state(genesis_hash, &validators, None, None, min_stake);
+        initial_state.set_maximum_stake(max_stake);
+
+        let mut public_keys = HashSet::new();
+        let mut finalizer_mailboxes = HashMap::new();
+        for (idx, key_store) in key_stores.into_iter().enumerate() {
+            let public_key = key_store.node_key.public_key();
+            public_keys.insert(public_key.clone());
+
+            let uid = format!("validator_{public_key}");
+            let namespace = String::from("_SUMMIT");
+
+            let engine_client = engine_client_network.create_client(uid.clone());
+
+            let config = get_default_engine_config(
+                engine_client,
+                SimulatedOracle::new(oracle.clone()),
+                uid.clone(),
+                genesis_hash,
+                namespace,
+                key_store,
+                validators.clone(),
+                initial_state.clone(),
+            );
+            let engine = Engine::new(context.with_label(&uid), config).await;
+            finalizer_mailboxes.insert(idx, engine.finalizer_mailbox.clone());
+
+            let (pending, recovered, resolver, orchestrator, broadcast) =
+                registrations.remove(&public_key).unwrap();
+
+            engine.start(pending, recovered, resolver, orchestrator, broadcast);
+        }
+
+        // All 5 genesis validators stay above the new min (40 >= 36) and continue
+        // participating, so all of them should reach stop_height.
+        let mut height_reached = HashSet::new();
+        loop {
+            let metrics = context.encode();
+
+            let mut success = false;
+            for line in metrics.lines() {
+                if !line.starts_with("validator_") {
+                    continue;
+                }
+
+                let mut parts = line.split_whitespace();
+                let metric = parts.next().unwrap();
+                let value = parts.next().unwrap();
+
+                if metric.ends_with("_peers_blocked") {
+                    let value = value.parse::<u64>().unwrap();
+                    assert_eq!(value, 0);
+                }
+
+                if metric.ends_with("finalizer_height") {
+                    let height = value.parse::<u64>().unwrap();
+                    if height >= stop_height {
+                        height_reached.insert(metric.to_string());
+                    }
+                }
+
+                if height_reached.len() as u32 == n {
+                    success = true;
+                    break;
+                }
+            }
+            if success {
+                break;
+            }
+
+            context.sleep(Duration::from_secs(1)).await;
+        }
+
+        // Sanity-check: protocol param took effect and the new validator's account
+        // ended up Inactive with zero balance
+        let state_query = finalizer_mailboxes.get(&0).unwrap();
+        assert_eq!(state_query.get_minimum_stake().await, new_min_stake);
+        let new_account = state_query
+            .get_validator_account(new_validator_pubkey.clone())
+            .await
+            .expect("new validator account should still exist (withdrawal not yet processed)");
+        assert_eq!(new_account.status, ValidatorStatus::Inactive);
+        assert_eq!(new_account.balance, 0);
+
+        // Bug under test: epoch 1's finalized header must NOT list the joining
+        // validator in added_validators. The pending activation should have been
+        // cancelled at the penultimate block; otherwise a header-walking verifier
+        // would reconstruct the validator into the committee for epoch 2 while the
+        // live node correctly excludes them.
+        let mut mailbox = finalizer_mailboxes.get(&0).unwrap().clone();
+        let finalized_header = mailbox
+            .get_finalized_header(1)
+            .await
+            .expect("failed to get finalized header for last block of epoch 1");
+
+        let added = &finalized_header.header.added_validators;
+        assert!(
+            !added.iter().any(|av| av.node_key == new_validator_pubkey),
+            "force-removed Joining validator should NOT appear in added_validators of \
+             epoch 1's finalized header, but added_validators = {added:?}"
         );
 
         context.auditor().state()

--- a/node/src/tests/execution_requests/protocol_params.rs
+++ b/node/src/tests/execution_requests/protocol_params.rs
@@ -1288,3 +1288,222 @@ fn test_protocol_param_max_deposits_per_epoch_rejected_above_max() {
         context.auditor().state()
     })
 }
+
+/// Verifies that a validator force-removed by stake-bound enforcement is recorded in the
+/// finalized header's `removed_validators` list at the epoch boundary where the removal
+/// takes effect.
+///
+/// Setup (DEFAULT_BLOCKS_PER_EPOCH = 10):
+/// - 5 genesis validators, each at 32 ETH. min_stake = 32 ETH, max_stake = 40 ETH.
+/// - Block 3: validators 0..=3 each deposit 8 ETH → 40 ETH (= max_stake). Validator 4
+///   does not deposit (stays at 32 ETH).
+/// - Block 5: protocol-param request raises min_stake to 40 ETH.
+/// - At the epoch 0 boundary (block 9), the new min_stake takes effect and validator 4
+///   (still at 32 ETH) must be force-removed.
+///
+/// Assertion: the finalized header for epoch 0 contains validator 4 in
+/// `removed_validators`, so a node joining later (which reconstructs the next epoch's
+/// committee from header deltas in `verify_checkpoint_chain`) sees the same validator
+/// set as a live node.
+#[test_traced("INFO")]
+fn test_removed_validators_at_epoch_boundary_stake_bound() {
+    let n: u32 = 5;
+    let min_stake = 32_000_000_000; // 32 ETH
+    let max_stake = 40_000_000_000; // 40 ETH (set from genesis to avoid partial-withdrawal noise)
+    let link = Link {
+        latency: Duration::from_millis(80),
+        jitter: Duration::from_millis(10),
+        success_rate: 0.98,
+    };
+
+    let cfg = deterministic::Config::default().with_seed(0);
+    let executor = Runner::from(cfg);
+    executor.start(|context| async move {
+        let (network, mut oracle) = Network::new(
+            context.with_label("network"),
+            simulated::Config {
+                max_size: 1024 * 1024,
+                disconnect_on_block: false,
+                tracked_peer_sets: NZUsize!(n as usize * 10),
+            },
+        );
+
+        network.start();
+
+        let mut key_stores = Vec::new();
+        let mut validators = Vec::new();
+        for i in 0..n {
+            let mut rng = StdRng::seed_from_u64(i as u64);
+            let node_key = PrivateKey::random(&mut rng);
+            let node_public_key = node_key.public_key();
+            let consensus_key = bls12381::PrivateKey::random(&mut rng);
+            let consensus_public_key = consensus_key.public_key();
+            let key_store = KeyStore {
+                node_key,
+                consensus_key,
+            };
+            key_stores.push(key_store);
+            validators.push((node_public_key, consensus_public_key));
+        }
+        validators.sort_by(|lhs, rhs| lhs.0.cmp(&rhs.0));
+        key_stores.sort_by_key(|ks| ks.node_key.public_key());
+
+        let node_public_keys: Vec<_> = validators.iter().map(|(pk, _)| pk.clone()).collect();
+        let mut registrations = common::register_validators(&oracle, &node_public_keys).await;
+
+        common::link_validators(&mut oracle, &node_public_keys, link, None).await;
+
+        let genesis_hash =
+            from_hex_formatted(common::GENESIS_HASH).expect("failed to decode genesis hash");
+        let genesis_hash: [u8; 32] = genesis_hash
+            .try_into()
+            .expect("failed to convert genesis hash");
+
+        // Validator at index n-1 stays at 32 ETH — it will fall below the new 40 ETH min
+        // stake and must be force-removed at the epoch 0 boundary.
+        let kicked_idx = (n - 1) as usize;
+        let kicked_pubkey = validators[kicked_idx].0.clone();
+
+        // Validators 0..kicked_idx each deposit 8 ETH (32 + 8 = 40 ETH, exactly at max).
+        let mut deposit_requests = Vec::new();
+        let deposit_amount = 8_000_000_000u64;
+        for i in 0..kicked_idx as u64 {
+            let (deposit, _, _) = common::create_deposit_request(
+                i,
+                deposit_amount,
+                common::get_domain(),
+                Some(key_stores[i as usize].node_key.clone()),
+                None,
+            );
+            deposit_requests.push(ExecutionRequest::Deposit(deposit));
+        }
+        let requests_deposits = common::execution_requests_to_requests(deposit_requests);
+
+        let new_min_stake = 40_000_000_000u64; // 40 ETH
+        let min_param = common::create_protocol_param_request(0x00, new_min_stake);
+        let requests_param =
+            common::execution_requests_to_requests(vec![ExecutionRequest::ProtocolParam(
+                min_param,
+            )]);
+
+        let deposit_block_height = 3;
+        let protocol_param_block_height = 5;
+        // Last block of epoch 0 = 9. Stop at 10 so block 9 is finalized.
+        let last_block_epoch_0 = last_block_in_epoch(DEFAULT_BLOCKS_PER_EPOCH, 0);
+        let stop_height = last_block_epoch_0 + 1;
+
+        let mut execution_requests_map = HashMap::new();
+        execution_requests_map.insert(deposit_block_height, requests_deposits);
+        execution_requests_map.insert(protocol_param_block_height, requests_param);
+
+        let engine_client_network = MockEngineNetworkBuilder::new(genesis_hash)
+            .with_execution_requests(execution_requests_map)
+            .with_stop_at(stop_height)
+            .build();
+        let mut initial_state = get_initial_state(genesis_hash, &validators, None, None, min_stake);
+        initial_state.set_maximum_stake(max_stake);
+
+        let mut public_keys = HashSet::new();
+        let mut finalizer_mailboxes = HashMap::new();
+        for (idx, key_store) in key_stores.into_iter().enumerate() {
+            let public_key = key_store.node_key.public_key();
+            public_keys.insert(public_key.clone());
+
+            let uid = format!("validator_{public_key}");
+            let namespace = String::from("_SUMMIT");
+
+            let engine_client = engine_client_network.create_client(uid.clone());
+
+            let config = get_default_engine_config(
+                engine_client,
+                SimulatedOracle::new(oracle.clone()),
+                uid.clone(),
+                genesis_hash,
+                namespace,
+                key_store,
+                validators.clone(),
+                initial_state.clone(),
+            );
+            let engine = Engine::new(context.with_label(&uid), config).await;
+            finalizer_mailboxes.insert(idx, engine.finalizer_mailbox.clone());
+
+            let (pending, recovered, resolver, orchestrator, broadcast) =
+                registrations.remove(&public_key).unwrap();
+
+            engine.start(pending, recovered, resolver, orchestrator, broadcast);
+        }
+
+        // The kicked validator exits at the epoch boundary, so only n-1 validators
+        // will reach stop_height.
+        let mut height_reached = HashSet::new();
+        loop {
+            let metrics = context.encode();
+
+            let mut success = false;
+            for line in metrics.lines() {
+                if !line.starts_with("validator_") {
+                    continue;
+                }
+
+                let mut parts = line.split_whitespace();
+                let metric = parts.next().unwrap();
+                let value = parts.next().unwrap();
+
+                if metric.ends_with("_peers_blocked") {
+                    let value = value.parse::<u64>().unwrap();
+                    assert_eq!(value, 0);
+                }
+
+                if metric.ends_with("finalizer_height") {
+                    let height = value.parse::<u64>().unwrap();
+                    if height >= stop_height {
+                        height_reached.insert(metric.to_string());
+                    }
+                }
+
+                if height_reached.len() as u32 == n - 1 {
+                    success = true;
+                    break;
+                }
+            }
+            if success {
+                break;
+            }
+
+            context.sleep(Duration::from_secs(1)).await;
+        }
+
+        // Sanity-check that the stake-bound enforcement actually fired: the protocol
+        // parameter took effect and the kicked validator was moved out of the active
+        // set. Query a still-running validator (index 0) — the kicked validator's
+        // finalizer shuts down after exit.
+        let state_query = finalizer_mailboxes.get(&0).unwrap();
+        assert_eq!(state_query.get_minimum_stake().await, new_min_stake);
+        let kicked_account = state_query
+            .get_validator_account(kicked_pubkey.clone())
+            .await;
+        assert!(
+            kicked_account.is_none()
+                || kicked_account.as_ref().unwrap().status == ValidatorStatus::Inactive,
+            "kicked validator should be Inactive (or already removed) after epoch 0 boundary"
+        );
+
+        // The header for the last block of epoch 0 must include the force-removed
+        // validator in `removed_validators` so header-walking verifiers
+        // (verify_checkpoint_chain) reconstruct the same committee as live nodes.
+        let mut mailbox = finalizer_mailboxes.get(&0).unwrap().clone();
+        let finalized_header = mailbox
+            .get_finalized_header(0)
+            .await
+            .expect("failed to get finalized header for last block of epoch 0");
+
+        let removed_validators = &finalized_header.header.removed_validators;
+        assert!(
+            removed_validators.iter().any(|pk| *pk == kicked_pubkey),
+            "force-removed validator (stake-bound) should be in removed_validators of \
+             epoch 0's finalized header, but removed_validators = {removed_validators:?}"
+        );
+
+        context.auditor().state()
+    })
+}

--- a/types/src/consensus_state.rs
+++ b/types/src/consensus_state.rs
@@ -201,6 +201,45 @@ impl ConsensusState {
         self.validator_maximum_stake
     }
 
+    /// Returns the minimum stake that *will* apply after the queued protocol-parameter
+    /// changes are drained at the next epoch boundary. If no `MinimumStake` change is
+    /// queued, returns the currently-active value.
+    pub fn prospective_minimum_stake(&self) -> u64 {
+        self.protocol_param_changes
+            .iter()
+            .rev()
+            .find_map(|p| match p {
+                ProtocolParam::MinimumStake(v) => Some(*v),
+                _ => None,
+            })
+            .unwrap_or(self.validator_minimum_stake)
+    }
+
+    /// Returns the maximum stake that *will* apply after the queued protocol-parameter
+    /// changes are drained at the next epoch boundary. If no `MaximumStake` change is
+    /// queued, returns the currently-active value.
+    pub fn prospective_maximum_stake(&self) -> u64 {
+        self.protocol_param_changes
+            .iter()
+            .rev()
+            .find_map(|p| match p {
+                ProtocolParam::MaximumStake(v) => Some(*v),
+                _ => None,
+            })
+            .unwrap_or(self.validator_maximum_stake)
+    }
+
+    /// Whether a `MinimumStake` or `MaximumStake` change is queued for application at
+    /// the next epoch boundary.
+    pub fn has_pending_stake_bound_change(&self) -> bool {
+        self.protocol_param_changes.iter().any(|p| {
+            matches!(
+                p,
+                ProtocolParam::MinimumStake(_) | ProtocolParam::MaximumStake(_)
+            )
+        })
+    }
+
     pub fn set_minimum_stake(&mut self, stake: u64) {
         self.validator_minimum_stake = stake;
         self.ssz_tree.set_validator_minimum_stake(stake);


### PR DESCRIPTION
The finalized header for an epoch will be created on the penultimate block of an epoch. This is because the finalized header has to be included in the last block of an epoch, so that the aggregated signature from the finalization certificate can be used to attest to the finalized header.
Therefore, all the fields that will be included in the finalized header (including `removed_validators`) have to be calculated after processing the penultimate block of an epoch.

Protocol parameter updates are processed on the last block of an epoch. If `MinimumStake` is increased, validators whose stake is below the new minimum stake will be removed. 
However, when the validators are removed on the last block of an epoch, they won't be included in the `removed_validators` field of the finalized header. 
Similarly, validators that are scheduled to join in a future epoch won't be removed from the `added_validators` map.

When a joining validator wants to verify a checkpoint, they calculate the validator set for each epoch based on the validator deltas included in the finalized headers. Stake-bound force-removals would be missing from this delta, and pending validators whose participation was aborted before joining will be included wrongfully.

Changes:
- On the penultimate block of an epoch, it is checked if a protocol parameter change for the maximum or minimum stake is currently pending. If yes, the list of active validators whose stake is below the new minimum stake is calculated and added to `removed_validators`. The list of joining validators whose stake is below the new minimum stake is calculated and removed from `added_validators`. The actual handling of the protocol parameter updates is still done at the last block of an epoch to ensure that the protocol parameter updates are only effective for the new epoch.
- If a protocol parameter request for `MinimumStake` arrives with the last block of an epoch, some validators could be removed, but the changes wouldn't be recorded in `removed_validators`. Therefore, protocol param requests arriving with the last block of an epoch will be buffered until the next epoch.
- An e2e test `test_removed_validators_at_epoch_boundary_stake_bound` is added to verify that the finalized header's `removed_validators` field will include validators that were forcefully removed due to insufficient stake.
- An e2e test `test_joining_validator_activation_cancelled_on_stake_bound_force_removal` is added to verify that if a joining validator is kicked before becoming active, they won't be included in the finalized header's `added_validators` field.