### PR TITLE
fix: create admin RPC server for getDepositSignature endpoint

### DIFF
--- a/node/src/args.rs
+++ b/node/src/args.rs
@@ -109,6 +109,11 @@ pub struct RunFlags {
     #[arg(long, default_value_t = 3030)]
     pub rpc_port: u16,
 
+    /// Port for the localhost-only admin RPC server (handles validator-key
+    /// signing methods like `getDepositSignature`).
+    #[arg(long, default_value_t = 3031)]
+    pub admin_rpc_port: u16,
+
     /// Number of tokio worker threads (defaults to number of logical CPUs)
     #[arg(long)]
     pub worker_threads: Option<usize>,
@@ -683,12 +688,14 @@ where
     // Start RPC server
     let key_store_path = flags.key_store_path;
     let rpc_port = flags.rpc_port;
+    let admin_rpc_port = flags.admin_rpc_port;
     let stop_signal = context.stopped();
     let rpc_handle = context.with_label("rpc").spawn(move |_context| async move {
         if let Err(e) = start_rpc_server(
             finalizer_mailbox,
             key_store_path,
             rpc_port,
+            admin_rpc_port,
             stop_signal,
             #[cfg(feature = "permissioned")]
             paused,

--- a/node/src/bin/observer.rs
+++ b/node/src/bin/observer.rs
@@ -501,6 +501,7 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         prom_port: (28600 + (node * 10)) as u16,
         prom_ip: "0.0.0.0".into(),
         rpc_port: (3030 + (node * 10)) as u16,
+        admin_rpc_port: (3031 + (node * 10)) as u16,
         worker_threads: Some(2),
         log_level: "debug".into(),
         db_prefix: format!("{node}"),

--- a/node/src/bin/protocol_params.rs
+++ b/node/src/bin/protocol_params.rs
@@ -400,6 +400,7 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         prom_port: (28600 + (node * 10)) as u16,
         prom_ip: "0.0.0.0".into(),
         rpc_port: (3030 + (node * 10)) as u16,
+        admin_rpc_port: (3031 + (node * 10)) as u16,
         worker_threads: Some(2),
         log_level: "debug".into(),
         db_prefix: format!("{node}"),

--- a/node/src/bin/stake_and_checkpoint.rs
+++ b/node/src/bin/stake_and_checkpoint.rs
@@ -687,6 +687,7 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         prom_port: (28600 + (node * 10)) as u16,
         prom_ip: "0.0.0.0".into(),
         rpc_port: (3030 + (node * 10)) as u16,
+        admin_rpc_port: (3031 + (node * 10)) as u16,
         worker_threads: Some(2),
         log_level: "debug".into(),
         db_prefix: format!("{node}"),

--- a/node/src/bin/stake_and_join_with_outdated_ckpt.rs
+++ b/node/src/bin/stake_and_join_with_outdated_ckpt.rs
@@ -805,6 +805,7 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         prom_port: (28600 + (node * 10)) as u16,
         prom_ip: "0.0.0.0".into(),
         rpc_port: (3030 + (node * 10)) as u16,
+        admin_rpc_port: (3031 + (node * 10)) as u16,
         worker_threads: Some(2),
         log_level: "debug".into(),
         db_prefix: format!("{node}"),

--- a/node/src/bin/sync_from_genesis.rs
+++ b/node/src/bin/sync_from_genesis.rs
@@ -670,6 +670,7 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         prom_port: (28600 + (node * 10)) as u16,
         prom_ip: "0.0.0.0".into(),
         rpc_port: (3030 + (node * 10)) as u16,
+        admin_rpc_port: (3031 + (node * 10)) as u16,
         worker_threads: Some(2),
         log_level: "debug".into(),
         db_prefix: format!("{node}"),

--- a/node/src/bin/testnet.rs
+++ b/node/src/bin/testnet.rs
@@ -187,6 +187,7 @@ fn get_node_flags(node: usize) -> RunFlags {
         prom_port: (28600 + (node * 10)) as u16,
         prom_ip: "0.0.0.0".into(),
         rpc_port: (3030 + (node * 10)) as u16,
+        admin_rpc_port: (3031 + (node * 10)) as u16,
         worker_threads: Some(2),
         log_level: "debug".into(),
         db_prefix: format!("{node}"),

--- a/node/src/bin/verify_consensus_state_proof.rs
+++ b/node/src/bin/verify_consensus_state_proof.rs
@@ -547,6 +547,7 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         prom_port: (28600 + (node * 10)) as u16,
         prom_ip: "0.0.0.0".into(),
         rpc_port: (3030 + (node * 10)) as u16,
+        admin_rpc_port: (3031 + (node * 10)) as u16,
         worker_threads: Some(2),
         log_level: "debug".into(),
         db_prefix: format!("{node}"),

--- a/node/src/bin/withdraw_and_exit.rs
+++ b/node/src/bin/withdraw_and_exit.rs
@@ -395,6 +395,7 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         prom_port: (28600 + (node * 10)) as u16,
         prom_ip: "0.0.0.0".into(),
         rpc_port: (3030 + (node * 10)) as u16,
+        admin_rpc_port: (3031 + (node * 10)) as u16,
         worker_threads: Some(2),
         log_level: "debug".into(),
         db_prefix: format!("{node}"),

--- a/rpc/src/api.rs
+++ b/rpc/src/api.rs
@@ -41,13 +41,6 @@ pub trait SummitApi {
         public_key: String,
     ) -> RpcResult<ValidatorAccountResponse>;
 
-    #[method(name = "getDepositSignature")]
-    async fn get_deposit_signature(
-        &self,
-        amount: u64,
-        address: String,
-    ) -> RpcResult<DepositTransactionResponse>;
-
     #[method(name = "getMinimumStake")]
     async fn get_minimum_stake(&self) -> RpcResult<u64>;
 
@@ -90,6 +83,20 @@ pub trait SummitPermissionedApi {
 
     #[method(name = "isPaused")]
     async fn is_paused(&self) -> RpcResult<bool>;
+}
+
+/// Admin-only RPC surface. Must be served on a localhost-bound listener.
+///
+/// `getDepositSignature` uses the node's local validator private keys to sign
+/// caller-supplied deposit data.
+#[rpc(server, client)]
+pub trait SummitAdminApi {
+    #[method(name = "getDepositSignature")]
+    async fn get_deposit_signature(
+        &self,
+        amount: u64,
+        address: String,
+    ) -> RpcResult<DepositTransactionResponse>;
 }
 
 #[rpc(server, client)]

--- a/rpc/src/builder.rs
+++ b/rpc/src/builder.rs
@@ -41,6 +41,17 @@ impl RpcServerBuilder {
         }
     }
 
+    /// Bind to 127.0.0.1 only. Used for the admin RPC listener so the
+    /// validator-key signing methods (`SummitAdminApi`) can't be reached
+    /// from off-host even if the firewall is misconfigured.
+    pub fn new_localhost(port: u16) -> Self {
+        Self {
+            addr: SocketAddr::from(([127, 0, 0, 1], port)),
+            config: ServerConfigBuilder::new(),
+            cors_domains: None,
+        }
+    }
+
     pub fn with_max_connections(mut self, max: u32) -> Self {
         self.config = self.config.max_connections(max);
         self

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -12,8 +12,8 @@ pub use server::SummitRpcServer;
 pub use types::*;
 
 pub use api::{
-    SummitApiClient, SummitApiServer, SummitGenesisApiClient, SummitGenesisApiServer,
-    SummitProofApiClient, SummitProofApiServer,
+    SummitAdminApiClient, SummitAdminApiServer, SummitApiClient, SummitApiServer,
+    SummitGenesisApiClient, SummitGenesisApiServer, SummitProofApiClient, SummitProofApiServer,
 };
 #[cfg(feature = "permissioned")]
 pub use api::{SummitPermissionedApiClient, SummitPermissionedApiServer};
@@ -34,6 +34,7 @@ pub async fn start_rpc_server(
     finalizer_mailbox: FinalizerMailbox<MultisigScheme, Block>,
     key_store_path: String,
     port: u16,
+    admin_port: u16,
     stop_signal: Signal,
     #[cfg(feature = "permissioned")] paused: Arc<AtomicBool>,
 ) -> anyhow::Result<()> {
@@ -44,12 +45,12 @@ pub async fn start_rpc_server(
         paused,
     );
 
-    let mut methods = SummitApiServer::into_rpc(rpc_impl.clone());
-    methods.merge(SummitProofApiServer::into_rpc(rpc_impl.clone()))?;
+    let mut public_methods = SummitApiServer::into_rpc(rpc_impl.clone());
+    public_methods.merge(SummitProofApiServer::into_rpc(rpc_impl.clone()))?;
     #[cfg(feature = "permissioned")]
-    methods.merge(SummitPermissionedApiServer::into_rpc(rpc_impl))?;
+    public_methods.merge(SummitPermissionedApiServer::into_rpc(rpc_impl.clone()))?;
 
-    let server = builder::RpcServerBuilder::new(port)
+    let public_server = builder::RpcServerBuilder::new(port)
         .with_max_connections(1000)
         .with_max_request_body_size(10 * 1024 * 1024)
         .with_max_response_body_size(10 * 1024 * 1024)
@@ -57,18 +58,43 @@ pub async fn start_rpc_server(
         .build()
         .await?;
 
-    let handle = server.start(methods);
+    let public_handle = public_server.start(public_methods);
 
     tracing::info!("RPC Server listening on http://0.0.0.0:{port}");
 
+    // Admin RPC: hosts `SummitAdminApi` (validator-key signing methods).
+    let admin_methods = SummitAdminApiServer::into_rpc(rpc_impl);
+
+    let admin_server = builder::RpcServerBuilder::new_localhost(admin_port)
+        .with_max_connections(1000)
+        .with_max_request_body_size(10 * 1024 * 1024)
+        .with_max_response_body_size(10 * 1024 * 1024)
+        .build()
+        .await?;
+
+    let admin_handle = admin_server.start(admin_methods);
+
+    tracing::info!("Admin RPC Server listening on http://127.0.0.1:{admin_port}");
+
     let sig = stop_signal.await?;
     tracing::info!("RPC server stopped: {sig}");
-    handle.stop()?;
+    public_handle.stop()?;
+    admin_handle.stop()?;
 
     Ok(())
 }
 
-/// Starts the RPC server and returns the handle and bound address (useful for testing)
+/// Bundle of public + admin RPC handles + bound addresses returned by
+/// `start_rpc_server_pair_with_handle` for tests that need both listeners.
+pub struct RpcHandles {
+    pub public_handle: ServerHandle,
+    pub public_addr: SocketAddr,
+    pub admin_handle: ServerHandle,
+    pub admin_addr: SocketAddr,
+}
+
+/// Starts only the public RPC listener and returns its handle/address. Used
+/// by tests that don't exercise the admin RPC surface.
 pub async fn start_rpc_server_with_handle(
     finalizer_mailbox: FinalizerMailbox<MultisigScheme, Block>,
     key_store_path: String,
@@ -82,12 +108,12 @@ pub async fn start_rpc_server_with_handle(
         paused,
     );
 
-    let mut methods = SummitApiServer::into_rpc(rpc_impl.clone());
-    methods.merge(SummitProofApiServer::into_rpc(rpc_impl.clone()))?;
+    let mut public_methods = SummitApiServer::into_rpc(rpc_impl.clone());
+    public_methods.merge(SummitProofApiServer::into_rpc(rpc_impl.clone()))?;
     #[cfg(feature = "permissioned")]
-    methods.merge(SummitPermissionedApiServer::into_rpc(rpc_impl))?;
+    public_methods.merge(SummitPermissionedApiServer::into_rpc(rpc_impl))?;
 
-    let server = builder::RpcServerBuilder::new(port)
+    let public_server = builder::RpcServerBuilder::new(port)
         .with_max_connections(1000)
         .with_max_request_body_size(10 * 1024 * 1024)
         .with_max_response_body_size(10 * 1024 * 1024)
@@ -95,12 +121,66 @@ pub async fn start_rpc_server_with_handle(
         .build()
         .await?;
 
-    let addr = server.local_addr()?;
-    let handle = server.start(methods);
+    let public_addr = public_server.local_addr()?;
+    let public_handle = public_server.start(public_methods);
 
-    tracing::info!("RPC Server listening on http://{}", addr);
+    tracing::info!("RPC Server listening on http://{}", public_addr);
 
-    Ok((handle, addr))
+    Ok((public_handle, public_addr))
+}
+
+/// Starts the public RPC listener and the admin RPC listener and returns
+/// handles + bound addresses for both. Used by tests that exercise the
+/// admin (localhost-only) RPC surface. Passing `0` for either port asks
+/// the OS to allocate a free port.
+pub async fn start_rpc_server_pair_with_handle(
+    finalizer_mailbox: FinalizerMailbox<MultisigScheme, Block>,
+    key_store_path: String,
+    port: u16,
+    admin_port: u16,
+    #[cfg(feature = "permissioned")] paused: Arc<AtomicBool>,
+) -> anyhow::Result<RpcHandles> {
+    let rpc_impl = SummitRpcServer::new(
+        key_store_path,
+        finalizer_mailbox,
+        #[cfg(feature = "permissioned")]
+        paused,
+    );
+
+    let mut public_methods = SummitApiServer::into_rpc(rpc_impl.clone());
+    public_methods.merge(SummitProofApiServer::into_rpc(rpc_impl.clone()))?;
+    #[cfg(feature = "permissioned")]
+    public_methods.merge(SummitPermissionedApiServer::into_rpc(rpc_impl.clone()))?;
+
+    let public_server = builder::RpcServerBuilder::new(port)
+        .with_max_connections(1000)
+        .with_max_request_body_size(10 * 1024 * 1024)
+        .with_max_response_body_size(10 * 1024 * 1024)
+        .with_cors(Some("*".to_string()))
+        .build()
+        .await?;
+
+    let public_addr = public_server.local_addr()?;
+    let public_handle = public_server.start(public_methods);
+
+    let admin_methods = SummitAdminApiServer::into_rpc(rpc_impl);
+
+    let admin_server = builder::RpcServerBuilder::new_localhost(admin_port)
+        .with_max_connections(1000)
+        .with_max_request_body_size(10 * 1024 * 1024)
+        .with_max_response_body_size(10 * 1024 * 1024)
+        .build()
+        .await?;
+
+    let admin_addr = admin_server.local_addr()?;
+    let admin_handle = admin_server.start(admin_methods);
+
+    Ok(RpcHandles {
+        public_handle,
+        public_addr,
+        admin_handle,
+        admin_addr,
+    })
 }
 
 pub async fn start_rpc_server_for_genesis(

--- a/rpc/src/server.rs
+++ b/rpc/src/server.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "permissioned")]
 use crate::api::SummitPermissionedApiServer;
-use crate::api::{SummitApiServer, SummitProofApiServer};
+use crate::api::{SummitAdminApiServer, SummitApiServer, SummitProofApiServer};
 #[cfg(feature = "permissioned")]
 use crate::auth;
 use crate::error::RpcError;
@@ -213,80 +213,6 @@ impl SummitApiServer for SummitRpcServer {
         }
     }
 
-    async fn get_deposit_signature(
-        &self,
-        amount: u64,
-        address: String,
-    ) -> RpcResult<DepositTransactionResponse> {
-        let mut withdrawal_credentials = [0u8; 32];
-        withdrawal_credentials[0] = 0x01;
-
-        let withdrawal_address = Address::from_hex(address)
-            .map_err(|e| RpcError::InvalidPublicKey(format!("Invalid address: {}", e)))?;
-        withdrawal_credentials[12..32].copy_from_slice(withdrawal_address.as_slice());
-
-        let key_paths = KeyPaths::new(self.key_store_path.clone());
-
-        let consensus_priv_key = key_paths
-            .consensus_private_key()
-            .map_err(|e| RpcError::KeyStoreError(format!("Failed to read consensus key: {}", e)))?;
-        let consensus_pub = consensus_priv_key.public_key();
-
-        let node_priv_key = key_paths
-            .node_private_key()
-            .map_err(|e| RpcError::KeyStoreError(format!("Failed to read node key: {}", e)))?;
-        let node_pub = node_priv_key.public_key();
-
-        let req = DepositRequest {
-            node_pubkey: node_pub.clone(),
-            consensus_pubkey: consensus_pub.clone(),
-            withdrawal_credentials,
-            amount,
-            node_signature: [0; 64],
-            consensus_signature: [0; 96],
-            index: 0,
-        };
-
-        let protocol_version_digest = Sha256::hash(&PROTOCOL_VERSION.to_le_bytes());
-        let message = req.as_message(protocol_version_digest);
-
-        let node_signature = node_priv_key.sign(&[], &message);
-        let node_signature_bytes: [u8; 64] = node_signature
-            .as_ref()
-            .try_into()
-            .expect("ed25519 sig is always 64 bytes");
-
-        let consensus_signature = consensus_priv_key.sign(&[], &message);
-        let consensus_signature_slice: &[u8] = consensus_signature.as_ref();
-        let consensus_signature_bytes: [u8; 96] = consensus_signature_slice
-            .try_into()
-            .expect("bls sig is always 96 bytes");
-
-        let node_pubkey_bytes: [u8; 32] = node_pub.to_vec().try_into().expect("Cannot fail");
-        let consensus_pubkey_bytes: [u8; 48] =
-            consensus_pub.encode().as_ref()[..48].try_into().unwrap();
-
-        let deposit_amount = U256::from(amount) * U256::from(1_000_000_000u64);
-
-        let deposit_root = compute_deposit_data_root(
-            &node_pubkey_bytes,
-            &consensus_pubkey_bytes,
-            &withdrawal_credentials,
-            deposit_amount,
-            &node_signature_bytes,
-            &consensus_signature_bytes,
-        );
-
-        Ok(DepositTransactionResponse {
-            node_pubkey: node_pubkey_bytes,
-            consensus_pubkey: consensus_pubkey_bytes.to_vec(),
-            withdrawal_credentials,
-            node_signature: node_signature_bytes.to_vec(),
-            consensus_signature: consensus_signature_bytes.to_vec(),
-            deposit_data_root: deposit_root,
-        })
-    }
-
     async fn get_minimum_stake(&self) -> RpcResult<u64> {
         let minimum_stake = self.finalizer_mailbox.get_minimum_stake().await;
         Ok(minimum_stake)
@@ -372,6 +298,83 @@ impl SummitApiServer for SummitRpcServer {
             }),
             None => Err(RpcError::WithdrawalNotFound.into()),
         }
+    }
+}
+
+#[async_trait]
+impl SummitAdminApiServer for SummitRpcServer {
+    async fn get_deposit_signature(
+        &self,
+        amount: u64,
+        address: String,
+    ) -> RpcResult<DepositTransactionResponse> {
+        let mut withdrawal_credentials = [0u8; 32];
+        withdrawal_credentials[0] = 0x01;
+
+        let withdrawal_address = Address::from_hex(address)
+            .map_err(|e| RpcError::InvalidPublicKey(format!("Invalid address: {}", e)))?;
+        withdrawal_credentials[12..32].copy_from_slice(withdrawal_address.as_slice());
+
+        let key_paths = KeyPaths::new(self.key_store_path.clone());
+
+        let consensus_priv_key = key_paths
+            .consensus_private_key()
+            .map_err(|e| RpcError::KeyStoreError(format!("Failed to read consensus key: {}", e)))?;
+        let consensus_pub = consensus_priv_key.public_key();
+
+        let node_priv_key = key_paths
+            .node_private_key()
+            .map_err(|e| RpcError::KeyStoreError(format!("Failed to read node key: {}", e)))?;
+        let node_pub = node_priv_key.public_key();
+
+        let req = DepositRequest {
+            node_pubkey: node_pub.clone(),
+            consensus_pubkey: consensus_pub.clone(),
+            withdrawal_credentials,
+            amount,
+            node_signature: [0; 64],
+            consensus_signature: [0; 96],
+            index: 0,
+        };
+
+        let protocol_version_digest = Sha256::hash(&PROTOCOL_VERSION.to_le_bytes());
+        let message = req.as_message(protocol_version_digest);
+
+        let node_signature = node_priv_key.sign(&[], &message);
+        let node_signature_bytes: [u8; 64] = node_signature
+            .as_ref()
+            .try_into()
+            .expect("ed25519 sig is always 64 bytes");
+
+        let consensus_signature = consensus_priv_key.sign(&[], &message);
+        let consensus_signature_slice: &[u8] = consensus_signature.as_ref();
+        let consensus_signature_bytes: [u8; 96] = consensus_signature_slice
+            .try_into()
+            .expect("bls sig is always 96 bytes");
+
+        let node_pubkey_bytes: [u8; 32] = node_pub.to_vec().try_into().expect("Cannot fail");
+        let consensus_pubkey_bytes: [u8; 48] =
+            consensus_pub.encode().as_ref()[..48].try_into().unwrap();
+
+        let deposit_amount = U256::from(amount) * U256::from(1_000_000_000u64);
+
+        let deposit_root = compute_deposit_data_root(
+            &node_pubkey_bytes,
+            &consensus_pubkey_bytes,
+            &withdrawal_credentials,
+            deposit_amount,
+            &node_signature_bytes,
+            &consensus_signature_bytes,
+        );
+
+        Ok(DepositTransactionResponse {
+            node_pubkey: node_pubkey_bytes,
+            consensus_pubkey: consensus_pubkey_bytes.to_vec(),
+            withdrawal_credentials,
+            node_signature: node_signature_bytes.to_vec(),
+            consensus_signature: consensus_signature_bytes.to_vec(),
+            deposit_data_root: deposit_root,
+        })
     }
 }
 

--- a/rpc/tests/integration_test.rs
+++ b/rpc/tests/integration_test.rs
@@ -6,7 +6,8 @@ use std::sync::Arc;
 #[cfg(feature = "permissioned")]
 use std::sync::atomic::AtomicBool;
 use summit_rpc::{
-    PathSender, start_rpc_server_for_genesis_with_handle, start_rpc_server_with_handle,
+    PathSender, start_rpc_server_for_genesis_with_handle, start_rpc_server_pair_with_handle,
+    start_rpc_server_with_handle,
 };
 use utils::{MockFinalizerState, create_test_finalizer_mailbox, create_test_keystore};
 
@@ -379,4 +380,78 @@ async fn test_get_maximum_stake() {
     assert_eq!(response.unwrap(), 64_000_000_000);
 
     handle.stop().unwrap();
+}
+
+/// `getDepositSignature` signs caller-supplied deposit data with the node's
+/// validator private keys. It must not be reachable on the public RPC
+/// listener — only on the localhost-bound admin listener — so a network
+/// caller can't preemptively register the node's validator identity with
+/// attacker-chosen withdrawal credentials.
+#[tokio::test]
+async fn test_get_deposit_signature_not_on_public_listener() {
+    use jsonrpsee::core::ClientError;
+    use jsonrpsee::types::error::ErrorCode;
+    use summit_rpc::SummitAdminApiClient;
+
+    let (mailbox, _finalizer_handle) = create_test_finalizer_mailbox(MockFinalizerState::default());
+    let temp_dir = create_test_keystore().unwrap();
+    let key_store_path = temp_dir.path().to_str().unwrap().to_string();
+
+    let handles = start_rpc_server_pair_with_handle(
+        mailbox,
+        key_store_path,
+        0,
+        0,
+        #[cfg(feature = "permissioned")]
+        Arc::new(AtomicBool::new(false)),
+    )
+    .await
+    .unwrap();
+
+    // The public listener must reject `getDepositSignature` with
+    // method-not-found — it isn't part of `SummitApi`/`SummitProofApi`.
+    let public_url = format!("http://{}", handles.public_addr);
+    let public_client = HttpClientBuilder::default().build(&public_url).unwrap();
+    let address = format!("0x{}", "a".repeat(40));
+    let public_resp = SummitAdminApiClient::get_deposit_signature(
+        &public_client,
+        32_000_000_000,
+        address.clone(),
+    )
+    .await;
+
+    match public_resp {
+        Err(ClientError::Call(err)) => {
+            assert_eq!(
+                err.code(),
+                ErrorCode::MethodNotFound.code(),
+                "expected MethodNotFound on the public RPC listener, got {:?}",
+                err
+            );
+        }
+        other => panic!(
+            "public RPC listener must not serve getDepositSignature; got {:?}",
+            other
+        ),
+    }
+
+    // The admin listener (loopback) must serve `getDepositSignature`.
+    let admin_url = format!("http://{}", handles.admin_addr);
+    let admin_client = HttpClientBuilder::default().build(&admin_url).unwrap();
+    let admin_resp =
+        SummitAdminApiClient::get_deposit_signature(&admin_client, 32_000_000_000, address)
+            .await
+            .expect("admin listener should serve getDepositSignature");
+    assert_eq!(admin_resp.node_signature.len(), 64);
+    assert_eq!(admin_resp.consensus_signature.len(), 96);
+
+    // Admin listener must be loopback-bound.
+    assert!(
+        handles.admin_addr.ip().is_loopback(),
+        "admin listener must be bound to loopback; bound to {}",
+        handles.admin_addr.ip()
+    );
+
+    handles.public_handle.stop().unwrap();
+    handles.admin_handle.stop().unwrap();
 }


### PR DESCRIPTION
This addresses https://github.com/SeismicSystems/summit/issues/182.

Changes:
- Creates a new `SummitAdminApi` trait served on a separate listener bound to `127.0.0.1` and a separate admin port.
- Moves the `getDepositSignature` endpoint to the new trait.