### PR TITLE
fix: verify proposed block's round and refactor header digest calculation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6199,6 +6199,7 @@ dependencies = [
  "dirs 6.0.0",
  "ethereum_hashing",
  "ethereum_ssz",
+ "ethereum_ssz_derive",
  "futures",
  "libc",
  "metrics",

--- a/application/src/actor.rs
+++ b/application/src/actor.rs
@@ -790,19 +790,20 @@ fn handle_verify<ES: Epocher>(
         );
         return false;
     }
-    if block.header.prev_epoch_header_hash != aux_data.header_hash {
+    if block.header.prev_epoch_header_hash() != aux_data.header_hash {
         warn!(
             "prev_epoch_header_hash mismatch: expected: {:?}, received: {:?}",
-            aux_data.header_hash, block.header.prev_epoch_header_hash
+            aux_data.header_hash,
+            block.header.prev_epoch_header_hash()
         );
         return false;
     }
 
     // Validate consensus trie state root
-    if block.header.parent_beacon_block_root != aux_data.state_root {
+    if block.header.parent_beacon_block_root() != aux_data.state_root {
         warn!(
             expected = ?aux_data.state_root,
-            actual = ?block.header.parent_beacon_block_root,
+            actual = ?block.header.parent_beacon_block_root(),
             "parent_beacon_block_root mismatch"
         );
         return false;
@@ -811,30 +812,32 @@ fn handle_verify<ES: Epocher>(
     // Validate checkpoint_hash (None means [0; 32], matching Block::compute_digest)
     let expected_checkpoint_hash: Digest =
         aux_data.checkpoint_hash.unwrap_or_else(|| [0; 32].into());
-    if block.header.checkpoint_hash != expected_checkpoint_hash {
+    if block.header.checkpoint_hash() != expected_checkpoint_hash {
         warn!(
             expected = ?expected_checkpoint_hash,
-            actual = ?block.header.checkpoint_hash,
+            actual = ?block.header.checkpoint_hash(),
             "checkpoint_hash mismatch"
         );
         return false;
     }
 
     // Validate added_validators
-    if block.header.added_validators != aux_data.added_validators {
+    let added_validators = block.header.added_validators();
+    if added_validators != aux_data.added_validators {
         warn!(
             expected_count = aux_data.added_validators.len(),
-            actual_count = block.header.added_validators.len(),
+            actual_count = added_validators.len(),
             "added_validators mismatch"
         );
         return false;
     }
 
     // Validate removed_validators
-    if block.header.removed_validators != aux_data.removed_validators {
+    let removed_validators = block.header.removed_validators();
+    if removed_validators != aux_data.removed_validators {
         warn!(
             expected_count = aux_data.removed_validators.len(),
-            actual_count = block.header.removed_validators.len(),
+            actual_count = removed_validators.len(),
             "removed_validators mismatch"
         );
         return false;

--- a/application/src/actor.rs
+++ b/application/src/actor.rs
@@ -749,6 +749,22 @@ fn handle_verify<ES: Epocher>(
         return false;
     }
     // Basic structural validation
+    if block.view() != round.view().get() {
+        warn!(
+            "block view mismatch: expected: {}, received: {}",
+            round.view().get(),
+            block.view()
+        );
+        return false;
+    }
+    if block.epoch() != round.epoch().get() {
+        warn!(
+            "block epoch mismatch: expected: {}, received: {}",
+            round.epoch().get(),
+            block.epoch()
+        );
+        return false;
+    }
     if block.parent() != parent.digest() {
         warn!(
             "block parent mismatch: expected: {}, received: {}",

--- a/docs/ssz-merklization.md
+++ b/docs/ssz-merklization.md
@@ -346,6 +346,8 @@ pub fn capture_state_root(&mut self, el_block_number: u64) {
 
 This is called after `execute_block` in the finalizer. The frozen `proof_tree` is used for all subsequent proof generation (via RPC), while the live `ssz_tree` continues to be mutated by finalization operations. The snapshot includes the sorted validator keys (needed for positional index lookups) and the withdrawal pubkey index (stored inside the `SszStateTree`).
 
+At an epoch boundary the finalized last block applies transition mutations *after* `execute_block` — protocol-parameter changes, committee updates, the epoch increment, the epoch-genesis hash, and added/removed-validator cleanup. So `capture_state_root()` is called a second time, after those mutations complete, before any aux data is exposed for the next block. This guarantees the first block of the new epoch advertises a `parent_beacon_block_root` that commits to the post-transition consensus state (the committee and parameters that authorize it), rather than the pre-transition snapshot from `execute_block`. The re-capture also re-freezes the `proof_tree`, so RPC proofs served after the boundary verify against the same post-transition root.
+
 The state root appears on-chain in EL block `proof_el_block_number + 1`.
 
 ## RPC API

--- a/finalizer/src/actor.rs
+++ b/finalizer/src/actor.rs
@@ -843,7 +843,7 @@ impl<
             // the finalization.
             let finalization = finalization
                 .expect("finalization is always included for the last block of an epoch");
-            debug_assert!(block.header.digest == finalization.proposal.payload);
+            debug_assert!(block.header.get_digest() == finalization.proposal.payload);
             // Get participant count from the certificate signers
             let participant_count = finalization.certificate.signers.len();
 
@@ -869,8 +869,8 @@ impl<
                 self.context.register(
                     format!(
                         "<header>{}</header><prev_header>{}</prev_header>_finalized_header_stored",
-                        hex::encode(finalized_header.header.digest),
-                        hex::encode(finalized_header.header.prev_epoch_header_hash)
+                        hex::encode(finalized_header.header.get_digest()),
+                        hex::encode(finalized_header.header.prev_epoch_header_hash())
                     ),
                     "chain height",
                     gauge,
@@ -1488,7 +1488,7 @@ impl<
             // the block that contains the last checkpoint
             let prev_header_hash =
                 if let Some(finalized_header) = self.db.get_most_recent_finalized_header().await {
-                    finalized_header.header.digest
+                    finalized_header.header.get_digest()
                 } else {
                     self.genesis_hash.into()
                 };

--- a/finalizer/src/db.rs
+++ b/finalizer/src/db.rs
@@ -525,7 +525,7 @@ mod tests {
                 create_test_db_with_context::<_, MinPk>("test_finalized_header", context).await;
 
             // Create a test header
-            let header = summit_types::Header::compute_digest(
+            let header = summit_types::Header::new(
                 [1u8; 32].into(), // parent
                 100,              // height
                 1234567890,       // timestamp
@@ -542,9 +542,9 @@ mod tests {
 
             // Create finalization proof
             let proposal = Proposal {
-                round: Round::new(Epoch::new(header.epoch), View::new(header.view)),
-                parent: View::new(header.height),
-                payload: header.digest,
+                round: Round::new(Epoch::new(header.epoch()), View::new(header.view())),
+                parent: View::new(header.height()),
+                payload: header.get_digest(),
             };
             let finalized = Finalization {
                 proposal,
@@ -566,15 +566,15 @@ mod tests {
             let retrieved = db.get_finalized_header(100).await;
             assert!(retrieved.is_some());
             let retrieved = retrieved.unwrap();
-            assert_eq!(retrieved.header.height, header.height);
-            assert_eq!(retrieved.header.digest, header.digest);
-            assert_eq!(retrieved.header.timestamp, header.timestamp);
+            assert_eq!(retrieved.header.height(), header.height());
+            assert_eq!(retrieved.header.get_digest(), header.get_digest());
+            assert_eq!(retrieved.header.timestamp(), header.timestamp());
 
             // Test that non-existent header returns None
             assert!(db.get_finalized_header(200).await.is_none());
 
             // Store another header at different height
-            let header2 = summit_types::Header::compute_digest(
+            let header2 = summit_types::Header::new(
                 [5u8; 32].into(), // parent
                 200,              // height
                 1234567900,       // timestamp
@@ -589,9 +589,9 @@ mod tests {
                 [0u8; 32],        // parent_beacon_block_root
             );
             let proposal2 = Proposal {
-                round: Round::new(Epoch::new(header2.epoch), View::new(header2.view)),
-                parent: View::new(header2.height),
-                payload: header2.digest,
+                round: Round::new(Epoch::new(header2.epoch()), View::new(header2.view())),
+                parent: View::new(header2.height()),
+                payload: header2.get_digest(),
             };
             let finalized2 = Finalization {
                 proposal: proposal2,
@@ -608,16 +608,16 @@ mod tests {
             // Both headers should be accessible
             let h1 = db.get_finalized_header(100).await.unwrap();
             let h2 = db.get_finalized_header(200).await.unwrap();
-            assert_eq!(h1.header.height, 100);
-            assert_eq!(h2.header.height, 200);
-            assert_ne!(h1.header.digest, h2.header.digest);
+            assert_eq!(h1.header.height(), 100);
+            assert_eq!(h2.header.height(), 200);
+            assert_ne!(h1.header.get_digest(), h2.header.get_digest());
 
             // Test get_most_recent_finalized_header returns the latest header
             let most_recent = db.get_most_recent_finalized_header().await;
             assert!(most_recent.is_some());
             let most_recent = most_recent.unwrap();
-            assert_eq!(most_recent.header.height, 200);
-            assert_eq!(most_recent.header.digest, header2.digest);
+            assert_eq!(most_recent.header.height(), 200);
+            assert_eq!(most_recent.header.get_digest(), header2.get_digest());
         });
     }
 
@@ -636,7 +636,7 @@ mod tests {
             assert!(db.get_most_recent_finalized_header().await.is_none());
 
             // Store headers out of order
-            let header1 = summit_types::Header::compute_digest(
+            let header1 = summit_types::Header::new(
                 [1u8; 32].into(), // parent
                 100,              // height
                 1234567890,       // timestamp
@@ -651,9 +651,9 @@ mod tests {
                 [0u8; 32],        // parent_beacon_block_root
             );
             let proposal1 = Proposal {
-                round: Round::new(Epoch::new(header1.epoch), View::new(header1.view)),
-                parent: View::new(header1.height),
-                payload: header1.digest,
+                round: Round::new(Epoch::new(header1.epoch()), View::new(header1.view())),
+                parent: View::new(header1.height()),
+                payload: header1.get_digest(),
             };
 
             let finalized1 = Finalization {
@@ -666,7 +666,7 @@ mod tests {
             let finalized_header1 =
                 summit_types::FinalizedHeader::new(header1.clone(), finalized1, 3);
 
-            let header3 = summit_types::Header::compute_digest(
+            let header3 = summit_types::Header::new(
                 [7u8; 32].into(),  // parent
                 300,               // height
                 1234567920,        // timestamp
@@ -681,9 +681,9 @@ mod tests {
                 [0u8; 32],         // parent_beacon_block_root
             );
             let proposal3 = Proposal {
-                round: Round::new(Epoch::new(header3.epoch), View::new(header3.view)),
-                parent: View::new(header3.height),
-                payload: header3.digest,
+                round: Round::new(Epoch::new(header3.epoch()), View::new(header3.view())),
+                parent: View::new(header3.height()),
+                payload: header3.get_digest(),
             };
 
             let finalized3 = Finalization {
@@ -696,7 +696,7 @@ mod tests {
             let finalized_header3 =
                 summit_types::FinalizedHeader::new(header3.clone(), finalized3, 3);
 
-            let header2 = summit_types::Header::compute_digest(
+            let header2 = summit_types::Header::new(
                 [5u8; 32].into(), // parent
                 200,              // height
                 1234567900,       // timestamp
@@ -711,9 +711,9 @@ mod tests {
                 [0u8; 32],        // parent_beacon_block_root
             );
             let proposal2 = Proposal {
-                round: Round::new(Epoch::new(header2.epoch), View::new(header2.view)),
-                parent: View::new(header2.height),
-                payload: header2.digest,
+                round: Round::new(Epoch::new(header2.epoch()), View::new(header2.view())),
+                parent: View::new(header2.height()),
+                payload: header2.get_digest(),
             };
 
             let finalized2 = Finalization {
@@ -732,8 +732,8 @@ mod tests {
 
             // Most recent should be height 100
             let most_recent = db.get_most_recent_finalized_header().await.unwrap();
-            assert_eq!(most_recent.header.height, 100);
-            assert_eq!(most_recent.header.digest, header1.digest);
+            assert_eq!(most_recent.header.height(), 100);
+            assert_eq!(most_recent.header.get_digest(), header1.get_digest());
 
             // Store height 300
             db.store_finalized_header(300, &finalized_header3).await;
@@ -741,8 +741,8 @@ mod tests {
 
             // Most recent should now be height 300
             let most_recent = db.get_most_recent_finalized_header().await.unwrap();
-            assert_eq!(most_recent.header.height, 300);
-            assert_eq!(most_recent.header.digest, header3.digest);
+            assert_eq!(most_recent.header.height(), 300);
+            assert_eq!(most_recent.header.get_digest(), header3.get_digest());
 
             // Store height 200 (lower than current max)
             db.store_finalized_header(200, &finalized_header2).await;
@@ -750,16 +750,16 @@ mod tests {
 
             // Most recent should still be height 300
             let most_recent = db.get_most_recent_finalized_header().await.unwrap();
-            assert_eq!(most_recent.header.height, 300);
-            assert_eq!(most_recent.header.digest, header3.digest);
+            assert_eq!(most_recent.header.height(), 300);
+            assert_eq!(most_recent.header.get_digest(), header3.get_digest());
 
             // Verify all headers are still individually accessible
             let h1 = db.get_finalized_header(100).await.unwrap();
             let h2 = db.get_finalized_header(200).await.unwrap();
             let h3 = db.get_finalized_header(300).await.unwrap();
-            assert_eq!(h1.header.height, 100);
-            assert_eq!(h2.header.height, 200);
-            assert_eq!(h3.header.height, 300);
+            assert_eq!(h1.header.height(), 100);
+            assert_eq!(h2.header.height(), 200);
+            assert_eq!(h3.header.height(), 300);
         });
     }
 

--- a/node/src/bin/observer.rs
+++ b/node/src/bin/observer.rs
@@ -447,7 +447,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
             println!(
                 "    latest finalized block (epoch {}, view {}) has {} signers, none of which is the observer",
-                finalized_header.header.epoch, finalized_header.header.view, signer_count
+                finalized_header.header.epoch(), finalized_header.header.view(), signer_count
             );
 
             println!("Test completed successfully!");

--- a/node/src/tests/checkpointing/creation.rs
+++ b/node/src/tests/checkpointing/creation.rs
@@ -201,7 +201,7 @@ fn test_checkpoint_created() {
             .await
             .expect("failed to get finalized header");
         assert_eq!(
-            finalized_header.header.checkpoint_hash.as_ref(),
+            finalized_header.header.checkpoint_hash().as_ref(),
             checkpoint.digest.as_ref(),
             "checkpoint_hash in header should match checkpoint digest"
         );

--- a/node/src/tests/checkpointing/verification.rs
+++ b/node/src/tests/checkpointing/verification.rs
@@ -492,11 +492,11 @@ fn test_checkpoint_verification_dynamic_committee() {
         // Verify epoch 1's header has both added and removed validators
         let epoch_1_header = &finalized_headers[1];
         assert!(
-            !epoch_1_header.header.added_validators.is_empty(),
+            !epoch_1_header.header.added_validators().is_empty(),
             "epoch 1 header should have added_validators"
         );
         assert!(
-            !epoch_1_header.header.removed_validators.is_empty(),
+            !epoch_1_header.header.removed_validators().is_empty(),
             "epoch 1 header should have removed_validators"
         );
 

--- a/node/src/tests/checkpointing/verification.rs
+++ b/node/src/tests/checkpointing/verification.rs
@@ -18,12 +18,37 @@ use rand::SeedableRng;
 use rand::rngs::StdRng;
 use std::collections::{HashMap, HashSet};
 use std::time::Duration;
+use summit_types::Header;
 use summit_types::PrivateKey;
 use summit_types::checkpoint::{self, CheckpointVerificationError};
 use summit_types::consensus_state::ConsensusState;
 use summit_types::execution_request::ExecutionRequest;
 use summit_types::genesis::{Genesis, GenesisValidator};
 use summit_types::keystore::KeyStore;
+
+/// Returns a clone of `header` with the first byte of `prev_epoch_header_hash`
+/// flipped. The header fields are private, so the value is rebuilt via the
+/// public constructor. The epoch-header chain-link check runs before signature
+/// verification in `verify_checkpoint_chain`, so this isolates
+/// `PrevEpochHeaderHashMismatch` from any signature failure.
+fn tamper_prev_epoch_header_hash(header: &Header) -> Header {
+    let mut prev = header.prev_epoch_header_hash();
+    prev.0[0] ^= 0xFF;
+    Header::new(
+        header.parent(),
+        header.height(),
+        header.timestamp(),
+        header.epoch(),
+        header.view(),
+        header.payload_hash(),
+        header.execution_request_hash(),
+        header.checkpoint_hash(),
+        prev,
+        header.added_validators().to_vec(),
+        header.removed_validators(),
+        header.parent_beacon_block_root(),
+    )
+}
 
 #[test_traced("INFO")]
 fn test_checkpoint_verification_fixed_committee() {
@@ -245,7 +270,8 @@ fn test_checkpoint_verification_fixed_committee() {
         // signature (which is over `header.digest`), so this exercises the
         // chain check independently.
         let mut chain_tampered_headers = finalized_headers.clone();
-        chain_tampered_headers[1].header.prev_epoch_header_hash.0[0] ^= 0xFF;
+        chain_tampered_headers[1].header =
+            tamper_prev_epoch_header_hash(&chain_tampered_headers[1].header);
         let err =
             checkpoint::verify_checkpoint_chain(&genesis, &chain_tampered_headers, &raw_checkpoint)
                 .expect_err("verification should fail with broken chain link");
@@ -259,7 +285,8 @@ fn test_checkpoint_verification_fixed_committee() {
 
         // Same check for the genesis anchor (epoch 0).
         let mut genesis_anchor_tampered = finalized_headers.clone();
-        genesis_anchor_tampered[0].header.prev_epoch_header_hash.0[0] ^= 0xFF;
+        genesis_anchor_tampered[0].header =
+            tamper_prev_epoch_header_hash(&genesis_anchor_tampered[0].header);
         let err = checkpoint::verify_checkpoint_chain(
             &genesis,
             &genesis_anchor_tampered,

--- a/node/src/tests/execution_requests/protocol_params.rs
+++ b/node/src/tests/execution_requests/protocol_params.rs
@@ -1500,7 +1500,7 @@ fn test_removed_validators_at_epoch_boundary_stake_bound() {
             .await
             .expect("failed to get finalized header for last block of epoch 0");
 
-        let removed_validators = &finalized_header.header.removed_validators;
+        let removed_validators = finalized_header.header.removed_validators();
         assert!(
             removed_validators.contains(&kicked_pubkey),
             "force-removed validator (stake-bound) should be in removed_validators of \
@@ -1740,7 +1740,7 @@ fn test_joining_validator_activation_cancelled_on_stake_bound_force_removal() {
             .await
             .expect("failed to get finalized header for last block of epoch 1");
 
-        let added = &finalized_header.header.added_validators;
+        let added = finalized_header.header.added_validators();
         assert!(
             !added.iter().any(|av| av.node_key == new_validator_pubkey),
             "force-removed Joining validator should NOT appear in added_validators of \

--- a/node/src/tests/execution_requests/validator_set.rs
+++ b/node/src/tests/execution_requests/validator_set.rs
@@ -182,7 +182,7 @@ fn test_added_validators_at_epoch_boundary() {
         // Verify the header contains the new validator in added_validators
         // The new validator's joining_epoch = 2, and at block 19 (last block of epoch 1),
         // the header should include validators joining in epoch 2 (next_epoch).
-        let added_validators = &finalized_header.header.added_validators;
+        let added_validators = finalized_header.header.added_validators();
 
         // Assert that added_validators contains the new validator
         assert!(
@@ -405,7 +405,7 @@ fn test_removed_validators_at_epoch_boundary() {
             .expect("Failed to get finalized header for last block of epoch 0");
 
         // Verify the header contains the withdrawing validator in removed_validators
-        let removed_validators = &finalized_header.header.removed_validators;
+        let removed_validators = finalized_header.header.removed_validators();
 
         // Assert that removed_validators contains the withdrawing validator
         assert!(

--- a/node/src/tests/execution_requests/withdrawals.rs
+++ b/node/src/tests/execution_requests/withdrawals.rs
@@ -2276,7 +2276,7 @@ fn test_joining_validator_withdrawal_on_last_block_keeps_header_consistent() {
             .get_finalized_header(1)
             .await
             .expect("missing finalized header for epoch 1");
-        let added_epoch_1 = &header_epoch_1.header.added_validators;
+        let added_epoch_1 = header_epoch_1.header.added_validators();
         assert!(
             added_epoch_1
                 .iter()
@@ -2293,7 +2293,7 @@ fn test_joining_validator_withdrawal_on_last_block_keeps_header_consistent() {
             .get_finalized_header(2)
             .await
             .expect("missing finalized header for epoch 2");
-        let removed_epoch_2 = &header_epoch_2.header.removed_validators;
+        let removed_epoch_2 = header_epoch_2.header.removed_validators();
         assert!(
             removed_epoch_2.contains(&new_validator_pubkey),
             "epoch 2 header must include the joining validator in removed_validators \

--- a/syncer/src/actor.rs
+++ b/syncer/src/actor.rs
@@ -1409,6 +1409,42 @@ where
             return false;
         }
 
+        // Final guard binding the block header to its certificate round.
+        //
+        // The per-ingress checks (direct Finalized/Notarized delivery) reject
+        // mismatches early, but a `(block, finalization)` pair becomes trusted
+        // storage here regardless of which path produced it — including paths
+        // that bypass those checks: a finalization cached first then the block
+        // fetched later by digest (`Request::Block`), a consensus finalization
+        // matched against a locally-found block, a notarized block paired with
+        // a cached finalization, checkpoint restart, and gap repair. Enforcing
+        // the binding at this join point ensures every order gets the same
+        // protection. Normal blocks bind epoch and view exactly; a same-digest
+        // reproposal of the epoch-terminal block may carry an older header view
+        // than the certificate (see `header_view_binds_to_round`).
+        if let Some(finalization) = &finalization {
+            let certified_round = finalization.round();
+            if finalization.proposal.payload != commitment
+                || block.epoch() != certified_round.epoch()
+                || !header_view_binds_to_round(
+                    &self.epocher,
+                    block.height().get(),
+                    block.view().get(),
+                    certified_round.view().get(),
+                )
+            {
+                warn!(
+                    ?certified_round,
+                    block_height = %block.height(),
+                    block_epoch = %block.epoch(),
+                    block_view = %block.view(),
+                    ?commitment,
+                    "rejecting finalization store with header/certificate round mismatch"
+                );
+                return false;
+            }
+        }
+
         self.notify_subscribers(commitment, &block).await;
 
         #[cfg(feature = "prom")]

--- a/syncer/src/actor.rs
+++ b/syncer/src/actor.rs
@@ -15,7 +15,7 @@ use commonware_consensus::simplex::types::{
     Finalization, Notarization, Subject, verify_certificates,
 };
 use commonware_consensus::types::{Epoch, Epocher, Height, Round, View, ViewDelta};
-use commonware_consensus::{Block, Epochable, Reporter};
+use commonware_consensus::{Block, Epochable, Reporter, Viewable};
 use commonware_cryptography::PublicKey;
 use commonware_cryptography::certificate::Scheme as CertificateScheme;
 use commonware_macros::select_loop;
@@ -197,7 +197,7 @@ struct BlockSubscription<B: Block> {
 pub struct Actor<E, B, P, FC, FB, ES, T, A = Exact>
 where
     E: BufferPooler + CryptoRngCore + Spawner + Metrics + Clock + GClock + Storage,
-    B: Block<Digest = Digest>,
+    B: Block<Digest = Digest> + Epochable + Viewable,
     P: Provider<Scope = Epoch, Scheme: Scheme<B::Digest>>,
     FC: Certificates<BlockDigest = B::Digest, Commitment = B::Digest, Scheme = P::Scheme>,
     FB: Blocks<Block = B>,
@@ -260,7 +260,7 @@ where
 impl<E, B, P, FC, FB, ES, T, A> Actor<E, B, P, FC, FB, ES, T, A>
 where
     E: BufferPooler + CryptoRngCore + Spawner + Metrics + Clock + GClock + Storage,
-    B: Block<Digest = Digest>,
+    B: Block<Digest = Digest> + Epochable + Viewable,
     P: Provider<Scope = Epoch, Scheme: Scheme<B::Digest>>,
     FC: Certificates<BlockDigest = B::Digest, Commitment = B::Digest, Scheme = P::Scheme>,
     FB: Blocks<Block = B>,
@@ -948,10 +948,22 @@ where
                     return false;
                 };
 
+                let certified_round = finalization.round();
                 if block.height() != height
                     || finalization.proposal.payload != block.digest()
                     || finalization.epoch() != epoch
+                    || block.epoch() != certified_round.epoch()
+                    || block.view() != certified_round.view()
                 {
+                    warn!(
+                        ?certified_round,
+                        block_height = %block.height(),
+                        block_epoch = %block.epoch(),
+                        block_view = %block.view(),
+                        expected_height = %height,
+                        expected_epoch = %epoch,
+                        "rejecting finalized delivery with header/certificate round mismatch"
+                    );
                     response.send_lossy(false);
                     return false;
                 }
@@ -986,8 +998,18 @@ where
                     return false;
                 };
 
-                if notarization.round() != round || notarization.proposal.payload != block.digest()
+                let certified_round = notarization.round();
+                if certified_round != round
+                    || notarization.proposal.payload != block.digest()
+                    || block.epoch() != certified_round.epoch()
+                    || block.view() != certified_round.view()
                 {
+                    warn!(
+                        ?certified_round,
+                        block_epoch = %block.epoch(),
+                        block_view = %block.view(),
+                        "rejecting notarized delivery with header/certificate round mismatch"
+                    );
                     response.send_lossy(false);
                     return false;
                 }

--- a/syncer/src/actor.rs
+++ b/syncer/src/actor.rs
@@ -182,6 +182,29 @@ struct BlockSubscription<B: Block> {
     _aborter: Aborter,
 }
 
+/// Whether a block's header view may legitimately differ from the view of the
+/// certificate that certified it.
+///
+/// Header view must equal the certified view for every block, with one exception:
+/// a same-digest reproposal of the final block of an epoch. Summit re-proposes the
+/// epoch-terminal block in a later view until it finalizes, so the reused block
+/// bytes carry the original (earlier) view while the network re-certifies the same
+/// digest in the later view. The digest commits to the header view, so the
+/// certificate is for that exact block; honest validators only produced it because
+/// the live verification path (`handle_verify`) accepts such reproposals without a
+/// view check. Sync/import must mirror that, or catch-up rejects valid boundary
+/// reproposal certificates. The epoch is bound separately by the caller; this only
+/// relaxes the view comparison.
+fn header_view_binds_to_round<ES: Epocher>(
+    epocher: &ES,
+    height: u64,
+    header_view: u64,
+    certified_view: u64,
+) -> bool {
+    header_view == certified_view
+        || (is_last_block_of_epoch(epocher, height) && header_view < certified_view)
+}
+
 /// The [Actor] is responsible for receiving uncertified blocks from the broadcast mechanism,
 /// receiving notarizations and finalizations from consensus, and reconstructing a total order
 /// of blocks.
@@ -953,7 +976,12 @@ where
                     || finalization.proposal.payload != block.digest()
                     || finalization.epoch() != epoch
                     || block.epoch() != certified_round.epoch()
-                    || block.view() != certified_round.view()
+                    || !header_view_binds_to_round(
+                        &self.epocher,
+                        block.height().get(),
+                        block.view().get(),
+                        certified_round.view().get(),
+                    )
                 {
                     warn!(
                         ?certified_round,
@@ -1002,7 +1030,12 @@ where
                 if certified_round != round
                     || notarization.proposal.payload != block.digest()
                     || block.epoch() != certified_round.epoch()
-                    || block.view() != certified_round.view()
+                    || !header_view_binds_to_round(
+                        &self.epocher,
+                        block.height().get(),
+                        block.view().get(),
+                        certified_round.view().get(),
+                    )
                 {
                     warn!(
                         ?certified_round,
@@ -1611,5 +1644,47 @@ where
             }
         )?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::header_view_binds_to_round;
+    use commonware_consensus::types::FixedEpocher;
+    use std::num::NonZeroU64;
+
+    // Epoch length 10: epoch E spans heights [E*10, E*10 + 9], so the last block
+    // of an epoch is E*10 + 9 (e.g. height 9 for epoch 0, height 19 for epoch 1).
+    fn epocher() -> FixedEpocher {
+        FixedEpocher::new(NonZeroU64::new(10).unwrap())
+    }
+
+    /// Regression for the sync/import side of "bind blocks to round": header view
+    /// must equal the certified view, EXCEPT for a same-digest reproposal of the
+    /// epoch-terminal block, where the reused bytes carry the original (earlier)
+    /// view. Without the exception, catch-up rejects valid boundary reproposal
+    /// certificates; without the strict check, a non-terminal block could carry a
+    /// header view that disagrees with the round it was certified in.
+    #[test]
+    fn header_view_binding_relaxes_only_for_epoch_terminal_reproposals() {
+        let e = epocher();
+        const NON_TERMINAL: u64 = 5; // mid-epoch 0
+        const TERMINAL: u64 = 9; // last block of epoch 0
+
+        // Matching views always bind, terminal or not.
+        assert!(header_view_binds_to_round(&e, NON_TERMINAL, 5, 5));
+        assert!(header_view_binds_to_round(&e, TERMINAL, 9, 9));
+
+        // Non-terminal block whose header view disagrees with the certified view
+        // is rejected — this is the core invariant the issue is about.
+        assert!(!header_view_binds_to_round(&e, NON_TERMINAL, 5, 7));
+
+        // Epoch-terminal block re-certified in a LATER view is accepted: this is
+        // the same-digest boundary reproposal that live verification accepts.
+        assert!(header_view_binds_to_round(&e, TERMINAL, 9, 12));
+
+        // But a terminal block whose header view is AHEAD of the certified view is
+        // still rejected (a header view can never lead its certificate).
+        assert!(!header_view_binds_to_round(&e, TERMINAL, 12, 9));
     }
 }

--- a/syncer/src/lib.rs
+++ b/syncer/src/lib.rs
@@ -1211,22 +1211,27 @@ mod tests {
                 actors.push(actor);
             }
 
-            // Create block at height 1
+            // Create the epoch-terminal block. With BLOCKS_PER_EPOCH = 20, height
+            // 19 is the last block of epoch 0; the mock derives the header view
+            // from the height, so the block's header view is 19. The header/round
+            // binding only permits a finalization view to differ from the header
+            // view for the epoch-terminal block (a same-digest reproposal), which
+            // is exactly the cross-view scenario this test exercises.
             let parent = Sha256::hash(b"");
-            let block = B::new::<Sha256>(parent, Height::new(1), 1);
+            let block = B::new::<Sha256>(parent, Height::new(19), 19);
             let commitment = block.digest();
 
-            // Both validators verify the block
+            // Both validators verify the block at its original view (19).
             actors[0]
-                .verified(Round::new(Epoch::new(0), View::new(1)), block.clone())
+                .verified(Round::new(Epoch::new(0), View::new(19)), block.clone())
                 .await;
             actors[1]
-                .verified(Round::new(Epoch::new(0), View::new(1)), block.clone())
+                .verified(Round::new(Epoch::new(0), View::new(19)), block.clone())
                 .await;
 
-            // Validator 0: Finalize with view 1
+            // Validator 0: finalize at the block's own view (19) — exact match.
             let proposal_v1 = Proposal {
-                round: Round::new(Epoch::new(0), View::new(1)),
+                round: Round::new(Epoch::new(0), View::new(19)),
                 parent: View::new(0),
                 payload: commitment,
             };
@@ -1239,11 +1244,12 @@ mod tests {
                 .report(Activity::Finalization(finalization_v1.clone()))
                 .await;
 
-            // Validator 1: Finalize with view 2 (simulates receiving finalization from different view)
-            // This could happen during epoch transitions where the same block gets finalized
-            // with different views by different validators.
+            // Validator 1: finalize the same terminal block via a same-digest
+            // reproposal certified in a later view (21). Header view 19 < 21 and
+            // the block is epoch-terminal, so the binding accepts it. (A
+            // non-terminal block finalized at a mismatched view would be rejected.)
             let proposal_v2 = Proposal {
-                round: Round::new(Epoch::new(0), View::new(2)), // Different view
+                round: Round::new(Epoch::new(0), View::new(21)), // Later view (reproposal)
                 parent: View::new(0),
                 payload: commitment, // Same block
             };
@@ -1260,29 +1266,33 @@ mod tests {
             context.sleep(Duration::from_millis(100)).await;
 
             // Verify both validators stored the block correctly
-            let block0 = actors[0].get_block(1).await.unwrap();
-            let block1 = actors[1].get_block(1).await.unwrap();
+            let block0 = actors[0].get_block(19).await.unwrap();
+            let block1 = actors[1].get_block(19).await.unwrap();
             assert_eq!(block0, block);
             assert_eq!(block1, block);
 
             // Verify both validators have finalizations stored
-            let fin0 = actors[0].get_finalization(Height::new(1)).await.unwrap();
-            let fin1 = actors[1].get_finalization(Height::new(1)).await.unwrap();
+            let fin0 = actors[0].get_finalization(Height::new(19)).await.unwrap();
+            let fin1 = actors[1].get_finalization(Height::new(19)).await.unwrap();
 
             // Verify the finalizations have the expected different views
             assert_eq!(fin0.proposal.payload, block.digest());
-            assert_eq!(fin0.round().view(), View::new(1));
+            assert_eq!(fin0.round().view(), View::new(19));
             assert_eq!(fin1.proposal.payload, block.digest());
-            assert_eq!(fin1.round().view(), View::new(2));
+            assert_eq!(fin1.round().view(), View::new(21));
 
             // Both validators can retrieve block by height
             assert_eq!(
-                actors[0].get_info(Identifier::Height(Height::new(1))).await,
-                Some((Height::new(1), commitment))
+                actors[0]
+                    .get_info(Identifier::Height(Height::new(19)))
+                    .await,
+                Some((Height::new(19), commitment))
             );
             assert_eq!(
-                actors[1].get_info(Identifier::Height(Height::new(1))).await,
-                Some((Height::new(1), commitment))
+                actors[1]
+                    .get_info(Identifier::Height(Height::new(19)))
+                    .await,
+                Some((Height::new(19), commitment))
             );
 
             // Test that a validator receiving BOTH finalizations handles it correctly
@@ -1295,13 +1305,13 @@ mod tests {
                 .await;
             context.sleep(Duration::from_millis(100)).await;
 
-            // Validator 0 should still have the original finalization (v1)
-            let fin0_after = actors[0].get_finalization(Height::new(1)).await.unwrap();
-            assert_eq!(fin0_after.round().view(), View::new(1));
+            // Validator 0 should still have the original finalization (view 19)
+            let fin0_after = actors[0].get_finalization(Height::new(19)).await.unwrap();
+            assert_eq!(fin0_after.round().view(), View::new(19));
 
-            // Validator 1 should still have the original finalization (v2)
-            let fin1_after = actors[1].get_finalization(Height::new(1)).await.unwrap();
-            assert_eq!(fin1_after.round().view(), View::new(2));
+            // Validator 1 should still have the original finalization (view 21)
+            let fin1_after = actors[1].get_finalization(Height::new(19)).await.unwrap();
+            assert_eq!(fin1_after.round().view(), View::new(21));
         })
     }
 

--- a/syncer/src/mocks/block.rs
+++ b/syncer/src/mocks/block.rs
@@ -1,7 +1,9 @@
 use bytes::{Buf, BufMut};
 use commonware_codec::{EncodeSize, Error, Read, ReadExt, Write, varint::UInt};
-use commonware_consensus::types::Height;
+use commonware_consensus::types::{Epoch, Height, View};
 use commonware_cryptography::{Digest, Digestible, Hasher};
+
+const MOCK_BLOCKS_PER_EPOCH: u64 = 20;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Block<D: Digest> {
@@ -13,6 +15,12 @@ pub struct Block<D: Digest> {
 
     /// The timestamp of the block (in milliseconds since the Unix epoch).
     pub timestamp: u64,
+
+    /// The epoch associated with this block in syncer tests.
+    pub epoch: Epoch,
+
+    /// The view associated with this block in syncer tests.
+    pub view: View,
 
     /// Pre-computed digest of the block.
     digest: D,
@@ -29,10 +37,14 @@ impl<D: Digest> Block<D> {
 
     pub fn new<H: Hasher<Digest = D>>(parent: D, height: Height, timestamp: u64) -> Self {
         let digest = Self::compute_digest::<H>(&parent, height, timestamp);
+        let epoch = Epoch::new(height.get() / MOCK_BLOCKS_PER_EPOCH);
+        let view = View::new(height.get());
         Self {
             parent,
             height,
             timestamp,
+            epoch,
+            view,
             digest,
         }
     }
@@ -54,6 +66,8 @@ impl<D: Digest> Read for Block<D> {
         let parent = D::read(reader)?;
         let height = Height::read(reader)?;
         let timestamp = UInt::read(reader)?.into();
+        let epoch = Epoch::new(height.get() / MOCK_BLOCKS_PER_EPOCH);
+        let view = View::new(height.get());
         let digest = D::read(reader)?;
 
         // Pre-compute the digest
@@ -61,6 +75,8 @@ impl<D: Digest> Read for Block<D> {
             parent,
             height,
             timestamp,
+            epoch,
+            view,
             digest,
         })
     }
@@ -89,8 +105,20 @@ impl<D: Digest> commonware_consensus::Heightable for Block<D> {
     }
 }
 
+impl<D: Digest> commonware_consensus::Epochable for Block<D> {
+    fn epoch(&self) -> Epoch {
+        self.epoch
+    }
+}
+
 impl<D: Digest> commonware_consensus::Block for Block<D> {
     fn parent(&self) -> Self::Digest {
         self.parent
+    }
+}
+
+impl<D: Digest> commonware_consensus::Viewable for Block<D> {
+    fn view(&self) -> View {
+        self.view
     }
 }

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -31,6 +31,7 @@ url = { workspace = true, optional = true }
 anyhow.workspace = true
 dirs.workspace = true
 ethereum_ssz.workspace = true
+ethereum_ssz_derive.workspace = true
 serde.workspace = true
 toml.workspace = true
 tokio.workspace = true

--- a/types/src/block.rs
+++ b/types/src/block.rs
@@ -10,8 +10,9 @@ use commonware_consensus::types::{Height, View};
 use commonware_consensus::{Block as ConsensusBlock, Heightable};
 use commonware_cryptography::{Digestible, Hasher, Sha256, sha256::Digest};
 use ssz::Encode as _;
+use ssz_derive::{Decode, Encode};
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
 pub struct Block {
     pub header: Header,
     pub payload: ExecutionPayloadV3,
@@ -21,8 +22,8 @@ pub struct Block {
 impl Block {
     pub fn eth_block_hash(&self) -> [u8; 32] {
         // if genesis return your own digest
-        if self.header.height == 0 {
-            self.header.digest.as_ref().try_into().unwrap()
+        if self.header.height() == 0 {
+            self.header.get_digest().as_ref().try_into().unwrap()
         } else {
             self.payload.payload_inner.payload_inner.block_hash.into()
         }
@@ -67,7 +68,7 @@ impl Block {
             [0; 32].into()
         };
 
-        let header = Header::compute_digest(
+        let header = Header::new(
             parent,
             height,
             timestamp,
@@ -108,10 +109,10 @@ impl Block {
             [0; 32].into()
         };
 
-        if payload_hash != header.payload_hash {
+        if payload_hash != header.payload_hash() {
             return Err(anyhow!("Payload hash mismatch"));
         }
-        if execution_request_hash != header.execution_request_hash {
+        if execution_request_hash != header.execution_request_hash() {
             return Err(anyhow!("Execution request hash mismatch"));
         }
         Ok(Self {
@@ -128,21 +129,21 @@ impl Block {
         hasher.update(&payload_ssz);
         let payload_hash = hasher.finalize();
 
-        let header = Header {
-            parent: genesis_hash.into(),
-            height: 0,
-            timestamp: 0,
-            epoch: 0,
-            view: 1,
+        let header = Header::new_with_digest(
+            genesis_hash.into(),
+            0,
+            0,
+            0,
+            1,
             payload_hash,
-            execution_request_hash: [0; 32].into(),
-            checkpoint_hash: [0; 32].into(),
-            prev_epoch_header_hash: [0; 32].into(),
-            added_validators: Vec::new(),
-            removed_validators: Vec::new(),
-            parent_beacon_block_root: [0; 32],
-            digest: genesis_hash.into(),
-        };
+            [0; 32].into(),
+            [0; 32].into(),
+            [0; 32].into(),
+            Vec::new(),
+            Vec::new(),
+            [0; 32],
+            genesis_hash.into(),
+        );
         Self {
             header,
             payload: ExecutionPayloadV3::from_block_slow(&AlloyBlock::<TxEnvelope>::default()),
@@ -151,91 +152,45 @@ impl Block {
     }
 
     pub fn parent(&self) -> Digest {
-        self.header.parent
+        self.header.parent()
     }
 
     pub fn height(&self) -> u64 {
-        self.header.height
+        self.header.height()
     }
 
     pub fn digest(&self) -> Digest {
-        self.header.digest
+        self.header.get_digest()
     }
 
     pub fn timestamp(&self) -> u64 {
-        self.header.timestamp
+        self.header.timestamp()
     }
 
     pub fn view(&self) -> u64 {
-        self.header.view
+        self.header.view()
     }
 
     pub fn epoch(&self) -> u64 {
-        self.header.epoch
+        self.header.epoch()
     }
 }
 
 impl Heightable for Block {
     fn height(&self) -> Height {
-        Height::new(self.header.height)
+        Height::new(self.header.height())
     }
 }
 
 impl ConsensusBlock for Block {
     fn parent(&self) -> Self::Digest {
-        self.header.parent
+        self.header.parent()
     }
 }
 
 impl Viewable for Block {
     fn view(&self) -> View {
-        View::new(self.header.view)
-    }
-}
-
-impl ssz::Encode for Block {
-    fn is_ssz_fixed_len() -> bool {
-        false
-    }
-
-    fn ssz_append(&self, buf: &mut Vec<u8>) {
-        let offset = ssz::BYTES_PER_LENGTH_OFFSET * 3; // 3 variable-length fields
-
-        let mut encoder = ssz::SszEncoder::container(buf, offset);
-
-        encoder.append(&self.header);
-        encoder.append(&self.payload);
-        encoder.append(&self.execution_requests);
-        encoder.finalize();
-    }
-
-    fn ssz_bytes_len(&self) -> usize {
-        self.header.ssz_bytes_len()
-            + self.payload.ssz_bytes_len()
-            + self.execution_requests.ssz_bytes_len()
-            + ssz::BYTES_PER_LENGTH_OFFSET * 3 // 3 variable-length fields need 3 offsets
-    }
-}
-
-impl ssz::Decode for Block {
-    fn is_ssz_fixed_len() -> bool {
-        false
-    }
-
-    fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, ssz::DecodeError> {
-        let mut builder = ssz::SszDecoderBuilder::new(bytes);
-        builder.register_type::<Header>()?;
-        builder.register_type::<ExecutionPayloadV3>()?;
-        builder.register_type::<Vec<AlloyBytes>>()?;
-
-        let mut decoder = builder.build()?;
-
-        let header: Header = decoder.decode_next()?;
-        let payload = decoder.decode_next()?;
-        let execution_requests = decoder.decode_next()?;
-
-        Self::new_with_verify(header, payload, execution_requests)
-            .map_err(|e| ssz::DecodeError::BytesInvalid(e.to_string()))
+        View::new(self.header.view())
     }
 }
 
@@ -276,7 +231,7 @@ impl Digestible for Block {
     type Digest = Digest;
 
     fn digest(&self) -> Digest {
-        self.header.digest
+        self.header.get_digest()
     }
 }
 

--- a/types/src/block.rs
+++ b/types/src/block.rs
@@ -6,8 +6,8 @@ use anyhow::{Result, anyhow};
 use bytes::{Buf, BufMut};
 use commonware_codec::{EncodeSize, Error, Read, Write};
 use commonware_consensus::Viewable;
-use commonware_consensus::types::{Height, View};
-use commonware_consensus::{Block as ConsensusBlock, Heightable};
+use commonware_consensus::types::{Epoch, Height, View};
+use commonware_consensus::{Block as ConsensusBlock, Epochable, Heightable};
 use commonware_cryptography::{Digestible, Hasher, Sha256, sha256::Digest};
 use ssz::Encode as _;
 use ssz_derive::{Decode, Encode};
@@ -179,6 +179,12 @@ impl Block {
 impl Heightable for Block {
     fn height(&self) -> Height {
         Height::new(self.header.height())
+    }
+}
+
+impl Epochable for Block {
+    fn epoch(&self) -> Epoch {
+        Epoch::new(self.header.epoch())
     }
 }
 

--- a/types/src/block.rs
+++ b/types/src/block.rs
@@ -10,9 +10,9 @@ use commonware_consensus::types::{Epoch, Height, View};
 use commonware_consensus::{Block as ConsensusBlock, Epochable, Heightable};
 use commonware_cryptography::{Digestible, Hasher, Sha256, sha256::Digest};
 use ssz::Encode as _;
-use ssz_derive::{Decode, Encode};
+use ssz_derive::Encode;
 
-#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+#[derive(Clone, Debug, PartialEq, Eq, Encode)]
 pub struct Block {
     pub header: Header,
     pub payload: ExecutionPayloadV3,
@@ -216,6 +216,35 @@ impl Write for Block {
     }
 }
 
+// NOTE: `Decode` is implemented manually (rather than via `ssz_derive`) so that
+// decoding re-derives the body commitments and verifies them against the header
+// via `new_with_verify`. Without this, SSZ decode could produce a block whose
+// `payload`/`execution_requests` do not match the `payload_hash`/
+// `execution_request_hash` committed in the (signed) header. The block digest is
+// computed solely from the header, so a mismatched body would otherwise share the
+// same digest and pass certificate verification.
+impl ssz::Decode for Block {
+    fn is_ssz_fixed_len() -> bool {
+        false
+    }
+
+    fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, ssz::DecodeError> {
+        let mut builder = ssz::SszDecoderBuilder::new(bytes);
+        builder.register_type::<Header>()?;
+        builder.register_type::<ExecutionPayloadV3>()?;
+        builder.register_type::<Vec<AlloyBytes>>()?;
+
+        let mut decoder = builder.build()?;
+
+        let header: Header = decoder.decode_next()?;
+        let payload = decoder.decode_next()?;
+        let execution_requests = decoder.decode_next()?;
+
+        Self::new_with_verify(header, payload, execution_requests)
+            .map_err(|e| ssz::DecodeError::BytesInvalid(e.to_string()))
+    }
+}
+
 impl Read for Block {
     type Cfg = ();
 
@@ -411,6 +440,64 @@ mod test {
         let bytes = block.encode();
 
         Block::decode(bytes).unwrap();
+    }
+
+    #[test]
+    fn test_decode_rejects_body_header_commitment_mismatch() {
+        let payload = ExecutionPayloadV3::from_block_slow(&AlloyBlock::<TxEnvelope>::default());
+        let (added_validators, removed_validators) = create_test_validators();
+
+        // Same header inputs, but different execution_requests -> different
+        // execution_request_hash committed in the header.
+        let block_full = Block::compute_digest(
+            [1u8; 32].into(),
+            1,
+            1,
+            payload.clone(),
+            vec![AlloyBytes::from_static(&[1, 2, 3])],
+            0,
+            1,
+            None,
+            [0u8; 32].into(),
+            added_validators.clone(),
+            removed_validators.clone(),
+            [0u8; 32],
+        );
+        let block_empty = Block::compute_digest(
+            [1u8; 32].into(),
+            1,
+            1,
+            payload,
+            Vec::new(),
+            0,
+            1,
+            None,
+            [0u8; 32].into(),
+            added_validators,
+            removed_validators,
+            [0u8; 32],
+        );
+
+        // Sanity: each block decodes back to itself.
+        assert_eq!(
+            block_full,
+            Block::decode(block_full.encode()).expect("valid block decodes")
+        );
+
+        // Splice block_full's header (commits to a non-empty execution request)
+        // onto block_empty's body (no execution requests). The SSZ bytes are
+        // structurally valid but the header commitment no longer matches the body.
+        let mut spliced = Vec::new();
+        let mut encoder =
+            ssz::SszEncoder::container(&mut spliced, ssz::BYTES_PER_LENGTH_OFFSET * 3);
+        encoder.append(&block_full.header);
+        encoder.append(&block_empty.payload);
+        encoder.append(&block_empty.execution_requests);
+        encoder.finalize();
+
+        // Decode must reject the tampered block rather than silently accept a
+        // body that disagrees with the signed header commitments.
+        assert!(<Block as ssz::Decode>::from_ssz_bytes(&spliced).is_err());
     }
 
     #[test]

--- a/types/src/checkpoint.rs
+++ b/types/src/checkpoint.rs
@@ -254,9 +254,9 @@ pub fn verify_checkpoint_chain(
         let expected_prev = if i == 0 {
             genesis_hash
         } else {
-            finalized_headers[i - 1].header.digest
+            finalized_headers[i - 1].header.get_digest()
         };
-        if finalized_header.header.prev_epoch_header_hash != expected_prev {
+        if finalized_header.header.prev_epoch_header_hash() != expected_prev {
             return Err(CheckpointVerificationError::PrevEpochHeaderHashMismatch {
                 epoch: expected_epoch,
             });

--- a/types/src/checkpoint.rs
+++ b/types/src/checkpoint.rs
@@ -242,10 +242,10 @@ pub fn verify_checkpoint_chain(
         // Save the current participants — this is the signing set for this epoch
         signing_set = participants.clone();
         let expected_epoch = i as u64;
-        if finalized_header.header.epoch != expected_epoch {
+        if finalized_header.header.epoch() != expected_epoch {
             return Err(CheckpointVerificationError::NonContiguousEpochs {
                 expected: expected_epoch,
-                found: finalized_header.header.epoch,
+                found: finalized_header.header.epoch(),
             });
         }
 
@@ -283,15 +283,15 @@ pub fn verify_checkpoint_chain(
         }
 
         // Update validator set for the next epoch
-        for added in &finalized_header.header.added_validators {
+        for added in finalized_header.header.added_validators() {
             let minpk_public: &<MinPk as Variant>::Public = added.consensus_key.as_ref();
             let encoded = minpk_public.encode();
             let variant_pk = <MinPk as Variant>::Public::decode(&mut encoded.as_ref())
                 .expect("failed to decode BLS public key");
             participants.push((added.node_key.clone(), variant_pk));
         }
-        for removed in &finalized_header.header.removed_validators {
-            participants.retain(|(pk, _)| pk != removed);
+        for removed in finalized_header.header.removed_validators() {
+            participants.retain(|(pk, _)| *pk != removed);
         }
         participants.sort_by(|a, b| a.0.cmp(&b.0));
     }
@@ -301,7 +301,7 @@ pub fn verify_checkpoint_chain(
     let mut hasher = Sha256::new();
     hasher.update(&checkpoint.data);
     let computed_digest = hasher.finalize();
-    if last_header.header.checkpoint_hash != computed_digest {
+    if last_header.header.checkpoint_hash() != computed_digest {
         return Err(CheckpointVerificationError::CheckpointHashMismatch);
     }
 

--- a/types/src/engine_client.rs
+++ b/types/src/engine_client.rs
@@ -190,7 +190,7 @@ impl EngineClient for RethEngineClient {
             .new_payload_v4(
                 block.payload.clone(),
                 Vec::new(),
-                block.header.parent_beacon_block_root.into(),
+                block.header.parent_beacon_block_root().into(),
                 block.execution_requests.clone(),
             )
             .await
@@ -202,7 +202,7 @@ impl EngineClient for RethEngineClient {
                     .new_payload_v4(
                         block.payload.clone(),
                         Vec::new(),
-                        block.header.parent_beacon_block_root.into(),
+                        block.header.parent_beacon_block_root().into(),
                         block.execution_requests.clone(),
                     )
                     .await
@@ -339,7 +339,7 @@ impl EngineClient for BadBlockEngineClient {
         let parent_beacon_block_root = if block.view().is_multiple_of(self.bad_block_timing) {
             [1; 32].into()
         } else {
-            block.header.parent_beacon_block_root.into()
+            block.header.parent_beacon_block_root().into()
         };
 
         match self
@@ -359,7 +359,7 @@ impl EngineClient for BadBlockEngineClient {
                     .new_payload_v4(
                         block.payload.clone(),
                         Vec::new(),
-                        block.header.parent_beacon_block_root.into(),
+                        block.header.parent_beacon_block_root().into(),
                         block.execution_requests.clone(),
                     )
                     .await

--- a/types/src/header.rs
+++ b/types/src/header.rs
@@ -862,4 +862,104 @@ mod test {
         assert_eq!(actual_encoded.len(), pure_ssz.len() + 4);
         assert_eq!(actual_encoded.len(), encode_len);
     }
+
+    /// Builds a header identical in every fixed field, varying only the
+    /// validator-transition vectors, so any digest difference is attributable
+    /// solely to the added/removed partition.
+    fn header_with(added: Vec<AddedValidator>, removed: Vec<PublicKey>) -> Header {
+        Header::new(
+            [27u8; 32].into(),
+            27,
+            2727,
+            42,
+            1,
+            [1u8; 32].into(),
+            [2u8; 32].into(),
+            [3u8; 32].into(),
+            [4u8; 32].into(),
+            added,
+            removed,
+            [0u8; 32],
+        )
+    }
+
+    /// Regression test for the header-digest validator-partition ambiguity.
+    ///
+    /// The previous hand-rolled digest concatenated `added_validators` and
+    /// `removed_validators` as raw byte streams with no length, count, or boundary,
+    /// so the digest did not commit to where the added list ended and the removed
+    /// list began. The SSZ container the digest is now computed over places an
+    /// explicit offset for each variable-length field, so the boundary (and each
+    /// list's count) is bound by the digest: distinct partitions cannot alias.
+    #[test]
+    fn test_header_digest_commits_to_validator_partition() {
+        let a1 = AddedValidator {
+            node_key: create_test_public_key(0),
+            consensus_key: bls12381::PrivateKey::from_seed(1).public_key(),
+        };
+        // a2's node identity is the same key that appears as a *removed* key in h_a.
+        let a2 = AddedValidator {
+            node_key: create_test_public_key(1),
+            consensus_key: bls12381::PrivateKey::from_seed(2).public_key(),
+        };
+
+        // Same set of identities, partitioned differently across the boundary:
+        //   h_a: pk(1) is a removed validator.
+        //   h_b: pk(1) is instead the node identity of an added validator (a2).
+        let h_a = header_with(
+            vec![a1.clone()],
+            vec![create_test_public_key(1), create_test_public_key(2)],
+        );
+        let h_b = header_with(vec![a1.clone(), a2], vec![create_test_public_key(2)]);
+        assert_ne!(
+            h_a.get_digest(),
+            h_b.get_digest(),
+            "moving an identity across the added/removed boundary must change the digest"
+        );
+
+        // Changing only the count of one list must change the digest too.
+        let h_one_removed = header_with(vec![a1.clone()], vec![create_test_public_key(2)]);
+        let h_two_removed = header_with(
+            vec![a1],
+            vec![create_test_public_key(2), create_test_public_key(3)],
+        );
+        assert_ne!(
+            h_one_removed.get_digest(),
+            h_two_removed.get_digest(),
+            "the removed-validator count must be committed by the digest"
+        );
+    }
+
+    /// Regression test that the SSZ encoding the digest is computed over is
+    /// canonical: the boundary between the added and removed lists is committed by
+    /// offsets, so extra heap bytes cannot be silently absorbed into the removed
+    /// list to forge a second header that decodes to a different partition yet
+    /// shares the digest.
+    #[test]
+    fn test_header_decode_rejects_misaligned_validator_bytes() {
+        let a1 = AddedValidator {
+            node_key: create_test_public_key(0),
+            consensus_key: bls12381::PrivateKey::from_seed(1).public_key(),
+        };
+        let h = header_with(vec![a1], vec![create_test_public_key(1)]);
+
+        // The encoding round-trips deterministically.
+        let ssz = h.as_ssz_bytes();
+        let decoded = Header::from_ssz_bytes(&ssz).expect("valid header must decode");
+        assert_eq!(
+            decoded.as_ssz_bytes(),
+            ssz,
+            "encoding must be canonical (re-encode matches)"
+        );
+
+        // Appending a stray byte makes the trailing removed-validator region
+        // (one 32-byte key) no longer a clean multiple of the element size, so
+        // decode must reject it rather than absorb the byte into the list.
+        let mut padded = ssz.clone();
+        padded.push(0u8);
+        assert!(
+            Header::from_ssz_bytes(&padded).is_err(),
+            "trailing bytes must not be absorbed into the removed-validator list"
+        );
+    }
 }

--- a/types/src/header.rs
+++ b/types/src/header.rs
@@ -1,13 +1,14 @@
-use std::ops::Deref as _;
+use std::sync::OnceLock;
 
 use crate::PublicKey;
 use bytes::{Buf, BufMut};
-use commonware_codec::{EncodeSize, Error, Read, Write};
+use commonware_codec::{Encode, EncodeSize, Error, FixedSize, Read, Write};
 use commonware_consensus::simplex::types::Finalization;
 use commonware_cryptography::bls12381;
 use commonware_cryptography::certificate::Scheme;
 use commonware_cryptography::{Hasher, Sha256, sha256::Digest};
 use ssz::Encode as _;
+use ssz_derive::{Decode, Encode};
 
 /// Represents a validator being added to the committee.
 /// Contains both the node identity key (ed25519) and consensus signing key (BLS).
@@ -19,27 +20,79 @@ pub struct AddedValidator {
     pub consensus_key: bls12381::PublicKey,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
 pub struct Header {
-    pub parent: Digest,
-    pub height: u64,
-    pub timestamp: u64,
-    pub epoch: u64,
-    pub view: u64,
-    pub payload_hash: Digest,
-    pub execution_request_hash: Digest,
-    pub checkpoint_hash: Digest,
-    pub prev_epoch_header_hash: Digest,
-    pub added_validators: Vec<AddedValidator>,
-    pub removed_validators: Vec<PublicKey>,
-    pub parent_beacon_block_root: [u8; 32],
+    parent: SszDigest,
+    height: u64,
+    timestamp: u64,
+    epoch: u64,
+    view: u64,
+    payload_hash: SszDigest,
+    execution_request_hash: SszDigest,
+    checkpoint_hash: SszDigest,
+    prev_epoch_header_hash: SszDigest,
+    added_validators: Vec<AddedValidator>,
+    removed_validators: Vec<SszPublicKey>,
+    parent_beacon_block_root: [u8; 32],
     // precomputed digest of this header
-    pub digest: Digest,
+    #[ssz(skip_serializing, skip_deserializing)]
+    digest: OnceLock<Digest>,
 }
 
 impl Header {
+    pub fn parent(&self) -> Digest {
+        self.parent.inner
+    }
+
+    pub fn height(&self) -> u64 {
+        self.height
+    }
+
+    pub fn timestamp(&self) -> u64 {
+        self.timestamp
+    }
+
+    pub fn epoch(&self) -> u64 {
+        self.epoch
+    }
+
+    pub fn view(&self) -> u64 {
+        self.view
+    }
+
+    pub fn payload_hash(&self) -> Digest {
+        self.payload_hash.inner
+    }
+
+    pub fn execution_request_hash(&self) -> Digest {
+        self.execution_request_hash.inner
+    }
+
+    pub fn checkpoint_hash(&self) -> Digest {
+        self.checkpoint_hash.inner
+    }
+
+    pub fn prev_epoch_header_hash(&self) -> Digest {
+        self.prev_epoch_header_hash.inner
+    }
+
+    pub fn added_validators(&self) -> &[AddedValidator] {
+        &self.added_validators
+    }
+
+    pub fn removed_validators(&self) -> Vec<PublicKey> {
+        self.removed_validators
+            .iter()
+            .map(|w| w.inner.clone())
+            .collect()
+    }
+
+    pub fn parent_beacon_block_root(&self) -> [u8; 32] {
+        self.parent_beacon_block_root
+    }
+
     #[allow(clippy::too_many_arguments)]
-    pub fn compute_digest(
+    pub fn new(
         parent: Digest,
         height: u64,
         timestamp: u64,
@@ -53,229 +106,226 @@ impl Header {
         removed_validators: Vec<PublicKey>,
         parent_beacon_block_root: [u8; 32],
     ) -> Self {
-        let mut hasher = Sha256::new();
-        hasher.update(&parent);
-        hasher.update(&height.to_be_bytes());
-        hasher.update(&timestamp.to_be_bytes());
-        hasher.update(&payload_hash);
-        hasher.update(&execution_request_hash);
-        hasher.update(&checkpoint_hash);
-        hasher.update(&prev_epoch_header_hash);
-        // Hash the added validators (both node key and consensus key)
-        for av in &added_validators {
-            let node_key_bytes: [u8; 32] = av
-                .node_key
-                .as_ref()
-                .try_into()
-                .expect("PublicKey is 32 bytes");
-            hasher.update(&node_key_bytes);
-            hasher.update(av.consensus_key.as_ref());
-        }
-        // Hash removed validators
-        let removed_validators_bytes: Vec<[u8; 32]> = removed_validators
-            .iter()
-            .map(|pk| pk.as_ref().try_into().expect("PublicKey is 32 bytes"))
-            .collect();
-        hasher.update(&removed_validators_bytes.as_ssz_bytes());
-        hasher.update(&view.to_be_bytes());
-        hasher.update(&parent_beacon_block_root);
-        let digest = hasher.finalize();
-
         Self {
-            parent,
+            parent: parent.into(),
             height,
             timestamp,
             epoch,
             view,
-            payload_hash,
-            execution_request_hash,
-            checkpoint_hash,
-            prev_epoch_header_hash,
+            payload_hash: payload_hash.into(),
+            execution_request_hash: execution_request_hash.into(),
+            checkpoint_hash: checkpoint_hash.into(),
+            prev_epoch_header_hash: prev_epoch_header_hash.into(),
             added_validators,
-            removed_validators,
+            removed_validators: removed_validators.into_iter().map(|x| x.into()).collect(),
             parent_beacon_block_root,
-            digest,
+            digest: OnceLock::new(),
         }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_with_digest(
+        parent: Digest,
+        height: u64,
+        timestamp: u64,
+        epoch: u64,
+        view: u64,
+        payload_hash: Digest,
+        execution_request_hash: Digest,
+        checkpoint_hash: Digest,
+        prev_epoch_header_hash: Digest,
+        added_validators: Vec<AddedValidator>,
+        removed_validators: Vec<PublicKey>,
+        parent_beacon_block_root: [u8; 32],
+        digest: Digest,
+    ) -> Self {
+        Self {
+            parent: parent.into(),
+            height,
+            timestamp,
+            epoch,
+            view,
+            payload_hash: payload_hash.into(),
+            execution_request_hash: execution_request_hash.into(),
+            checkpoint_hash: checkpoint_hash.into(),
+            prev_epoch_header_hash: prev_epoch_header_hash.into(),
+            added_validators,
+            removed_validators: removed_validators.into_iter().map(|x| x.into()).collect(),
+            parent_beacon_block_root,
+            digest: OnceLock::from(digest),
+        }
+    }
+
+    pub fn get_digest(&self) -> Digest {
+        let bytes = self.encode();
+        let mut hasher = Sha256::new();
+        hasher.update(&bytes);
+        let digest = hasher.finalize();
+        *self.digest.get_or_init(|| digest)
     }
 }
 
 // Size of AddedValidator in SSZ: 32 bytes (node_key) + 48 bytes (BLS consensus_key) = 80 bytes
 const ADDED_VALIDATOR_SSZ_SIZE: usize = 32 + 48;
 
-impl ssz::Encode for Header {
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SszDigest {
+    inner: Digest,
+}
+
+impl ssz::Encode for SszDigest {
     fn is_ssz_fixed_len() -> bool {
-        false
+        true
+    }
+
+    fn ssz_fixed_len() -> usize {
+        Digest::SIZE
     }
 
     fn ssz_append(&self, buf: &mut Vec<u8>) {
-        let offset = <[u8; 32] as ssz::Encode>::ssz_fixed_len() * 6 // parent, payload_hash, execution_request_hash, checkpoint_hash, prev_epoch_header_hash, parent_beacon_block_root
-            + <u64 as ssz::Encode>::ssz_fixed_len() * 4 // height, timestamp, epoch, view
-            + <Vec<u8> as ssz::Encode>::ssz_fixed_len() * 2; // added_validators, removed_validators offsets
-
-        let mut encoder = ssz::SszEncoder::container(buf, offset);
-
-        let parent: [u8; 32] = self.parent.deref().try_into().expect("Digest is 32 bytes");
-        let payload_hash: [u8; 32] = self
-            .payload_hash
-            .deref()
-            .try_into()
-            .expect("Digest is 32 bytes");
-        let execution_request_hash: [u8; 32] = self
-            .execution_request_hash
-            .deref()
-            .try_into()
-            .expect("Digest is 32 bytes");
-        let checkpoint_hash: [u8; 32] = self
-            .checkpoint_hash
-            .deref()
-            .try_into()
-            .expect("Digest is 32 bytes");
-        let prev_epoch_header_hash: [u8; 32] = self
-            .prev_epoch_header_hash
-            .deref()
-            .try_into()
-            .expect("Digest is 32 bytes");
-
-        // Serialize AddedValidator as concatenated bytes: node_key (32) + consensus_key (48)
-        let mut added_validators_bytes =
-            Vec::with_capacity(self.added_validators.len() * ADDED_VALIDATOR_SSZ_SIZE);
-        for av in &self.added_validators {
-            let node_key_bytes: [u8; 32] = av
-                .node_key
-                .as_ref()
-                .try_into()
-                .expect("PublicKey is 32 bytes");
-            added_validators_bytes.extend_from_slice(&node_key_bytes);
-            added_validators_bytes.extend_from_slice(av.consensus_key.as_ref());
-        }
-
-        // Convert removed_validators PublicKey to byte arrays
-        let mut removed_validators_bytes = Vec::with_capacity(self.removed_validators.len() * 32);
-        for pk in &self.removed_validators {
-            let pk_bytes: [u8; 32] = pk.as_ref().try_into().expect("PublicKey is 32 bytes");
-            removed_validators_bytes.extend_from_slice(&pk_bytes);
-        }
-
-        encoder.append(&parent);
-        encoder.append(&self.height);
-        encoder.append(&self.timestamp);
-        encoder.append(&self.epoch);
-        encoder.append(&self.view);
-        encoder.append(&payload_hash);
-        encoder.append(&execution_request_hash);
-        encoder.append(&checkpoint_hash);
-        encoder.append(&prev_epoch_header_hash);
-        encoder.append(&self.parent_beacon_block_root);
-        encoder.append(&added_validators_bytes);
-        encoder.append(&removed_validators_bytes);
-        encoder.finalize();
+        buf.extend_from_slice(&self.inner.0);
     }
 
     fn ssz_bytes_len(&self) -> usize {
-        let fixed_size = <[u8; 32] as ssz::Encode>::ssz_fixed_len() * 6 // parent, payload_hash, execution_request_hash, checkpoint_hash, prev_epoch_header_hash, parent_beacon_block_root
-            + <u64 as ssz::Encode>::ssz_fixed_len() * 4; // height, timestamp, epoch, view
-
-        // AddedValidator: 32 (node_key) + 48 (consensus_key) = 80 bytes each
-        let added_validators_len = self.added_validators.len() * ADDED_VALIDATOR_SSZ_SIZE;
-        let removed_validators_len = self.removed_validators.len() * 32;
-
-        fixed_size
-            + ssz::BYTES_PER_LENGTH_OFFSET * 2  // 2 variable-length fields need 2 offsets
-            + added_validators_len
-            + removed_validators_len
+        Digest::SIZE
     }
 }
 
-impl ssz::Decode for Header {
+impl ssz::Decode for SszDigest {
     fn is_ssz_fixed_len() -> bool {
-        false
+        true
+    }
+
+    fn ssz_fixed_len() -> usize {
+        Digest::SIZE
     }
 
     fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, ssz::DecodeError> {
-        let mut builder = ssz::SszDecoderBuilder::new(bytes);
-        builder.register_type::<[u8; 32]>()?; // parent
-        builder.register_type::<u64>()?; // height
-        builder.register_type::<u64>()?; // timestamp
-        builder.register_type::<u64>()?; // epoch
-        builder.register_type::<u64>()?; // view
-        builder.register_type::<[u8; 32]>()?; // payload_hash
-        builder.register_type::<[u8; 32]>()?; // execution_request_hash
-        builder.register_type::<[u8; 32]>()?; // checkpoint_hash
-        builder.register_type::<[u8; 32]>()?; // prev_epoch_header_hash
-        builder.register_type::<[u8; 32]>()?; // parent_beacon_block_root
-        builder.register_type::<Vec<u8>>()?; // added_validators (raw bytes)
-        builder.register_type::<Vec<u8>>()?; // removed_validators (raw bytes)
+        if bytes.len() != Digest::SIZE {
+            return Err(ssz::DecodeError::InvalidByteLength {
+                len: bytes.len(),
+                expected: Digest::SIZE,
+            });
+        }
+        let digest: [u8; Digest::SIZE] = bytes[0..Digest::SIZE]
+            .try_into()
+            .expect("size is checked above");
+        Ok(Self {
+            inner: Digest(digest),
+        })
+    }
+}
 
-        let mut decoder = builder.build()?;
+impl From<Digest> for SszDigest {
+    fn from(value: Digest) -> Self {
+        SszDigest { inner: value }
+    }
+}
 
-        let parent: [u8; 32] = decoder.decode_next()?;
-        let height: u64 = decoder.decode_next()?;
-        let timestamp: u64 = decoder.decode_next()?;
-        let epoch: u64 = decoder.decode_next()?;
-        let view: u64 = decoder.decode_next()?;
-        let payload_hash: [u8; 32] = decoder.decode_next()?;
-        let execution_request_hash: [u8; 32] = decoder.decode_next()?;
-        let checkpoint_hash: [u8; 32] = decoder.decode_next()?;
-        let prev_epoch_header_hash: [u8; 32] = decoder.decode_next()?;
-        let parent_beacon_block_root: [u8; 32] = decoder.decode_next()?;
-        let added_validators_bytes: Vec<u8> = decoder.decode_next()?;
-        let removed_validators_bytes: Vec<u8> = decoder.decode_next()?;
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SszPublicKey {
+    inner: PublicKey,
+}
 
-        // Parse AddedValidator entries (80 bytes each: 32 node_key + 48 consensus_key)
+impl ssz::Encode for SszPublicKey {
+    fn is_ssz_fixed_len() -> bool {
+        true
+    }
+
+    fn ssz_fixed_len() -> usize {
+        PublicKey::SIZE
+    }
+
+    fn ssz_append(&self, buf: &mut Vec<u8>) {
+        buf.extend_from_slice(self.inner.as_ref());
+    }
+
+    fn ssz_bytes_len(&self) -> usize {
+        PublicKey::SIZE
+    }
+}
+
+impl ssz::Decode for SszPublicKey {
+    fn is_ssz_fixed_len() -> bool {
+        true
+    }
+
+    fn ssz_fixed_len() -> usize {
+        PublicKey::SIZE
+    }
+
+    fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, ssz::DecodeError> {
+        if bytes.len() != PublicKey::SIZE {
+            return Err(ssz::DecodeError::InvalidByteLength {
+                len: bytes.len(),
+                expected: PublicKey::SIZE,
+            });
+        }
         use commonware_codec::DecodeExt as _;
-        if !added_validators_bytes
-            .len()
-            .is_multiple_of(ADDED_VALIDATOR_SSZ_SIZE)
-        {
-            return Err(ssz::DecodeError::BytesInvalid(
-                "Invalid added_validators length".to_string(),
-            ));
-        }
-        let added_validators: Vec<AddedValidator> = added_validators_bytes
-            .chunks_exact(ADDED_VALIDATOR_SSZ_SIZE)
-            .map(|chunk| {
-                let node_key = PublicKey::decode(&chunk[..32]).map_err(|_| {
-                    ssz::DecodeError::BytesInvalid("Invalid node_key bytes".to_string())
-                })?;
-                let consensus_key = bls12381::PublicKey::decode(&chunk[32..]).map_err(|_| {
-                    ssz::DecodeError::BytesInvalid("Invalid consensus_key bytes".to_string())
-                })?;
-                Ok(AddedValidator {
-                    node_key,
-                    consensus_key,
-                })
-            })
-            .collect::<Result<Vec<_>, ssz::DecodeError>>()?;
+        let inner = PublicKey::decode(bytes)
+            .map_err(|_| ssz::DecodeError::BytesInvalid("invalid PublicKey bytes".to_string()))?;
+        Ok(Self { inner })
+    }
+}
 
-        // Parse removed_validators (32 bytes each)
-        if !removed_validators_bytes.len().is_multiple_of(32) {
-            return Err(ssz::DecodeError::BytesInvalid(
-                "Invalid removed_validators length".to_string(),
-            ));
-        }
-        let removed_validators: Vec<PublicKey> = removed_validators_bytes
-            .chunks_exact(32)
-            .map(|chunk| {
-                PublicKey::decode(chunk).map_err(|_| {
-                    ssz::DecodeError::BytesInvalid("Invalid PublicKey bytes".to_string())
-                })
-            })
-            .collect::<Result<Vec<_>, _>>()?;
+impl From<PublicKey> for SszPublicKey {
+    fn from(value: PublicKey) -> Self {
+        SszPublicKey { inner: value }
+    }
+}
 
-        Ok(Self::compute_digest(
-            parent.into(),
-            height,
-            timestamp,
-            epoch,
-            view,
-            payload_hash.into(),
-            execution_request_hash.into(),
-            checkpoint_hash.into(),
-            prev_epoch_header_hash.into(),
-            added_validators,
-            removed_validators,
-            parent_beacon_block_root,
-        ))
+impl From<SszPublicKey> for PublicKey {
+    fn from(value: SszPublicKey) -> Self {
+        value.inner
+    }
+}
+
+impl ssz::Encode for AddedValidator {
+    fn is_ssz_fixed_len() -> bool {
+        true
+    }
+
+    fn ssz_fixed_len() -> usize {
+        ADDED_VALIDATOR_SSZ_SIZE
+    }
+
+    fn ssz_append(&self, buf: &mut Vec<u8>) {
+        buf.extend_from_slice(self.node_key.as_ref());
+        buf.extend_from_slice(self.consensus_key.as_ref());
+    }
+
+    fn ssz_bytes_len(&self) -> usize {
+        ADDED_VALIDATOR_SSZ_SIZE
+    }
+}
+
+impl ssz::Decode for AddedValidator {
+    fn is_ssz_fixed_len() -> bool {
+        true
+    }
+
+    fn ssz_fixed_len() -> usize {
+        ADDED_VALIDATOR_SSZ_SIZE
+    }
+
+    fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, ssz::DecodeError> {
+        if bytes.len() != ADDED_VALIDATOR_SSZ_SIZE {
+            return Err(ssz::DecodeError::InvalidByteLength {
+                len: bytes.len(),
+                expected: ADDED_VALIDATOR_SSZ_SIZE,
+            });
+        }
+        use commonware_codec::DecodeExt as _;
+        let node_key = PublicKey::decode(&bytes[..PublicKey::SIZE])
+            .map_err(|_| ssz::DecodeError::BytesInvalid("invalid node_key bytes".to_string()))?;
+        let consensus_key =
+            bls12381::PublicKey::decode(&bytes[PublicKey::SIZE..]).map_err(|_| {
+                ssz::DecodeError::BytesInvalid("invalid consensus_key bytes".to_string())
+            })?;
+        Ok(AddedValidator {
+            node_key,
+            consensus_key,
+        })
     }
 }
 
@@ -390,7 +440,7 @@ where
             .map_err(|e| ssz::DecodeError::BytesInvalid(format!("{e:?}")))?;
 
         // Ensure the finalization is for the header
-        if finalization.proposal.payload != header.digest {
+        if finalization.proposal.payload != header.get_digest() {
             return Err(ssz::DecodeError::BytesInvalid(
                 "Finalization payload does not match header digest".to_string(),
             ));
@@ -448,7 +498,7 @@ where
 mod test {
     use super::*;
     use alloy_primitives::hex;
-    use commonware_codec::{DecodeExt as _, Encode as _};
+    use commonware_codec::DecodeExt as _;
     use commonware_consensus::simplex::scheme::bls12381_multisig;
     use commonware_consensus::types::{Epoch, View};
     use commonware_consensus::{
@@ -550,9 +600,87 @@ mod test {
     }
 
     #[test]
+    fn test_ssz_digest_roundtrip() {
+        let value: SszDigest = Digest([7u8; Digest::SIZE]).into();
+
+        let bytes = value.as_ssz_bytes();
+        assert_eq!(bytes.len(), Digest::SIZE);
+        assert_eq!(value.ssz_bytes_len(), Digest::SIZE);
+        assert_eq!(<SszDigest as ssz::Encode>::ssz_fixed_len(), Digest::SIZE);
+        assert_eq!(<SszDigest as ssz::Decode>::ssz_fixed_len(), Digest::SIZE);
+
+        let decoded = SszDigest::from_ssz_bytes(&bytes).unwrap();
+        assert_eq!(decoded, value);
+
+        for bad_len in [Digest::SIZE - 1, Digest::SIZE + 1] {
+            assert!(matches!(
+                SszDigest::from_ssz_bytes(&vec![0u8; bad_len]),
+                Err(ssz::DecodeError::InvalidByteLength { .. })
+            ));
+        }
+    }
+
+    #[test]
+    fn test_ssz_public_key_roundtrip() {
+        let value: SszPublicKey = create_test_public_key(1).into();
+
+        let bytes = value.as_ssz_bytes();
+        assert_eq!(bytes.len(), PublicKey::SIZE);
+        assert_eq!(value.ssz_bytes_len(), PublicKey::SIZE);
+        assert_eq!(
+            <SszPublicKey as ssz::Encode>::ssz_fixed_len(),
+            PublicKey::SIZE
+        );
+        assert_eq!(
+            <SszPublicKey as ssz::Decode>::ssz_fixed_len(),
+            PublicKey::SIZE
+        );
+
+        let decoded = SszPublicKey::from_ssz_bytes(&bytes).unwrap();
+        assert_eq!(decoded, value);
+
+        for bad_len in [PublicKey::SIZE - 1, PublicKey::SIZE + 1] {
+            assert!(matches!(
+                SszPublicKey::from_ssz_bytes(&vec![0u8; bad_len]),
+                Err(ssz::DecodeError::InvalidByteLength { .. })
+            ));
+        }
+    }
+
+    #[test]
+    fn test_added_validator_roundtrip() {
+        let value = AddedValidator {
+            node_key: create_test_public_key(1),
+            consensus_key: bls12381::PrivateKey::from_seed(1).public_key(),
+        };
+
+        let bytes = value.as_ssz_bytes();
+        assert_eq!(bytes.len(), ADDED_VALIDATOR_SSZ_SIZE);
+        assert_eq!(value.ssz_bytes_len(), ADDED_VALIDATOR_SSZ_SIZE);
+        assert_eq!(
+            <AddedValidator as ssz::Encode>::ssz_fixed_len(),
+            ADDED_VALIDATOR_SSZ_SIZE
+        );
+        assert_eq!(
+            <AddedValidator as ssz::Decode>::ssz_fixed_len(),
+            ADDED_VALIDATOR_SSZ_SIZE
+        );
+
+        let decoded = AddedValidator::from_ssz_bytes(&bytes).unwrap();
+        assert_eq!(decoded, value);
+
+        for bad_len in [ADDED_VALIDATOR_SSZ_SIZE - 1, ADDED_VALIDATOR_SSZ_SIZE + 1] {
+            assert!(matches!(
+                AddedValidator::from_ssz_bytes(&vec![0u8; bad_len]),
+                Err(ssz::DecodeError::InvalidByteLength { .. })
+            ));
+        }
+    }
+
+    #[test]
     fn test_header_encode_decode() {
         let (added_validators, removed_validators) = create_test_validators();
-        let header = Header::compute_digest(
+        let header = Header::new(
             [27u8; 32].into(),
             27,
             2727,
@@ -576,7 +704,7 @@ mod test {
     #[test]
     fn test_finalized_header_encode_decode() {
         let (added_validators, removed_validators) = create_test_validators();
-        let header = Header::compute_digest(
+        let header = Header::new(
             [27u8; 32].into(),
             27,
             2727,
@@ -594,7 +722,7 @@ mod test {
         let proposal = Proposal {
             round: Round::new(Epoch::new(0), View::new(header.view)),
             parent: View::new(header.height),
-            payload: header.digest,
+            payload: header.get_digest(),
         };
 
         // Use BLS certificate
@@ -630,7 +758,7 @@ mod test {
     #[test]
     fn test_finalized_header_validation() {
         let (added_validators, removed_validators) = create_test_validators();
-        let header = Header::compute_digest(
+        let header = Header::new(
             [27u8; 32].into(),
             27,
             2727,
@@ -684,7 +812,7 @@ mod test {
     #[test]
     fn test_finalized_header_encode_size() {
         let (added_validators, removed_validators) = create_test_validators();
-        let header = Header::compute_digest(
+        let header = Header::new(
             [27u8; 32].into(),
             27,
             2727,
@@ -702,7 +830,7 @@ mod test {
         let proposal = Proposal {
             round: Round::new(Epoch::new(0), View::new(header.view)),
             parent: View::new(header.height),
-            payload: header.digest,
+            payload: header.get_digest(),
         };
 
         // Use BLS certificate

--- a/types/src/header.rs
+++ b/types/src/header.rs
@@ -123,8 +123,12 @@ impl Header {
         }
     }
 
+    /// Builds a header with an externally-supplied digest instead of deriving it
+    /// from the canonical encoding. This is intentionally `pub(crate)` and exists
+    /// only for `Block::genesis`, which uses the eth genesis hash as the block
+    /// identity rather than `SHA256(ssz(header))`.
     #[allow(clippy::too_many_arguments)]
-    pub fn new_with_digest(
+    pub(crate) fn new_with_digest(
         parent: Digest,
         height: u64,
         timestamp: u64,

--- a/types/src/header.rs
+++ b/types/src/header.rs
@@ -157,11 +157,12 @@ impl Header {
     }
 
     pub fn get_digest(&self) -> Digest {
-        let bytes = self.encode();
-        let mut hasher = Sha256::new();
-        hasher.update(&bytes);
-        let digest = hasher.finalize();
-        *self.digest.get_or_init(|| digest)
+        *self.digest.get_or_init(|| {
+            let bytes = self.encode();
+            let mut hasher = Sha256::new();
+            hasher.update(&bytes);
+            hasher.finalize()
+        })
     }
 }
 


### PR DESCRIPTION
This addresses https://github.com/SeismicSystems/summit/issues/173.

Edit: this also addresses: https://github.com/SeismicSystems/summit/issues/196

Changes:
- Adds checks to `handle_verify` to ensure that the Simplex view and epoch matches the view and epoch from the proposed block's header.
- Implements `ssz_derive::Encode` and `ssz_derive::Decode` for `Header` and `Block` . This avoids scenarios where a field is added the structs, but not included in the digest calculation. The `Header` now has to be created before we can call `encode` to get the serialized bytes, so we cannot directly have a `digest` field on the header anymore. A `get_digest` method is added, and a field `digest: OnceLock<Digest>` is added to the header to avoid re-calculating the digest whenever `get_digest` is called.