### PR TITLE
fix: return errors from engine client methods instead of panicing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6180,6 +6180,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-types-engine",
+ "alloy-transport",
  "alloy-transport-ipc",
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ alloy-rpc-types = "1.0.9"
 alloy-rpc-types-engine = { version = "1.0.9", features = ["serde", "ssz"] }
 alloy-signer = "1.0.9"
 alloy-signer-local = "1.0.9"
+alloy-transport = "1.0.9"
 alloy-transport-http = { version = "1.0.9", features = ["hyper", "jwt-auth"] }
 alloy-provider = { version = "1.0.9", features = ["hyper", "engine-api","ipc"] }
 alloy-primitives = "1.2.1"

--- a/application/src/actor.rs
+++ b/application/src/actor.rs
@@ -24,7 +24,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use summit_finalizer::FinalizerMailbox;
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 #[cfg(feature = "prom")]
 use metrics::{counter, histogram};
@@ -273,7 +273,21 @@ impl<
                                         let check_start = std::time::Instant::now();
 
                                         let valid = loop {
-                                            let status = engine_client.check_payload(&block).await;
+                                            let status = match engine_client.check_payload(&block).await {
+                                                Ok(status) => status,
+                                                Err(e) => {
+                                                    error!(
+                                                        target: "critical",
+                                                        ?round,
+                                                        height = block.height(),
+                                                        "certify: engine client error on check_payload: {e}"
+                                                    );
+                                                    #[cfg(feature = "prom")]
+                                                    counter!("critical_errors_total", "reason" => "engine_client_error", "severity" => "critical")
+                                                        .increment(1);
+                                                    break false;
+                                                }
+                                            };
                                             if status.is_syncing() {
                                                 warn!(
                                                     ?round,
@@ -625,6 +639,7 @@ impl<
                     .await
             }
         }
+        .map_err(|e| anyhow!("engine client error on start_building_block: {e}"))?
         .ok_or(anyhow!("Unable to build payload"))?;
 
         #[cfg(feature = "prom")]
@@ -639,7 +654,11 @@ impl<
         // STEP 5: Get payload (Engine Client)
         #[cfg(feature = "prom")]
         let get_payload_start = std::time::Instant::now();
-        let payload_envelope = self.engine_client.get_payload(payload_id).await;
+        let payload_envelope = self
+            .engine_client
+            .get_payload(payload_id)
+            .await
+            .map_err(|e| anyhow!("engine client error on get_payload: {e}"))?;
         #[cfg(feature = "prom")]
         {
             let get_payload_duration = get_payload_start.elapsed().as_millis() as f64;

--- a/finalizer/src/actor.rs
+++ b/finalizer/src/actor.rs
@@ -26,7 +26,7 @@ use rand::Rng;
 use std::collections::{BTreeMap, HashMap};
 use std::marker::PhantomData;
 use std::num::NonZero;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use summit_orchestrator::Message;
 use summit_syncer::Update;
 use summit_types::account::{ValidatorAccount, ValidatorStatus};
@@ -270,23 +270,30 @@ impl<
                     "sending initial forkchoice update to execution client, waiting for sync..."
                 );
                 loop {
-                    let status = self.engine_client.commit_hash(*forkchoice).await;
+                    let status = match self.engine_client.commit_hash(*forkchoice).await {
+                        Ok(status) => status,
+                        Err(e) => {
+                            error!(target: "critical", "engine client error on initial forkchoice update: {e}");
+                            #[cfg(feature = "prom")]
+                            counter!("critical_errors_total", "reason" => "engine_client_error", "severity" => "critical")
+                                .increment(1);
+                            self.cancellation_token.cancel();
+                            return;
+                        }
+                    };
                     if status.is_valid() {
                         info!("execution client synced to checkpoint head, ready to replay blocks");
                         break;
                     } else if status.is_syncing() {
                         warn!("execution client still syncing, waiting 5s...");
-                        self.context.sleep(std::time::Duration::from_secs(5)).await;
+                        self.context.sleep(Duration::from_secs(5)).await;
                     } else {
                         error!(target: "critical", "finalizer started with invalid forkchoice: {forkchoice:?}, height: {}, epoch: {}", self.canonical_state.get_latest_height(), self.canonical_state.get_epoch());
                         #[cfg(feature = "prom")]
                         counter!("critical_errors_total", "reason" => "invalid_forkchoice", "severity" => "critical")
                             .increment(1);
-                        panic!(
-                            "finalizer started with invalid forkchoice: {forkchoice:?}, height: {}, epoch: {}",
-                            self.canonical_state.get_latest_height(),
-                            self.canonical_state.get_epoch()
-                        );
+                        self.cancellation_token.cancel();
+                        return;
                     }
                 }
             }
@@ -440,7 +447,7 @@ impl<
                 ?block_digest,
                 "executing finalized block directly (no prior fork state)"
             );
