### PR TITLE
fix: enforce BLS key uniqueness

### DIFF
--- a/finalizer/src/actor.rs
+++ b/finalizer/src/actor.rs
@@ -1934,6 +1934,17 @@ fn verify_deposit_request<R: Storage + Metrics + Clock + Spawner + governor::clo
 
     // Check for pending deposit or withdrawal (only if account exists)
     if let Some(acc) = account {
+        // Top-up deposits must carry the same BLS consensus key already
+        // stored on the account. Otherwise the deposit shape and the
+        // validator's effective consensus key drift apart and the
+        // BLS-uniqueness invariant becomes harder to reason about (see also
+        // the cross-account duplicate-BLS scan below).
+        if acc.consensus_public_key != deposit_request.consensus_pubkey {
+            info!(
+                "Skipping deposit request: consensus_pubkey does not match the BLS key already stored on this validator account: {deposit_request:?}"
+            );
+            return Err(DepositRejectionReason::Refund);
+        }
         if acc.has_pending_deposit {
             info!(
                 "Skipping deposit request because the validator already has a pending deposit request: {deposit_request:?}"
@@ -1943,6 +1954,22 @@ fn verify_deposit_request<R: Storage + Metrics + Clock + Spawner + governor::clo
         if acc.has_pending_withdrawal {
             info!(
                 "Skipping deposit request because the validator already has a pending withdrawal request: {deposit_request:?}"
+            );
+            return Err(DepositRejectionReason::Refund);
+        }
+    }
+
+    // Cross-account BLS uniqueness: reject if the submitted consensus_pubkey
+    // is already attached to a *different* validator account. Without this
+    // check, an actor controlling an already-used BLS private key could
+    // register a second validator identity under a fresh node key, and once
+    // both were active the orchestrator's BiMap construction would panic on
+    // the duplicate BLS value.
+    for (key, acc) in state.validator_accounts_iter() {
+        if key != &validator_pubkey && acc.consensus_public_key == deposit_request.consensus_pubkey
+        {
+            info!(
+                "Skipping deposit request: consensus_pubkey is already attached to a different validator account: {deposit_request:?}"
             );
             return Err(DepositRejectionReason::Refund);
         }

--- a/node/src/test_harness/common.rs
+++ b/node/src/test_harness/common.rs
@@ -455,6 +455,7 @@ pub fn create_deposit_request(
     amount: u64,
     domain: Digest,
     private_key: Option<PrivateKey>,
+    consensus_key: Option<bls12381::PrivateKey>,
     withdrawal_credentials: Option<[u8; 32]>,
 ) -> (DepositRequest, PrivateKey, bls12381::PrivateKey) {
     let withdrawal_credentials = if let Some(withdrawal_credentials) = withdrawal_credentials {
@@ -479,8 +480,14 @@ pub fn create_deposit_request(
     };
     let node_pubkey = ed25519_private_key.public_key();
 
-    // Generate consensus (BLS) key
-    let bls_private_key = bls12381::PrivateKey::random(&mut rng);
+    // Generate consensus (BLS) key. Top-up deposits for an existing
+    // validator must carry that validator's stored BLS key, so callers can
+    // pass `Some(key_stores[i].consensus_key.clone())` explicitly.
+    let bls_private_key = if let Some(consensus_key) = consensus_key {
+        consensus_key
+    } else {
+        bls12381::PrivateKey::random(&mut rng)
+    };
     let consensus_pubkey = bls_private_key.public_key();
 
     let mut deposit = DepositRequest {

--- a/node/src/tests/checkpointing/verification.rs
+++ b/node/src/tests/checkpointing/verification.rs
@@ -338,7 +338,7 @@ fn test_checkpoint_verification_dynamic_committee() {
         // joining_epoch = 0 + VALIDATOR_NUM_WARM_UP_EPOCHS = 2
         // added_validators will appear in epoch 1's finalized header
         let (deposit, _, _) =
-            common::create_deposit_request(10, min_stake, common::get_domain(), None, None);
+            common::create_deposit_request(10, min_stake, common::get_domain(), None, None, None);
         let deposit_requests =
             common::execution_requests_to_requests(vec![ExecutionRequest::Deposit(deposit)]);
 

--- a/node/src/tests/execution_requests/deposit_withdrawal_combined.rs
+++ b/node/src/tests/execution_requests/deposit_withdrawal_combined.rs
@@ -71,6 +71,7 @@ fn test_deposit_and_withdrawal_request_single() {
             common::get_domain(),
             None,
             None,
+            None,
         );
 
         let withdrawal_address = Address::from_slice(&test_deposit.withdrawal_credentials[12..32]);
@@ -291,6 +292,7 @@ fn test_deposit_and_withdrawal_request_multiple() {
                 i as u64,
                 min_stake,
                 common::get_domain(),
+                None,
                 None,
                 None,
             );
@@ -556,6 +558,7 @@ fn test_deposit_blocked_by_pending_withdrawal() {
             deposit_amount,
             common::get_domain(),
             Some(key_stores[0].node_key.clone()),
+            Some(key_stores[0].consensus_key.clone()),
             Some(withdrawal_credentials),
         );
 
@@ -761,6 +764,7 @@ fn test_invalid_deposit_refund_does_not_merge_with_later_withdrawal() {
             deposit_amount,
             common::get_domain(),
             None,
+            None,
             Some(attacker_withdrawal_credentials),
         );
         // Re-target the deposit to the existing validator after signing so signature verification
@@ -964,6 +968,7 @@ fn test_withdrawal_blocked_by_pending_deposit() {
             deposit_amount,
             common::get_domain(),
             Some(key_stores[0].node_key.clone()),
+            Some(key_stores[0].consensus_key.clone()),
             Some(withdrawal_credentials),
         );
 
@@ -1166,6 +1171,7 @@ fn test_deposit_and_withdrawal_same_block() {
             deposit_amount,
             common::get_domain(),
             Some(key_stores[0].node_key.clone()),
+            Some(key_stores[0].consensus_key.clone()),
             Some(withdrawal_credentials),
         );
 

--- a/node/src/tests/execution_requests/deposits.rs
+++ b/node/src/tests/execution_requests/deposits.rs
@@ -61,7 +61,7 @@ fn test_deposit_request_single() {
 
         // Create a single deposit request using the helper
         let (test_deposit, _, _) =
-            common::create_deposit_request(10, min_stake, common::get_domain(), None, None);
+            common::create_deposit_request(10, min_stake, common::get_domain(), None, None, None);
 
         // Convert to ExecutionRequest and then to Requests
         let execution_requests = vec![ExecutionRequest::Deposit(test_deposit.clone())];
@@ -248,13 +248,20 @@ fn test_deposit_request_top_up() {
             .expect("failed to convert genesis hash");
 
         // Create a single deposit request using the helper
-        let (test_deposit1, private_key, _) =
-            common::create_deposit_request(10, minimum_stake, common::get_domain(), None, None);
+        let (test_deposit1, private_key, consensus_key) = common::create_deposit_request(
+            10,
+            minimum_stake,
+            common::get_domain(),
+            None,
+            None,
+            None,
+        );
         let (test_deposit2, _, _) = common::create_deposit_request(
             10,
             8_000_000_000,
             common::get_domain(),
             Some(private_key.clone()),
+            Some(consensus_key.clone()),
             Some(test_deposit1.withdrawal_credentials),
         );
         let (test_deposit3, _, _) = common::create_deposit_request(
@@ -262,6 +269,7 @@ fn test_deposit_request_top_up() {
             1_000_000_000,
             common::get_domain(),
             Some(private_key),
+            Some(consensus_key),
             Some(test_deposit1.withdrawal_credentials),
         );
 
@@ -493,6 +501,7 @@ fn test_deposit_less_than_min_stake_rejected() {
             common::get_domain(),
             None,
             None,
+            None,
         );
 
         let validator_node_key = test_deposit.node_pubkey.clone();
@@ -696,6 +705,7 @@ fn test_deposit_greater_than_max_stake_rejected() {
             common::get_domain(),
             None,
             None,
+            None,
         );
 
         let validator_node_key = test_deposit.node_pubkey.clone();
@@ -877,11 +887,11 @@ fn test_deposit_request_invalid_node_signature() {
 
         // Create deposit request with valid signatures
         let (mut test_deposit, _, _) =
-            common::create_deposit_request(n, min_stake, common::get_domain(), None, None);
+            common::create_deposit_request(n, min_stake, common::get_domain(), None, None, None);
 
         // Create another deposit to get a different node signature
         let (test_deposit2, _, _) =
-            common::create_deposit_request(2, min_stake, common::get_domain(), None, None);
+            common::create_deposit_request(2, min_stake, common::get_domain(), None, None, None);
 
         // Only invalidate the node signature (keep consensus signature valid)
         test_deposit.node_signature = test_deposit2.node_signature;
@@ -1075,11 +1085,11 @@ fn test_deposit_request_invalid_consensus_signature() {
 
         // Create deposit request with valid signatures
         let (mut test_deposit, _, _) =
-            common::create_deposit_request(n, min_stake, common::get_domain(), None, None);
+            common::create_deposit_request(n, min_stake, common::get_domain(), None, None, None);
 
         // Create another deposit to get a different consensus signature
         let (test_deposit2, _, _) =
-            common::create_deposit_request(2, min_stake, common::get_domain(), None, None);
+            common::create_deposit_request(2, min_stake, common::get_domain(), None, None, None);
 
         // Only invalidate the consensus signature (keep node signature valid)
         test_deposit.consensus_signature = test_deposit2.consensus_signature;
@@ -1289,6 +1299,7 @@ fn test_duplicate_deposit_blocked() {
             deposit_amount1,
             common::get_domain(),
             Some(key_stores[0].node_key.clone()),
+            Some(key_stores[0].consensus_key.clone()),
             None,
         );
         let (deposit2, _, _) = common::create_deposit_request(
@@ -1296,8 +1307,12 @@ fn test_duplicate_deposit_blocked() {
             deposit_amount2,
             common::get_domain(),
             Some(key_stores[0].node_key.clone()),
+            Some(key_stores[0].consensus_key.clone()),
             Some(deposit1.withdrawal_credentials),
         );
+        println!("{:?}", deposit1);
+        println!("");
+        println!("{:?}", deposit2);
 
         let validator0_pubkey = validators[0].0.clone();
 
@@ -1399,6 +1414,492 @@ fn test_duplicate_deposit_blocked() {
         // No refund withdrawals should have been created (second deposit was just ignored)
         let withdrawals = engine_client_network.get_withdrawals();
         assert!(withdrawals.is_empty());
+
+        assert!(
+            engine_client_network
+                .verify_consensus(None, Some(stop_height))
+                .is_ok()
+        );
+
+        context.auditor().state()
+    })
+}
+
+/// `verify_deposit_request` must reject a deposit whose `consensus_pubkey`
+/// matches an existing validator account's BLS key under a different node
+/// public key.
+///
+/// Validator accounts are stored keyed by ed25519 node pubkey, so a fresh
+/// node key + a re-used BLS key currently slips past the per-account
+/// duplicate-deposit and signature checks. If that deposit is later
+/// processed and activated, the active validator set contains two distinct
+/// node identities mapped to the same BLS key. Epoch scheme construction
+/// builds a one-to-one `BiMap` from node keys to BLS keys and panics on
+/// duplicate BLS values (`types/src/scheme.rs:109`).
+///
+/// Setup (DEFAULT_BLOCKS_PER_EPOCH = 10, VALIDATOR_NUM_WARM_UP_EPOCHS = 2):
+///  - 5 genesis validators @ 32 ETH with distinct BLS keys.
+///  - Block 5: a deposit signed by a fresh ed25519 node key + reuses
+///    genesis validator 0's BLS private key (i.e. an attacker who controls
+///    that BLS key tries to register a second node identity under the same
+///    BLS key).
+///
+/// Assertions (stop at block 10 — past deposit processing at block 8, but
+/// before the duplicate would be activated at the epoch 1→2 boundary where
+/// scheme construction would panic if the duplicate slipped through):
+///  - No validator account exists at the fresh node pubkey. The deposit was
+///    rejected and refunded; the duplicate never entered the validator set.
+///  - Genesis validator 0 is unaffected.
+#[test_traced("INFO")]
+fn test_duplicate_bls_consensus_key_rejected() {
+    use commonware_codec::Write;
+    use summit_types::execution_request::DepositRequest;
+
+    let n = 5;
+    let min_stake = 32_000_000_000;
+    let new_validator_amount = min_stake;
+    let link = Link {
+        latency: Duration::from_millis(80),
+        jitter: Duration::from_millis(10),
+        success_rate: 0.98,
+    };
+
+    let cfg = deterministic::Config::default().with_seed(0);
+    let executor = Runner::from(cfg);
+    executor.start(|context| async move {
+        let (network, mut oracle) = Network::new(
+            context.with_label("network"),
+            simulated::Config {
+                max_size: 1024 * 1024,
+                disconnect_on_block: false,
+                tracked_peer_sets: NZUsize!(n as usize * 10),
+            },
+        );
+
+        network.start();
+
+        let mut key_stores = Vec::new();
+        let mut validators = Vec::new();
+        for i in 0..n {
+            let mut rng = StdRng::seed_from_u64(i as u64);
+            let node_key = PrivateKey::random(&mut rng);
+            let node_public_key = node_key.public_key();
+            let consensus_key = bls12381::PrivateKey::random(&mut rng);
+            let consensus_public_key = consensus_key.public_key();
+            let key_store = KeyStore {
+                node_key,
+                consensus_key,
+            };
+            key_stores.push(key_store);
+            validators.push((node_public_key, consensus_public_key));
+        }
+        validators.sort_by(|lhs, rhs| lhs.0.cmp(&rhs.0));
+        key_stores.sort_by_key(|ks| ks.node_key.public_key());
+
+        let node_public_keys: Vec<_> = validators.iter().map(|(pk, _)| pk.clone()).collect();
+        let mut registrations = common::register_validators(&oracle, &node_public_keys).await;
+
+        common::link_validators(&mut oracle, &node_public_keys, link, None).await;
+
+        let genesis_hash =
+            from_hex_formatted(common::GENESIS_HASH).expect("failed to decode genesis hash");
+        let genesis_hash: [u8; 32] = genesis_hash
+            .try_into()
+            .expect("failed to convert genesis hash");
+
+        // Build a deposit with a FRESH ed25519 node key but reuse genesis
+        // validator 0's BLS private key as the consensus key. This simulates
+        // an attacker who controls validator 0's BLS private key and is
+        // trying to register a second validator identity under the same BLS
+        // key. Both signatures verify, but the deposit must still be
+        // rejected because the BLS key is already attached to another
+        // validator account.
+        let mut rng = StdRng::seed_from_u64(99_999);
+        let new_node_priv = PrivateKey::random(&mut rng);
+        let new_node_pub = new_node_priv.public_key();
+        let dup_bls_priv = key_stores[0].consensus_key.clone();
+        let dup_bls_pub = dup_bls_priv.public_key();
+        // Sanity: the reused BLS key really is genesis validator 0's.
+        assert_eq!(dup_bls_pub, validators[0].1);
+
+        let mut withdrawal_credentials = [0u8; 32];
+        withdrawal_credentials[0] = 0x01;
+        for j in 0..20 {
+            withdrawal_credentials[12 + j] = (j as u8) ^ 0xAA;
+        }
+
+        let mut deposit = DepositRequest {
+            node_pubkey: new_node_pub.clone(),
+            consensus_pubkey: dup_bls_pub,
+            withdrawal_credentials,
+            amount: new_validator_amount,
+            node_signature: [0u8; 64],
+            consensus_signature: [0u8; 96],
+            index: n as u64,
+        };
+
+        let message = deposit.as_message(common::get_domain());
+
+        let node_sig = new_node_priv.sign(&[], &message);
+        deposit.node_signature.copy_from_slice(node_sig.as_ref());
+
+        let bls_sig = dup_bls_priv.sign(&[], &message);
+        // Encode the BLS signature into the fixed-size signature buffer.
+        let mut bls_sig_buf: Vec<u8> = Vec::new();
+        bls_sig.write(&mut bls_sig_buf);
+        assert_eq!(bls_sig_buf.len(), 96);
+        deposit.consensus_signature.copy_from_slice(&bls_sig_buf);
+
+        let deposit_requests =
+            common::execution_requests_to_requests(vec![ExecutionRequest::Deposit(deposit)]);
+
+        let deposit_block_height = 5;
+        // Stop one block past the end of epoch 0 — deposit processing has
+        // already run at block 8 (penultimate of epoch 0). The duplicate
+        // would be activated at the epoch 1→2 boundary (end of block 19),
+        // at which point scheme construction would panic on the BiMap if
+        // the duplicate slipped through; we deliberately stop before that
+        // so the test fails on the assertion (with the bug) instead of on
+        // a panic in another task.
+        let stop_height = DEFAULT_BLOCKS_PER_EPOCH + 1;
+
+        let mut execution_requests_map = HashMap::new();
+        execution_requests_map.insert(deposit_block_height, deposit_requests);
+
+        let engine_client_network = MockEngineNetworkBuilder::new(genesis_hash)
+            .with_execution_requests(execution_requests_map)
+            .with_stop_at(stop_height)
+            .build();
+        let initial_state = get_initial_state(genesis_hash, &validators, None, None, min_stake);
+
+        let mut public_keys = HashSet::new();
+        let mut consensus_state_queries = HashMap::new();
+        for (idx, key_store) in key_stores.into_iter().enumerate() {
+            let public_key = key_store.node_key.public_key();
+            public_keys.insert(public_key.clone());
+
+            let uid = format!("validator_{public_key}");
+            let namespace = String::from("_SUMMIT");
+
+            let engine_client = engine_client_network.create_client(uid.clone());
+
+            let config = get_default_engine_config(
+                engine_client,
+                SimulatedOracle::new(oracle.clone()),
+                uid.clone(),
+                genesis_hash,
+                namespace,
+                key_store,
+                validators.clone(),
+                initial_state.clone(),
+            );
+            let engine = Engine::new(context.with_label(&uid), config).await;
+            consensus_state_queries.insert(idx, engine.finalizer_mailbox.clone());
+
+            let (pending, recovered, resolver, orchestrator, broadcast) =
+                registrations.remove(&public_key).unwrap();
+
+            engine.start(pending, recovered, resolver, orchestrator, broadcast);
+        }
+
+        let mut height_reached = HashSet::new();
+        loop {
+            let metrics = context.encode();
+            let mut success = false;
+            for line in metrics.lines() {
+                if !line.starts_with("validator_") {
+                    continue;
+                }
+
+                let mut parts = line.split_whitespace();
+                let metric = parts.next().unwrap();
+                let value = parts.next().unwrap();
+
+                if metric.ends_with("finalizer_height") {
+                    let height = value.parse::<u64>().unwrap();
+                    if height >= stop_height {
+                        height_reached.insert(metric.to_string());
+                    }
+                }
+
+                if height_reached.len() as u32 == n {
+                    success = true;
+                    break;
+                }
+            }
+            if success {
+                break;
+            }
+            context.sleep(Duration::from_secs(1)).await;
+        }
+
+        let state_query = consensus_state_queries.get(&0).unwrap();
+
+        // The duplicate-BLS deposit must have been rejected at verification
+        // time — no validator account should exist at the fresh node pubkey.
+        let dup_account = state_query
+            .get_validator_account(new_node_pub.clone())
+            .await;
+        assert!(
+            dup_account.is_none(),
+            "deposit with duplicate BLS consensus key must be rejected and \
+             refunded, otherwise epoch scheme construction will later panic \
+             on the duplicate BLS value; found account = {:?}",
+            dup_account
+        );
+
+        // Genesis validator 0 is unaffected.
+        let v0 = state_query
+            .get_validator_account(validators[0].0.clone())
+            .await
+            .expect("genesis validator 0 should exist");
+        assert_eq!(v0.status, ValidatorStatus::Active);
+        assert_eq!(v0.balance, min_stake);
+
+        assert!(
+            engine_client_network
+                .verify_consensus(None, Some(stop_height))
+                .is_ok()
+        );
+
+        context.auditor().state()
+    })
+}
+
+/// A top-up deposit for an existing validator account must carry the BLS
+/// `consensus_pubkey` already stored on that account. Today
+/// `verify_deposit_request` only checks the deposit's signatures and balance
+/// bounds; the deposit's `consensus_pubkey` field is then silently ignored at
+/// top-up processing time (`finalizer/src/actor.rs:1814` only touches
+/// `balance`), so a top-up signed by the validator's node key but carrying a
+/// fresh BLS keypair credits the validator's balance without any binding
+/// between the deposit and the validator's actual consensus key.
+///
+/// This is defense-in-depth: a top-up should be strictly bound to the
+/// validator identity it's topping up, otherwise the deposit shape and the
+/// account state can drift apart in ways that are hard to reason about
+/// (and that bypass the BLS-uniqueness check exercised by
+/// `test_duplicate_bls_consensus_key_rejected`).
+///
+/// Setup (DEFAULT_BLOCKS_PER_EPOCH = 10):
+///  - 5 genesis validators @ 32 ETH (min_stake = 32 ETH, max_stake = 64 ETH).
+///  - Block 5: top-up deposit for validator 0 worth 8 ETH, signed by
+///    validator 0's node key BUT carrying a freshly-generated BLS keypair as
+///    `consensus_pubkey` (and signed by that fresh BLS key, so the BLS
+///    signature still verifies). The fresh BLS key is not in use by any
+///    existing account.
+///
+/// Assertions (stop at block 10 — past deposit processing at block 8):
+///  - Validator 0's balance is unchanged at 32 ETH. The mismatched top-up
+///    was refunded, not credited.
+///  - Validator 0's stored `consensus_public_key` is still the original
+///    genesis BLS key (the deposit's fresh key never replaced it).
+#[test_traced("INFO")]
+fn test_top_up_deposit_with_mismatched_bls_key_rejected() {
+    use commonware_codec::Write;
+    use summit_types::execution_request::DepositRequest;
+
+    let n = 5;
+    let min_stake = 32_000_000_000;
+    let max_stake = 64_000_000_000;
+    let top_up_amount = 8_000_000_000;
+    let link = Link {
+        latency: Duration::from_millis(80),
+        jitter: Duration::from_millis(10),
+        success_rate: 0.98,
+    };
+
+    let cfg = deterministic::Config::default().with_seed(0);
+    let executor = Runner::from(cfg);
+    executor.start(|context| async move {
+        let (network, mut oracle) = Network::new(
+            context.with_label("network"),
+            simulated::Config {
+                max_size: 1024 * 1024,
+                disconnect_on_block: false,
+                tracked_peer_sets: NZUsize!(n as usize * 10),
+            },
+        );
+
+        network.start();
+
+        let mut key_stores = Vec::new();
+        let mut validators = Vec::new();
+        for i in 0..n {
+            let mut rng = StdRng::seed_from_u64(i as u64);
+            let node_key = PrivateKey::random(&mut rng);
+            let node_public_key = node_key.public_key();
+            let consensus_key = bls12381::PrivateKey::random(&mut rng);
+            let consensus_public_key = consensus_key.public_key();
+            let key_store = KeyStore {
+                node_key,
+                consensus_key,
+            };
+            key_stores.push(key_store);
+            validators.push((node_public_key, consensus_public_key));
+        }
+        validators.sort_by(|lhs, rhs| lhs.0.cmp(&rhs.0));
+        key_stores.sort_by_key(|ks| ks.node_key.public_key());
+
+        let node_public_keys: Vec<_> = validators.iter().map(|(pk, _)| pk.clone()).collect();
+        let mut registrations = common::register_validators(&oracle, &node_public_keys).await;
+
+        common::link_validators(&mut oracle, &node_public_keys, link, None).await;
+
+        let genesis_hash =
+            from_hex_formatted(common::GENESIS_HASH).expect("failed to decode genesis hash");
+        let genesis_hash: [u8; 32] = genesis_hash
+            .try_into()
+            .expect("failed to convert genesis hash");
+
+        // Top-up deposit for validator 0: signed with validator 0's node
+        // private key (correct), but carrying a FRESH BLS keypair as
+        // consensus_pubkey + consensus_signature. Both signatures verify, but
+        // the deposit's BLS key does not match validator 0's stored BLS key.
+        let v0_node_priv = key_stores[0].node_key.clone();
+        let v0_node_pub = v0_node_priv.public_key();
+        let v0_original_bls_pub = validators[0].1.clone();
+
+        let mut rng = StdRng::seed_from_u64(424_242);
+        let fresh_bls_priv = bls12381::PrivateKey::random(&mut rng);
+        let fresh_bls_pub = fresh_bls_priv.public_key();
+        // Sanity: the fresh BLS key isn't already in use, so this deposit
+        // doesn't trip a duplicate-BLS-key check; it must fail purely on the
+        // "doesn't match the existing account's BLS key" check.
+        assert!(validators.iter().all(|(_, bls)| bls != &fresh_bls_pub));
+
+        let mut withdrawal_credentials = [0u8; 32];
+        withdrawal_credentials[0] = 0x01;
+        for j in 0..20 {
+            withdrawal_credentials[12 + j] = j as u8;
+        }
+
+        let mut deposit = DepositRequest {
+            node_pubkey: v0_node_pub.clone(),
+            consensus_pubkey: fresh_bls_pub,
+            withdrawal_credentials,
+            amount: top_up_amount,
+            node_signature: [0u8; 64],
+            consensus_signature: [0u8; 96],
+            index: n as u64,
+        };
+
+        let message = deposit.as_message(common::get_domain());
+
+        let node_sig = v0_node_priv.sign(&[], &message);
+        deposit.node_signature.copy_from_slice(node_sig.as_ref());
+
+        let bls_sig = fresh_bls_priv.sign(&[], &message);
+        let mut bls_sig_buf: Vec<u8> = Vec::new();
+        bls_sig.write(&mut bls_sig_buf);
+        assert_eq!(bls_sig_buf.len(), 96);
+        deposit.consensus_signature.copy_from_slice(&bls_sig_buf);
+
+        let deposit_requests =
+            common::execution_requests_to_requests(vec![ExecutionRequest::Deposit(deposit)]);
+
+        let deposit_block_height = 5;
+        let stop_height = DEFAULT_BLOCKS_PER_EPOCH + 1;
+
+        let mut execution_requests_map = HashMap::new();
+        execution_requests_map.insert(deposit_block_height, deposit_requests);
+
+        let engine_client_network = MockEngineNetworkBuilder::new(genesis_hash)
+            .with_execution_requests(execution_requests_map)
+            .with_stop_at(stop_height)
+            .build();
+        let mut initial_state = get_initial_state(genesis_hash, &validators, None, None, min_stake);
+        // Raise max_stake so that the post-top-up balance (32 + 8 = 40) is
+        // within [min, max]; otherwise the bounds check at deposit
+        // verification refunds the deposit and we wouldn't actually be
+        // exercising the missing "BLS key must match the account's stored
+        // BLS key" check.
+        initial_state.set_maximum_stake(max_stake);
+
+        let mut public_keys = HashSet::new();
+        let mut consensus_state_queries = HashMap::new();
+        for (idx, key_store) in key_stores.into_iter().enumerate() {
+            let public_key = key_store.node_key.public_key();
+            public_keys.insert(public_key.clone());
+
+            let uid = format!("validator_{public_key}");
+            let namespace = String::from("_SUMMIT");
+
+            let engine_client = engine_client_network.create_client(uid.clone());
+
+            let config = get_default_engine_config(
+                engine_client,
+                SimulatedOracle::new(oracle.clone()),
+                uid.clone(),
+                genesis_hash,
+                namespace,
+                key_store,
+                validators.clone(),
+                initial_state.clone(),
+            );
+            let engine = Engine::new(context.with_label(&uid), config).await;
+            consensus_state_queries.insert(idx, engine.finalizer_mailbox.clone());
+
+            let (pending, recovered, resolver, orchestrator, broadcast) =
+                registrations.remove(&public_key).unwrap();
+
+            engine.start(pending, recovered, resolver, orchestrator, broadcast);
+        }
+
+        let mut height_reached = HashSet::new();
+        loop {
+            let metrics = context.encode();
+            let mut success = false;
+            for line in metrics.lines() {
+                if !line.starts_with("validator_") {
+                    continue;
+                }
+
+                let mut parts = line.split_whitespace();
+                let metric = parts.next().unwrap();
+                let value = parts.next().unwrap();
+
+                if metric.ends_with("finalizer_height") {
+                    let height = value.parse::<u64>().unwrap();
+                    if height >= stop_height {
+                        height_reached.insert(metric.to_string());
+                    }
+                }
+
+                if height_reached.len() as u32 == n {
+                    success = true;
+                    break;
+                }
+            }
+            if success {
+                break;
+            }
+            context.sleep(Duration::from_secs(1)).await;
+        }
+
+        let state_query = consensus_state_queries.get(&0).unwrap();
+        let v0 = state_query
+            .get_validator_account(v0_node_pub.clone())
+            .await
+            .expect("validator 0 account should still exist");
+
+        // The mismatched top-up must have been refunded, not credited.
+        // (max_stake is 64 ETH, so 32 + 8 = 40 is within bounds; the bounds
+        // check can't be the reason for rejection.)
+        assert_eq!(
+            v0.balance, min_stake,
+            "validator 0's balance must remain at its genesis 32 ETH; the \
+             top-up carrying a BLS key that does not match the account's \
+             stored BLS key must be refunded, not credited"
+        );
+
+        // The stored BLS key on validator 0's account is unchanged — the
+        // deposit's fresh BLS key never replaces it.
+        assert_eq!(
+            v0.consensus_public_key, v0_original_bls_pub,
+            "validator 0's stored BLS key must not be overwritten by a \
+             top-up deposit carrying a different BLS key"
+        );
 
         assert!(
             engine_client_network

--- a/node/src/tests/execution_requests/protocol_params.rs
+++ b/node/src/tests/execution_requests/protocol_params.rs
@@ -586,6 +586,7 @@ fn test_protocol_param_stake_update_committee() {
                 deposit_amount,
                 common::get_domain(),
                 Some(key_stores[i as usize].node_key.clone()),
+                Some(key_stores[i as usize].consensus_key.clone()),
                 None,
             );
             deposit_requests.push(ExecutionRequest::Deposit(deposit));
@@ -598,6 +599,7 @@ fn test_protocol_param_stake_update_committee() {
             deposit_amount_validator8,
             common::get_domain(),
             Some(key_stores[8].node_key.clone()),
+            Some(key_stores[8].consensus_key.clone()),
             None,
         );
         deposit_requests.push(ExecutionRequest::Deposit(deposit8));

--- a/node/src/tests/execution_requests/validator_set.rs
+++ b/node/src/tests/execution_requests/validator_set.rs
@@ -67,7 +67,7 @@ fn test_added_validators_at_epoch_boundary() {
 
         // Create a deposit request for a new validator
         let (test_deposit, _, _) =
-            common::create_deposit_request(10, min_stake, common::get_domain(), None, None);
+            common::create_deposit_request(10, min_stake, common::get_domain(), None, None, None);
 
         let new_validator_node_key = test_deposit.node_pubkey.clone();
         let new_validator_consensus_key = test_deposit.consensus_pubkey.clone();

--- a/node/src/tests/execution_requests/withdrawals.rs
+++ b/node/src/tests/execution_requests/withdrawals.rs
@@ -58,12 +58,19 @@ fn test_grouped_withdrawal_requests_in_single_eip7685_entry() {
             .try_into()
             .expect("failed to convert genesis hash");
 
-        let (deposit1, _, _) =
-            common::create_deposit_request(n as u64, min_stake, common::get_domain(), None, None);
+        let (deposit1, _, _) = common::create_deposit_request(
+            n as u64,
+            min_stake,
+            common::get_domain(),
+            None,
+            None,
+            None,
+        );
         let (deposit2, _, _) = common::create_deposit_request(
             (n + 1) as u64,
             min_stake,
             common::get_domain(),
+            None,
             None,
             None,
         );
@@ -278,8 +285,14 @@ fn test_partial_withdrawal_balance_below_minimum_stake() {
             .expect("failed to convert genesis hash");
 
         // Create a single deposit request using the helper
-        let (test_deposit, _, _) =
-            common::create_deposit_request(n as u64, min_stake, common::get_domain(), None, None);
+        let (test_deposit, _, _) = common::create_deposit_request(
+            n as u64,
+            min_stake,
+            common::get_domain(),
+            None,
+            None,
+            None,
+        );
 
         let withdrawal_address = Address::from_slice(&test_deposit.withdrawal_credentials[12..32]);
         let test_withdrawal1 = common::create_withdrawal_request(
@@ -1046,8 +1059,14 @@ fn test_withdrawal_during_onboarding_aborts() {
             .expect("failed to convert genesis hash");
 
         // Create a deposit request for a new validator
-        let (test_deposit, _, _) =
-            common::create_deposit_request(n as u64, min_stake, common::get_domain(), None, None);
+        let (test_deposit, _, _) = common::create_deposit_request(
+            n as u64,
+            min_stake,
+            common::get_domain(),
+            None,
+            None,
+            None,
+        );
 
         let new_validator_pubkey: [u8; 32] = test_deposit.node_pubkey.as_ref().try_into().unwrap();
 


### PR DESCRIPTION
This addresses https://github.com/SeismicSystems/summit/issues/174.

Changes:
- Adds checks to ensure that a new joining validator can re-use an existing BLS key.
- Adds an e2e test `test_duplicate_bls_consensus_key_rejected` that verifies that a deposit request with a duplicate BLS key is rejected.
- Adds checks to ensure that a top-up deposit from an existing validator uses the same BLS key as the initial deposit.
- Adds an e2e test `test_top_up_deposit_with_mismatched_bls_key_rejected` that verifies that a top-up deposit with a different BLS key is rejected.