### PR TITLE
fix: enforce consistency between CL header metadata and EL payload metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6026,6 +6026,8 @@ dependencies = [
 name = "summit-application"
 version = "0.0.3-alpha"
 dependencies = [
+ "alloy-primitives",
+ "alloy-rpc-types-engine",
  "anyhow",
  "commonware-consensus",
  "commonware-cryptography",

--- a/application/Cargo.toml
+++ b/application/Cargo.toml
@@ -36,5 +36,5 @@ alloy-rpc-types-engine.workspace = true
 
 [features]
 prom = ["metrics"]
-bench = []
+bench = ["summit-types/bench"]
 permissioned = []

--- a/application/Cargo.toml
+++ b/application/Cargo.toml
@@ -30,6 +30,10 @@ metrics = { version = "0.24.0", optional = true }
 # commonware depends on it, so we have to build it anyway.
 prometheus-client = "0.22.3"
 
+[dev-dependencies]
+alloy-primitives.workspace = true
+alloy-rpc-types-engine.workspace = true
+
 [features]
 prom = ["metrics"]
 bench = []

--- a/application/src/actor.rs
+++ b/application/src/actor.rs
@@ -652,6 +652,24 @@ fn handle_verify<ES: Epocher>(
         return false;
     }
 
+    // Bind the embedded EL payload's metadata to the Summit header.
+    let payload_block_number = block.payload.payload_inner.payload_inner.block_number;
+    if payload_block_number != block.height() {
+        warn!(
+            header_height = block.height(),
+            payload_block_number, "payload.block_number does not match header.height"
+        );
+        return false;
+    }
+    let payload_timestamp = block.payload.payload_inner.payload_inner.timestamp;
+    if payload_timestamp != block.timestamp() {
+        warn!(
+            header_timestamp = block.timestamp(),
+            payload_timestamp, "payload.timestamp does not match header.timestamp"
+        );
+        return false;
+    }
+
     // Validate consensus trie state root
     if block.header.parent_beacon_block_root != aux_data.state_root {
         warn!(
@@ -878,6 +896,121 @@ mod tests {
         assert!(
             handle_verify(&block, parent, &epocher(), &aux_data, u64::MAX / 4),
             "ordinary child inside the parent's epoch must be accepted"
+        );
+    }
+
+    /// Construct a block where the Summit header carries one set of
+    /// (height, timestamp) but the embedded EL payload reports a different
+    /// (block_number, timestamp). Honest proposal keeps these matched; a
+    /// Byzantine proposer is not constrained to do so.
+    #[allow(clippy::too_many_arguments)]
+    fn make_block_with_payload_metadata(
+        parent: Digest,
+        header_height: u64,
+        header_timestamp: u64,
+        payload_block_number: u64,
+        payload_timestamp: u64,
+        epoch: u64,
+        view: u64,
+    ) -> Block {
+        let parent_bytes: [u8; 32] = parent.0;
+        let payload = empty_payload(payload_block_number, parent_bytes, payload_timestamp);
+        Block::compute_digest(
+            parent,
+            header_height,
+            header_timestamp,
+            payload,
+            Vec::new(),
+            U256::ZERO,
+            epoch,
+            view,
+            None,
+            [0u8; 32].into(),
+            Vec::new(),
+            Vec::new(),
+            [0u8; 32],
+        )
+    }
+
+    /// A block whose Summit header.height does not match the embedded EL
+    /// payload.block_number must be rejected. Otherwise consensus would
+    /// certify a header describing one height while the EL executes under a
+    /// different block number — breaking the one-to-one CL/EL meaning of a
+    /// Summit block.
+    #[test]
+    fn rejects_block_with_payload_block_number_mismatch() {
+        let parent_height = 3;
+        let parent = make_block(
+            [0u8; 32].into(),
+            parent_height,
+            0,
+            parent_height,
+            parent_height * 12,
+        );
+
+        let header_height = parent_height + 1;
+        let header_timestamp = header_height * 12;
+        // payload.block_number disagrees with header.height
+        let payload_block_number = header_height + 5;
+
+        let block = make_block_with_payload_metadata(
+            parent.digest(),
+            header_height,
+            header_timestamp,
+            payload_block_number,
+            header_timestamp,
+            0,
+            header_height,
+        );
+
+        let aux_data = make_aux_data(0);
+
+        assert!(
+            !handle_verify(&block, parent, &epocher(), &aux_data, u64::MAX / 4),
+            "block with payload.block_number ({}) != header.height ({}) must be rejected",
+            payload_block_number,
+            header_height
+        );
+    }
+
+    /// A block whose Summit header.timestamp does not match the embedded EL
+    /// payload.timestamp must be rejected. Otherwise CL timestamp policy
+    /// (wall-clock bounds, monotonicity) can be bypassed: the header carries
+    /// a benign timestamp while the EL payload executes under a different
+    /// one that descendants and recovery flows trust.
+    #[test]
+    fn rejects_block_with_payload_timestamp_mismatch() {
+        let parent_height = 3;
+        let parent = make_block(
+            [0u8; 32].into(),
+            parent_height,
+            0,
+            parent_height,
+            parent_height * 12,
+        );
+
+        let header_height = parent_height + 1;
+        let header_timestamp = header_height * 12;
+        // payload.timestamp disagrees with header.timestamp
+        let payload_timestamp = header_timestamp + 1_000_000;
+
+        let block = make_block_with_payload_metadata(
+            parent.digest(),
+            header_height,
+            header_timestamp,
+            header_height,
+            payload_timestamp,
+            0,
+            header_height,
+        );
+
+        let aux_data = make_aux_data(0);
+
+        assert!(
+            !handle_verify(&block, parent, &epocher(), &aux_data, u64::MAX / 4),
+            "block with payload.timestamp ({}) != header.timestamp ({}) must be rejected",
+            payload_timestamp,
+            header_timestamp
         );
     }
 }

--- a/application/src/actor.rs
+++ b/application/src/actor.rs
@@ -602,14 +602,21 @@ fn handle_verify<ES: Epocher>(
     aux_data: &BlockAuxData,
     now_millis: u64,
 ) -> bool {
-    // You can only re-propose the same block if it's the last height in the epoch.
+    // You can only re-propose the same block iff it's the last height in the epoch.
+    let last_in_epoch = epocher
+        .last(Epoch::new(aux_data.epoch))
+        .expect("epoch should exist")
+        .get();
     if parent.digest() == block.digest() {
-        let last_in_epoch = epocher
-            .last(Epoch::new(aux_data.epoch))
-            .expect("epoch should exist");
-        return block.height() == last_in_epoch.get();
+        return block.height() == last_in_epoch;
     }
-
+    if block.height() > last_in_epoch {
+        warn!(
+            block_height = block.height(),
+            last_in_epoch, "rejecting non-reproposal child past epoch boundary"
+        );
+        return false;
+    }
     // Basic structural validation
     if block.parent() != parent.digest() {
         warn!(
@@ -700,4 +707,177 @@ fn handle_verify<ES: Epocher>(
     }
 
     true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::U256;
+    use alloy_rpc_types_engine::{
+        ExecutionPayloadV1, ExecutionPayloadV2, ExecutionPayloadV3, ForkchoiceState,
+    };
+    use commonware_consensus::types::FixedEpocher;
+    use std::num::NonZeroU64;
+
+    const EPOCH_LENGTH: u64 = 10;
+
+    fn empty_payload(height: u64, parent_hash: [u8; 32], timestamp: u64) -> ExecutionPayloadV3 {
+        let mut block_hash = [0u8; 32];
+        block_hash[0..8].copy_from_slice(&height.to_le_bytes());
+        ExecutionPayloadV3 {
+            payload_inner: ExecutionPayloadV2 {
+                payload_inner: ExecutionPayloadV1 {
+                    base_fee_per_gas: U256::from(1_000_000_000u64),
+                    block_number: height,
+                    block_hash: block_hash.into(),
+                    logs_bloom: Default::default(),
+                    extra_data: Default::default(),
+                    gas_limit: 30_000_000,
+                    gas_used: 0,
+                    timestamp,
+                    fee_recipient: Default::default(),
+                    parent_hash: if height == 0 {
+                        [0u8; 32].into()
+                    } else {
+                        parent_hash.into()
+                    },
+                    prev_randao: Default::default(),
+                    receipts_root: Default::default(),
+                    state_root: Default::default(),
+                    transactions: Vec::new(),
+                },
+                withdrawals: Vec::new(),
+            },
+            blob_gas_used: 0,
+            excess_blob_gas: 0,
+        }
+    }
+
+    fn make_block(parent: Digest, height: u64, epoch: u64, view: u64, timestamp: u64) -> Block {
+        let parent_bytes: [u8; 32] = parent.0;
+        let payload = empty_payload(height, parent_bytes, timestamp);
+        Block::compute_digest(
+            parent,
+            height,
+            timestamp,
+            payload,
+            Vec::new(),
+            U256::ZERO,
+            epoch,
+            view,
+            None,
+            [0u8; 32].into(),
+            Vec::new(),
+            Vec::new(),
+            [0u8; 32],
+        )
+    }
+
+    fn make_aux_data(epoch: u64) -> BlockAuxData {
+        BlockAuxData {
+            epoch,
+            withdrawals: Vec::new(),
+            checkpoint_hash: None,
+            header_hash: [0u8; 32].into(),
+            added_validators: Vec::new(),
+            removed_validators: Vec::new(),
+            forkchoice: ForkchoiceState {
+                head_block_hash: [0u8; 32].into(),
+                safe_block_hash: [0u8; 32].into(),
+                finalized_block_hash: [0u8; 32].into(),
+            },
+            suggested_fee_recipient: Default::default(),
+            state_root: [0u8; 32],
+            allowed_timestamp_future_ms: u64::MAX / 2,
+        }
+    }
+
+    fn epocher() -> FixedEpocher {
+        FixedEpocher::new(NonZeroU64::new(EPOCH_LENGTH).unwrap())
+    }
+
+    /// A re-proposal of the epoch-terminal parent (identical digest, same
+    /// height) must be accepted: that is the only allowed shape past the
+    /// epoch boundary.
+    #[test]
+    fn accepts_same_digest_reproposal_at_epoch_terminal_parent() {
+        let last_height = EPOCH_LENGTH - 1; // block 9 with epoch_length 10
+        let parent = make_block(
+            [0u8; 32].into(),
+            last_height,
+            0,
+            last_height,
+            last_height * 12,
+        );
+        let block = parent.clone();
+        let aux_data = make_aux_data(0);
+
+        assert!(
+            handle_verify(&block, parent, &epocher(), &aux_data, u64::MAX / 4),
+            "re-proposal of the epoch-terminal block must be accepted"
+        );
+    }
+
+    /// A Byzantine proposer can craft a non-reproposal child whose parent is
+    /// the epoch-terminal block. handle_verify must reject it — honest
+    /// proposers re-propose the terminal block instead of building a normal
+    /// child past the boundary, and the verifier must enforce the same rule.
+    #[test]
+    fn rejects_non_reproposal_child_after_epoch_terminal_parent() {
+        let last_height = EPOCH_LENGTH - 1; // block 9
+        let parent = make_block(
+            [0u8; 32].into(),
+            last_height,
+            0,
+            last_height,
+            last_height * 12,
+        );
+        // A Byzantine "ordinary" child at parent.height + 1 (block 10) with
+        // a fresh digest. parent continuity and height+1 continuity hold, so
+        // the structural checks pass; the only thing that can reject this is
+        // an epoch-boundary check.
+        let block = make_block(
+            parent.digest(),
+            last_height + 1,
+            0,
+            last_height + 1,
+            (last_height + 1) * 12,
+        );
+
+        let aux_data = make_aux_data(0);
+
+        assert!(
+            !handle_verify(&block, parent, &epocher(), &aux_data, u64::MAX / 4),
+            "non-reproposal child whose parent is the epoch-terminal block \
+             must be rejected"
+        );
+    }
+
+    /// Sanity: an ordinary child inside the epoch is still accepted (so the
+    /// added check doesn't over-reject).
+    #[test]
+    fn accepts_ordinary_child_inside_epoch() {
+        let parent_height = 3; // mid-epoch 0
+        let parent = make_block(
+            [0u8; 32].into(),
+            parent_height,
+            0,
+            parent_height,
+            parent_height * 12,
+        );
+        let block = make_block(
+            parent.digest(),
+            parent_height + 1,
+            0,
+            parent_height + 1,
+            (parent_height + 1) * 12,
+        );
+
+        let aux_data = make_aux_data(0);
+
+        assert!(
+            handle_verify(&block, parent, &epocher(), &aux_data, u64::MAX / 4),
+            "ordinary child inside the parent's epoch must be accepted"
+        );
+    }
 }


### PR DESCRIPTION
Note: this PR builds on https://github.com/SeismicSystems/summit/pull/189 because it addresses a similar edge case, and the code changes are overlapping.

This fixes https://github.com/SeismicSystems/summit/issues/185.

Changes:
- Adds a check to `handle_verify` to enforce that Summit header's block number matches the payload's block number.
- Adds a check to `handle_verify` to enforce that Summit header's timestamp matches the payload's timestamp.
- Adds unit tests that ensure that blocks that violate these constraints are rejected.