-            let executed = execute_block(
+            let executed = match execute_block(
                 &mut self.engine_client,
                 &self.context,
                 &block,
@@ -448,7 +455,20 @@ impl<
                 &self.protocol_consts,
                 self.protocol_version_digest,
             )
-            .await;
+            .await
+            {
+                Ok(executed) => executed,
+                Err(e) => {
+                    error!(target: "critical", height, "engine client error while executing finalized block: {e}");
+                    #[cfg(feature = "prom")]
+                    counter!("critical_errors_total", "reason" => "engine_client_error", "severity" => "critical")
+                        .increment(1);
+                    self.cancellation_token.cancel();
+                    return Err(anyhow!(
+                        "engine client error while executing finalized block at height {height}: {e}"
+                    ));
+                }
+            };
             if !executed {
                 // Network finalized a block whose payload the local Reth instance rejects. Either
                 // Reth has diverged (bug, corruption, restart loss) or a byzantine
@@ -503,9 +523,18 @@ impl<
             );
         }
 
-        self.engine_client
+        if let Err(e) = self
+            .engine_client
             .commit_hash(*self.canonical_state.get_forkchoice())
-            .await;
+            .await
+        {
+            error!(target: "critical", "engine client error on canonical commit_hash after finalization: {e}");
+            #[cfg(feature = "prom")]
+            counter!("critical_errors_total", "reason" => "engine_client_error", "severity" => "critical")
+                .increment(1);
+            self.cancellation_token.cancel();
+            return Err(anyhow!("engine client error on canonical commit_hash: {e}"));
+        }
 
         #[cfg(feature = "prom")]
         {
@@ -846,7 +875,7 @@ impl<
             // discard the block: certify will reject it on every honest validator, no
             // certify quorum will form, and no descendant can build on it (find_parent
             // gates on certified). The fork is dead; skip fork-state creation.
-            let executed = execute_block(
+            let executed = match execute_block(
                 &mut self.engine_client,
                 &self.context,
                 &block,
@@ -854,7 +883,18 @@ impl<
                 &self.protocol_consts,
                 self.protocol_version_digest,
             )
-            .await;
+            .await
+            {
+                Ok(executed) => executed,
+                Err(e) => {
+                    error!(target: "critical", height, ?block_digest, "engine client error while executing notarized block: {e}");
+                    #[cfg(feature = "prom")]
+                    counter!("critical_errors_total", "reason" => "engine_client_error", "severity" => "critical")
+                        .increment(1);
+                    self.cancellation_token.cancel();
+                    return;
+                }
+            };
             if !executed {
                 warn!(
                     height,
@@ -882,7 +922,14 @@ impl<
                 safe_block_hash: self.canonical_state.get_forkchoice().finalized_block_hash,
                 finalized_block_hash: self.canonical_state.get_forkchoice().finalized_block_hash,
             };
-            self.engine_client.commit_hash(fork_forkchoice).await;
+            if let Err(e) = self.engine_client.commit_hash(fork_forkchoice).await {
+                error!(target: "critical", height, ?block_digest, "engine client error on fork commit_hash after notarization: {e}");
+                #[cfg(feature = "prom")]
+                counter!("critical_errors_total", "reason" => "engine_client_error", "severity" => "critical")
+                    .increment(1);
+                self.cancellation_token.cancel();
+                return;
+            }
 
             let total_fork_count: usize = self.fork_states.values().map(|f| f.len()).sum();
             info!(
@@ -1377,7 +1424,7 @@ async fn execute_block<
     state: &mut ConsensusState,
     consts: &ProtocolConsts,
     protocol_version_digest: Digest,
-) -> bool {
+) -> Result<bool, summit_types::EngineClientError> {
     #[cfg(feature = "prom")]
     let block_processing_start = Instant::now();
 
@@ -1385,7 +1432,7 @@ async fn execute_block<
     #[cfg(feature = "prom")]
     let payload_check_start = Instant::now();
     let payload_status = loop {
-        let status = engine_client.check_payload(block).await;
+        let status = engine_client.check_payload(block).await?;
 
         if status.is_syncing() {
             error!(
@@ -1393,7 +1440,7 @@ async fn execute_block<
                 "execution client returned SYNCING, sending forkchoice update to trigger sync and retrying..."
             );
 
-            context.sleep(std::time::Duration::from_secs(5)).await;
+            context.sleep(Duration::from_secs(5)).await;
             continue;
         }
         break status;
@@ -1410,7 +1457,7 @@ async fn execute_block<
     // Validate block against execution layer state
     // Note: withdrawals are validated in the application layer before voting
     if !payload_status.is_valid() {
-        return false;
+        return Ok(false);
     }
 
     let eth_hash = block.eth_block_hash();
@@ -1502,7 +1549,7 @@ async fn execute_block<
     let el_block_number = block.payload.payload_inner.payload_inner.block_number;
     state.capture_state_root(el_block_number);
 
-    true
+    Ok(true)
 }
 
 async fn parse_execution_requests<

--- a/finalizer/src/tests/mocks.rs
+++ b/finalizer/src/tests/mocks.rs
@@ -136,12 +136,15 @@ impl EngineClient for MockEngineClient {
         _suggested_fee_recipient: Address,
         _parent_beacon_block_root: Option<FixedBytes<32>>,
         #[cfg(feature = "bench")] height: u64,
-    ) -> Option<PayloadId> {
-        Some(PayloadId::new([0u8; 8]))
+    ) -> Result<Option<PayloadId>, summit_types::EngineClientError> {
+        Ok(Some(PayloadId::new([0u8; 8])))
     }
 
-    async fn get_payload(&mut self, _payload_id: PayloadId) -> ExecutionPayloadEnvelopeV4 {
-        ExecutionPayloadEnvelopeV4 {
+    async fn get_payload(
+        &mut self,
+        _payload_id: PayloadId,
+    ) -> Result<ExecutionPayloadEnvelopeV4, summit_types::EngineClientError> {
+        Ok(ExecutionPayloadEnvelopeV4 {
             envelope_inner: ExecutionPayloadEnvelopeV3 {
                 execution_payload: ExecutionPayloadV3 {
                     payload_inner: ExecutionPayloadV2 {
@@ -171,30 +174,36 @@ impl EngineClient for MockEngineClient {
                 should_override_builder: false,
             },
             execution_requests: Default::default(),
-        }
+        })
     }
 
-    async fn check_payload(&mut self, _block: &Block) -> PayloadStatus {
+    async fn check_payload(
+        &mut self,
+        _block: &Block,
+    ) -> Result<PayloadStatus, summit_types::EngineClientError> {
         if let Some(override_status) = self.check_payload_overrides.lock().unwrap().pop_front() {
-            return override_status;
+            return Ok(override_status);
         }
-        PayloadStatus {
+        Ok(PayloadStatus {
             status: PayloadStatusEnum::Valid,
             latest_valid_hash: Some([0u8; 32].into()),
-        }
+        })
     }
 
-    async fn commit_hash(&mut self, _fork_choice_state: ForkchoiceState) -> ForkchoiceUpdated {
+    async fn commit_hash(
+        &mut self,
+        _fork_choice_state: ForkchoiceState,
+    ) -> Result<ForkchoiceUpdated, summit_types::EngineClientError> {
         if let Some(override_response) = self.commit_hash_overrides.lock().unwrap().pop_front() {
-            return override_response;
+            return Ok(override_response);
         }
-        ForkchoiceUpdated {
+        Ok(ForkchoiceUpdated {
             payload_status: PayloadStatus {
                 status: PayloadStatusEnum::Valid,
                 latest_valid_hash: Some([0u8; 32].into()),
             },
             payload_id: None,
-        }
+        })
     }
 }
 

--- a/node/src/bin/execute_blocks.rs
+++ b/node/src/bin/execute_blocks.rs
@@ -98,16 +98,24 @@ async fn main() -> Result<()> {
             .start_building_block(forkchoice, 0, vec![], Default::default(), None)
             .await;
         match result {
-            Some(payload_id) => {
-                let payload = client.get_payload(payload_id).await;
+            Ok(Some(payload_id)) => {
+                let envelope = match client.get_payload(payload_id).await {
+                    Ok(envelope) => envelope,
+                    Err(e) => {
+                        eprintln!("get_payload failed: {e}");
+                        break;
+                    }
+                };
                 block_number = u64::from_le_bytes(payload_id.0.into());
 
-                let block_hash = payload
+                let block_hash = envelope
+                    .envelope_inner
                     .execution_payload
                     .payload_inner
                     .payload_inner
                     .block_hash;
-                let parent_hash = payload
+                let parent_hash = envelope
+                    .envelope_inner
                     .execution_payload
                     .payload_inner
                     .payload_inner
@@ -124,11 +132,16 @@ async fn main() -> Result<()> {
 
                 // use block number as view
                 let summit_block =
-                    execution_payload_envelope_to_block(payload, parent_digest, block_number);
+                    execution_payload_envelope_to_block(envelope, parent_digest, block_number);
 
                 // Check payload with Reth
-                let payload_status = client.check_payload(&summit_block).await;
-                println!("  Payload status: {:?}", payload_status);
+                match client.check_payload(&summit_block).await {
+                    Ok(status) => println!("  Payload status: {:?}", status),
+                    Err(e) => {
+                        eprintln!("check_payload failed: {e}");
+                        break;
+                    }
+                }
 
                 println!("forkchoice: {:?}", block_hash);
                 forkchoice = ForkchoiceState {
@@ -137,12 +150,19 @@ async fn main() -> Result<()> {
                     finalized_block_hash: block_hash,
                 };
 
-                client.commit_hash(forkchoice).await;
+                if let Err(e) = client.commit_hash(forkchoice).await {
+                    eprintln!("commit_hash failed: {e}");
+                    break;
+                }
                 println!("  Committed block {} to Reth", block_number);
             }
-            None => {
+            Ok(None) => {
                 // this also happens when there are no more blocks
                 eprintln!("failed to load block");
+                break;
+            }
+            Err(e) => {
+                eprintln!("start_building_block failed: {e}");
                 break;
             }
         }

--- a/node/src/test_harness/mock_engine_client.rs
+++ b/node/src/test_harness/mock_engine_client.rs
@@ -366,16 +366,16 @@ impl EngineClient for MockEngineClient {
         suggested_fee_recipient: Address,
         _parent_beacon_block_root: Option<FixedBytes<32>>,
         #[cfg(feature = "bench")] height: u64,
-    ) -> Option<PayloadId> {
+    ) -> Result<Option<PayloadId>, summit_types::EngineClientError> {
         let mut state = self.state.lock().unwrap();
 
         if state.should_fail {
-            return None;
+            return Ok(None);
         }
 
         if let Some(stop_at) = self.stop_at {
             if stop_at < state.next_block_number {
-                return None;
+                return Ok(None);
             }
         }
 
@@ -384,7 +384,7 @@ impl EngineClient for MockEngineClient {
             .canonical_blocks
             .contains_key(&fork_choice_state.head_block_hash)
         {
-            return None;
+            return Ok(None);
         }
 
         // Generate unique payload ID
@@ -425,33 +425,39 @@ impl EngineClient for MockEngineClient {
         // Store for later retrieval
         state.building_payloads.insert(payload_id, envelope);
 
-        Some(payload_id)
+        Ok(Some(payload_id))
     }
 
-    async fn get_payload(&mut self, payload_id: PayloadId) -> ExecutionPayloadEnvelopeV4 {
+    async fn get_payload(
+        &mut self,
+        payload_id: PayloadId,
+    ) -> Result<ExecutionPayloadEnvelopeV4, summit_types::EngineClientError> {
         let state = self.state.lock().unwrap();
 
-        state
+        Ok(state
             .building_payloads
             .get(&payload_id)
             .cloned()
-            .expect("Payload ID not found")
+            .expect("Payload ID not found"))
     }
 
-    async fn check_payload(&mut self, block: &Block) -> PayloadStatus {
+    async fn check_payload(
+        &mut self,
+        block: &Block,
+    ) -> Result<PayloadStatus, summit_types::EngineClientError> {
         let mut state = self.state.lock().unwrap();
 
         if let Some(override_status) = state.check_payload_overrides.pop_front() {
-            return override_status;
+            return Ok(override_status);
         }
 
         if state.force_invalid {
-            return PayloadStatus::new(
+            return Ok(PayloadStatus::new(
                 PayloadStatusEnum::Invalid {
                     validation_error: "Mock: Forced invalid".to_string(),
                 },
                 None,
-            );
+            ));
         }
 
         let block_hash = block.payload.payload_inner.payload_inner.block_hash;
@@ -466,7 +472,7 @@ impl EngineClient for MockEngineClient {
                 None,
             );
             state.known_blocks.insert(block_hash, status.clone());
-            return status;
+            return Ok(status);
         }
 
         // Block is valid - store both status and block data
@@ -475,14 +481,17 @@ impl EngineClient for MockEngineClient {
         state
             .validated_blocks
             .insert(block_hash, block.payload.clone());
-        status
+        Ok(status)
     }
 
-    async fn commit_hash(&mut self, fork_choice_state: ForkchoiceState) -> ForkchoiceUpdated {
+    async fn commit_hash(
+        &mut self,
+        fork_choice_state: ForkchoiceState,
+    ) -> Result<ForkchoiceUpdated, summit_types::EngineClientError> {
         let mut state = self.state.lock().unwrap();
 
         if let Some(override_response) = state.commit_hash_overrides.pop_front() {
-            return override_response;
+            return Ok(override_response);
         }
 
         // Update current head
@@ -533,13 +542,13 @@ impl EngineClient for MockEngineClient {
             }
         }
 
-        ForkchoiceUpdated {
+        Ok(ForkchoiceUpdated {
             payload_status: PayloadStatus::new(
                 PayloadStatusEnum::Valid,
                 Some(fork_choice_state.head_block_hash),
             ),
             payload_id: None,
-        }
+        })
     }
 }
 
@@ -777,8 +786,9 @@ mod tests {
                 0,
             )
             .await
+            .unwrap()
             .unwrap();
-        let envelope = client.get_payload(payload_id).await;
+        let envelope = client.get_payload(payload_id).await.unwrap();
         let block = envelope.envelope_inner.execution_payload;
 
         // Commit the block
@@ -788,7 +798,7 @@ mod tests {
             finalized_block_hash: FixedBytes::from(genesis_hash),
         };
 
-        client.commit_hash(new_fork_choice).await;
+        client.commit_hash(new_fork_choice).await.unwrap();
 
         // Should now be at height 1
         assert_eq!(client.get_chain_height(), 1);
@@ -847,8 +857,9 @@ mod tests {
                 0,
             )
             .await
+            .unwrap()
             .unwrap();
-        let envelope = client1.get_payload(payload_id).await;
+        let envelope = client1.get_payload(payload_id).await.unwrap();
         let block1 = envelope.envelope_inner.execution_payload.clone();
 
         let fork_choice1 = ForkchoiceState {
@@ -857,7 +868,7 @@ mod tests {
             finalized_block_hash: FixedBytes::from([0u8; 32]),
         };
 
-        client1.commit_hash(fork_choice1).await;
+        client1.commit_hash(fork_choice1).await.unwrap();
 
         // Now clients are diverged
         assert_eq!(client1.get_chain_height(), 1);
@@ -883,11 +894,11 @@ mod tests {
         );
 
         // Client2 checks the payload (validates it)
-        let validation_result = client2.check_payload(&block_for_validation).await;
+        let validation_result = client2.check_payload(&block_for_validation).await.unwrap();
         assert!(matches!(validation_result.status, PayloadStatusEnum::Valid));
 
         // Client2 commits to this fork choice (accepting the block)
-        client2.commit_hash(fork_choice1).await;
+        client2.commit_hash(fork_choice1).await.unwrap();
 
         // Now they should be in consensus again
         assert_eq!(client2.get_chain_height(), 1);
@@ -932,8 +943,9 @@ mod tests {
                     round,
                 )
                 .await
+                .unwrap()
                 .unwrap();
-            let envelope = producer.get_payload(payload_id.clone()).await;
+            let envelope = producer.get_payload(payload_id.clone()).await.unwrap();
             let new_block = envelope.envelope_inner.execution_payload.clone();
 
             let new_fork_choice = ForkchoiceState {
@@ -943,7 +955,7 @@ mod tests {
             };
 
             // Producer commits the block
-            producer.commit_hash(new_fork_choice).await;
+            producer.commit_hash(new_fork_choice).await.unwrap();
 
             // Simulate network propagation - all other clients get the block via Engine API
             for mut client in [client1.clone(), client2.clone(), client3.clone()] {
@@ -966,11 +978,12 @@ mod tests {
                     );
 
                     // Client validates the block
-                    let validation_result = client.check_payload(&block_for_validation).await;
+                    let validation_result =
+                        client.check_payload(&block_for_validation).await.unwrap();
                     assert!(matches!(validation_result.status, PayloadStatusEnum::Valid));
 
                     // Client commits to this fork choice (accepting the block)
-                    client.commit_hash(new_fork_choice).await;
+                    client.commit_hash(new_fork_choice).await.unwrap();
                 }
             }
 
@@ -1023,10 +1036,11 @@ mod tests {
                 0,
             )
             .await
+            .unwrap()
             .unwrap();
 
         // Get the payload and modify it to include the withdrawal
-        let mut envelope = client1.get_payload(payload_id).await;
+        let mut envelope = client1.get_payload(payload_id).await.unwrap();
         envelope
             .envelope_inner
             .execution_payload
@@ -1048,7 +1062,7 @@ mod tests {
             finalized_block_hash: FixedBytes::from(genesis_hash),
         };
 
-        client1.commit_hash(new_fork_choice).await;
+        client1.commit_hash(new_fork_choice).await.unwrap();
 
         // Simulate network propagation to client2
         let block_for_validation = Block::compute_digest(
@@ -1067,8 +1081,8 @@ mod tests {
             [0u8; 32],  // parent_beacon_block_root
         );
 
-        client2.check_payload(&block_for_validation).await;
-        client2.commit_hash(new_fork_choice).await;
+        client2.check_payload(&block_for_validation).await.unwrap();
+        client2.commit_hash(new_fork_choice).await.unwrap();
 
         // Test that network.get_withdrawals() returns the withdrawal
         let withdrawals = network.get_withdrawals();
@@ -1111,8 +1125,9 @@ mod tests {
                 0,
             )
             .await
+            .unwrap()
             .unwrap();
-        let envelope_a = client1.get_payload(payload_id_a).await;
+        let envelope_a = client1.get_payload(payload_id_a).await.unwrap();
         let block_a = envelope_a.envelope_inner.execution_payload.clone();
 
         // Client2 builds block B (different from A due to client_id in hash)
@@ -1127,8 +1142,9 @@ mod tests {
                 0,
             )
             .await
+            .unwrap()
             .unwrap();
-        let envelope_b = client2.get_payload(payload_id_b).await;
+        let envelope_b = client2.get_payload(payload_id_b).await.unwrap();
         let block_b = envelope_b.envelope_inner.execution_payload.clone();
 
         // Blocks should be different
@@ -1143,7 +1159,7 @@ mod tests {
             safe_block_hash: FixedBytes::from(genesis_hash),
             finalized_block_hash: FixedBytes::from(genesis_hash),
         };
-        client1.commit_hash(fork_choice_a).await;
+        client1.commit_hash(fork_choice_a).await.unwrap();
 
         // Client2 commits block B
         let fork_choice_b = ForkchoiceState {
@@ -1151,7 +1167,7 @@ mod tests {
             safe_block_hash: FixedBytes::from(genesis_hash),
             finalized_block_hash: FixedBytes::from(genesis_hash),
         };
-        client2.commit_hash(fork_choice_b).await;
+        client2.commit_hash(fork_choice_b).await.unwrap();
 
         // Now consensus should fail - clients have different blocks at height 1
         assert!(network.verify_consensus(None, None).is_err());

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -19,6 +19,7 @@ alloy-eips.workspace = true
 alloy-primitives.workspace = true
 alloy-consensus.workspace = true
 alloy-provider.workspace = true
+alloy-transport.workspace = true
 alloy-transport-ipc.workspace = true
 
 futures.workspace = true

--- a/types/src/engine_client.rs
+++ b/types/src/engine_client.rs
@@ -27,8 +27,40 @@ use alloy_rpc_types_engine::{
 use tracing::{error, warn};
 
 use crate::Block;
+use alloy_transport::TransportError;
 use alloy_transport_ipc::IpcConnect;
 use std::future::Future;
+
+/// Typed error returned by `EngineClient` methods so callers can decide
+/// whether to retry, drop a round, or shut down — instead of the wrapper
+/// panicking on every non-transport JSON-RPC failure.
+///
+/// Transport-level retry already happens inside each engine-client method
+/// via `wait_until_reconnect_available`, so by the time an
+/// `EngineClientError` reaches a caller the call has already been retried
+/// once after reconnect (or the error is JSON-RPC level, which is not
+/// retryable). Callers typically treat any `Err` as a graceful shutdown
+/// signal.
+#[derive(Debug)]
+pub struct EngineClientError(pub TransportError);
+
+impl std::fmt::Display for EngineClientError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "execution client error: {}", self.0)
+    }
+}
+
+impl std::error::Error for EngineClientError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.0)
+    }
+}
+
+impl From<TransportError> for EngineClientError {
+    fn from(e: TransportError) -> Self {
+        EngineClientError(e)
+    }
+}
 
 pub trait EngineClient: Clone + Send + Sync + 'static {
     fn start_building_block(
@@ -39,19 +71,22 @@ pub trait EngineClient: Clone + Send + Sync + 'static {
         suggested_fee_recipient: Address,
         parent_beacon_block_root: Option<FixedBytes<32>>,
         #[cfg(feature = "bench")] height: u64,
-    ) -> impl Future<Output = Option<PayloadId>> + Send;
+    ) -> impl Future<Output = Result<Option<PayloadId>, EngineClientError>> + Send;
 
     fn get_payload(
         &mut self,
         payload_id: PayloadId,
-    ) -> impl Future<Output = ExecutionPayloadEnvelopeV4> + Send;
+    ) -> impl Future<Output = Result<ExecutionPayloadEnvelopeV4, EngineClientError>> + Send;
 
-    fn check_payload(&mut self, block: &Block) -> impl Future<Output = PayloadStatus> + Send;
+    fn check_payload(
+        &mut self,
+        block: &Block,
+    ) -> impl Future<Output = Result<PayloadStatus, EngineClientError>> + Send;
 
     fn commit_hash(
         &mut self,
         fork_choice_state: ForkchoiceState,
-    ) -> impl Future<Output = ForkchoiceUpdated> + Send;
+    ) -> impl Future<Output = Result<ForkchoiceUpdated, EngineClientError>> + Send;
 }
 
 #[derive(Clone)]
@@ -97,7 +132,7 @@ impl EngineClient for RethEngineClient {
         suggested_fee_recipient: Address,
         parent_beacon_block_root: Option<FixedBytes<32>>,
         #[cfg(feature = "bench")] _height: u64,
-    ) -> Option<PayloadId> {
+    ) -> Result<Option<PayloadId>, EngineClientError> {
         let payload_attributes = PayloadAttributes {
             timestamp,
             prev_randao: [0; 32].into(),
@@ -117,9 +152,9 @@ impl EngineClient for RethEngineClient {
                 self.provider
                     .fork_choice_updated_v3(fork_choice_state, Some(payload_attributes))
                     .await
-                    .expect("Failed to update fork choice after reconnect")
+                    .map_err(EngineClientError::from)?
             }
-            Err(e) => panic!("failed to start building block: {e:?}"),
+            Err(e) => return Err(EngineClientError::from(e)),
         };
 
         if res.is_invalid() {
@@ -129,24 +164,27 @@ impl EngineClient for RethEngineClient {
             warn!("syncing returned for forkchoice state {fork_choice_state:?}: {res:?}");
         }
 
-        res.payload_id
+        Ok(res.payload_id)
     }
 
-    async fn get_payload(&mut self, payload_id: PayloadId) -> ExecutionPayloadEnvelopeV4 {
+    async fn get_payload(
+        &mut self,
+        payload_id: PayloadId,
+    ) -> Result<ExecutionPayloadEnvelopeV4, EngineClientError> {
         match self.provider.get_payload_v4(payload_id).await {
-            Ok(res) => res,
+            Ok(res) => Ok(res),
             Err(e) if e.is_transport_error() => {
                 self.wait_until_reconnect_available().await;
                 self.provider
                     .get_payload_v4(payload_id)
                     .await
-                    .expect("Failed to get payload after reconnect")
+                    .map_err(EngineClientError::from)
             }
-            Err(e) => panic!("failed to retrieve payload, error: {}", e),
+            Err(e) => Err(EngineClientError::from(e)),
         }
     }
 
-    async fn check_payload(&mut self, block: &Block) -> PayloadStatus {
+    async fn check_payload(&mut self, block: &Block) -> Result<PayloadStatus, EngineClientError> {
         match self
             .provider
             .new_payload_v4(
@@ -157,7 +195,7 @@ impl EngineClient for RethEngineClient {
             )
             .await
         {
-            Ok(res) => res,
+            Ok(res) => Ok(res),
             Err(e) if e.is_transport_error() => {
                 self.wait_until_reconnect_available().await;
                 self.provider
@@ -168,27 +206,30 @@ impl EngineClient for RethEngineClient {
                         block.execution_requests.clone(),
                     )
                     .await
-                    .expect("Failed to check payload after reconnect")
+                    .map_err(EngineClientError::from)
             }
-            Err(e) => panic!("failed to check payload, error: {}", e),
+            Err(e) => Err(EngineClientError::from(e)),
         }
     }
 
-    async fn commit_hash(&mut self, fork_choice_state: ForkchoiceState) -> ForkchoiceUpdated {
+    async fn commit_hash(
+        &mut self,
+        fork_choice_state: ForkchoiceState,
+    ) -> Result<ForkchoiceUpdated, EngineClientError> {
         match self
             .provider
             .fork_choice_updated_v3(fork_choice_state, None)
             .await
         {
-            Ok(res) => res,
+            Ok(res) => Ok(res),
             Err(e) if e.is_transport_error() => {
                 self.wait_until_reconnect_available().await;
                 self.provider
                     .fork_choice_updated_v3(fork_choice_state, None)
                     .await
-                    .expect("Failed to commit hash after reconnect")
+                    .map_err(EngineClientError::from)
             }
-            Err(e) => panic!("failed to commit hash, error: {}", e),
+            Err(e) => Err(EngineClientError::from(e)),
         }
     }
 }
@@ -242,7 +283,7 @@ impl EngineClient for BadBlockEngineClient {
         suggested_fee_recipient: Address,
         parent_beacon_block_root: Option<FixedBytes<32>>,
         #[cfg(feature = "bench")] _height: u64,
-    ) -> Option<PayloadId> {
+    ) -> Result<Option<PayloadId>, EngineClientError> {
         let payload_attributes = PayloadAttributes {
             timestamp,
             prev_randao: [0; 32].into(),
@@ -262,9 +303,9 @@ impl EngineClient for BadBlockEngineClient {
                 self.provider
                     .fork_choice_updated_v3(fork_choice_state, Some(payload_attributes))
                     .await
-                    .expect("Failed to update fork choice after reconnect")
+                    .map_err(EngineClientError::from)?
             }
-            Err(_) => panic!("Unable to get a response"),
+            Err(e) => return Err(EngineClientError::from(e)),
         };
 
         if res.is_invalid() {
@@ -274,24 +315,27 @@ impl EngineClient for BadBlockEngineClient {
             warn!("syncing returned for forkchoice state {fork_choice_state:?}: {res:?}");
         }
 
-        res.payload_id
+        Ok(res.payload_id)
     }
 
-    async fn get_payload(&mut self, payload_id: PayloadId) -> ExecutionPayloadEnvelopeV4 {
+    async fn get_payload(
+        &mut self,
+        payload_id: PayloadId,
+    ) -> Result<ExecutionPayloadEnvelopeV4, EngineClientError> {
         match self.provider.get_payload_v4(payload_id).await {
-            Ok(res) => res,
+            Ok(res) => Ok(res),
             Err(e) if e.is_transport_error() => {
                 self.wait_until_reconnect_available().await;
                 self.provider
                     .get_payload_v4(payload_id)
                     .await
-                    .expect("Failed to get payload after reconnect")
+                    .map_err(EngineClientError::from)
             }
-            Err(_) => panic!("Unable to get a response"),
+            Err(e) => Err(EngineClientError::from(e)),
         }
     }
 
-    async fn check_payload(&mut self, block: &Block) -> PayloadStatus {
+    async fn check_payload(&mut self, block: &Block) -> Result<PayloadStatus, EngineClientError> {
         let parent_beacon_block_root = if block.view().is_multiple_of(self.bad_block_timing) {
             [1; 32].into()
         } else {
@@ -308,7 +352,7 @@ impl EngineClient for BadBlockEngineClient {
             )
             .await
         {
-            Ok(res) => res,
+            Ok(res) => Ok(res),
             Err(e) if e.is_transport_error() => {
                 self.wait_until_reconnect_available().await;
                 self.provider
@@ -319,34 +363,37 @@ impl EngineClient for BadBlockEngineClient {
                         block.execution_requests.clone(),
                     )
                     .await
-                    .expect("Failed to check payload after reconnect")
+                    .map_err(EngineClientError::from)
             }
-            Err(_) => panic!("Unable to get a response"),
+            Err(e) => Err(EngineClientError::from(e)),
         }
     }
 
-    async fn commit_hash(&mut self, fork_choice_state: ForkchoiceState) -> ForkchoiceUpdated {
+    async fn commit_hash(
+        &mut self,
+        fork_choice_state: ForkchoiceState,
+    ) -> Result<ForkchoiceUpdated, EngineClientError> {
         match self
             .provider
             .fork_choice_updated_v3(fork_choice_state, None)
             .await
         {
-            Ok(res) => res,
+            Ok(res) => Ok(res),
             Err(e) if e.is_transport_error() => {
                 self.wait_until_reconnect_available().await;
                 self.provider
                     .fork_choice_updated_v3(fork_choice_state, None)
                     .await
-                    .expect("Failed to commit hash after reconnect")
+                    .map_err(EngineClientError::from)
             }
-            Err(_) => panic!("Unable to get a response"),
+            Err(e) => Err(EngineClientError::from(e)),
         }
     }
 }
 
 #[cfg(feature = "bench")]
 pub mod benchmarking {
-    use crate::engine_client::EngineClient;
+    use crate::engine_client::{EngineClient, EngineClientError};
     use crate::{Block, Digest};
     use alloy_eips::eip4895::Withdrawal;
     use alloy_eips::eip7685::Requests;
@@ -388,12 +435,15 @@ pub mod benchmarking {
             _suggested_fee_recipient: Address,
             _parent_beacon_block_hash: Option<FixedBytes<32>>,
             #[cfg(feature = "bench")] height: u64,
-        ) -> Option<PayloadId> {
+        ) -> Result<Option<PayloadId>, EngineClientError> {
             let next_block_num = height + 1;
-            Some(PayloadId::new(next_block_num.to_le_bytes()))
+            Ok(Some(PayloadId::new(next_block_num.to_le_bytes())))
         }
 
-        async fn get_payload(&mut self, payload_id: PayloadId) -> ExecutionPayloadEnvelopeV4 {
+        async fn get_payload(
+            &mut self,
+            payload_id: PayloadId,
+        ) -> Result<ExecutionPayloadEnvelopeV4, EngineClientError> {
             let block_num = u64::from_le_bytes(payload_id.0.into());
             let filename = format!("block-{block_num}");
             let file_path = self.block_dir.join(filename);
@@ -408,7 +458,7 @@ pub mod benchmarking {
                 ssz::Decode::from_ssz_bytes(&data).expect("failed to read block file");
 
             // Convert to ExecutionPayloadEnvelopeV4 with correct structure
-            ExecutionPayloadEnvelopeV4 {
+            Ok(ExecutionPayloadEnvelopeV4 {
                 envelope_inner: ExecutionPayloadEnvelopeV3 {
                     execution_payload: block_data,
                     block_value: U256::ZERO,
@@ -416,10 +466,13 @@ pub mod benchmarking {
                     should_override_builder: false,
                 },
                 execution_requests: Requests::default(),
-            }
+            })
         }
 
-        async fn check_payload(&mut self, block: &Block) -> PayloadStatus {
+        async fn check_payload(
+            &mut self,
+            block: &Block,
+        ) -> Result<PayloadStatus, EngineClientError> {
             // For Ethereum, use standard engine_newPayloadV4 without Optimism-specific logic
             self.provider
                 .new_payload_v4(
@@ -429,14 +482,17 @@ pub mod benchmarking {
                     block.execution_requests.clone(), // execution_requests
                 )
                 .await
-                .unwrap()
+                .map_err(EngineClientError::from)
         }
 
-        async fn commit_hash(&mut self, fork_choice_state: ForkchoiceState) -> ForkchoiceUpdated {
+        async fn commit_hash(
+            &mut self,
+            fork_choice_state: ForkchoiceState,
+        ) -> Result<ForkchoiceUpdated, EngineClientError> {
             self.provider
                 .fork_choice_updated_v3(fork_choice_state, None)
                 .await
-                .unwrap()
+                .map_err(EngineClientError::from)
         }
     }
 


### PR DESCRIPTION
Note: this PR builds on https://github.com/SeismicSystems/summit/pull/167 because it addresses a similar edge case, and the code changes are overlapping.

This addresses https://github.com/SeismicSystems/summit/issues/181.

Changes:
- Refactors engine client to return errors and remove the `expects` calls.
- In the application and finalizer, where engine client methods are called, handle errors with a graceful shutdown (transport errors are already retried inside of the engine client, only non-transport errors are returned).