### PR TITLE
fix: buffer blocks in finalizer when EL is syncing without blocking main loop

### DIFF
--- a/finalizer/src/actor.rs
+++ b/finalizer/src/actor.rs
@@ -282,40 +282,73 @@ impl<
             }))
             .await;
 
-        // Send initial forkchoice to the execution client so it knows the chain
-        // head and can start P2P sync. Then wait for sync to complete before
-        // replaying any blocks. Without this, catch-up blocks fail because the
-        // execution client doesn't have them yet.
+        // Send initial forkchoice to the execution client so it knows the
+        // chain head and can start P2P sync.
+        // We do not block the actor here waiting for SYNCING to resolve.
+        //
+        // If the EL is still SYNCING, we fall through and enter the main
+        // mailbox loop immediately. The first finalized or notarized block
+        // we receive goes through `execute_block`, whose own SYNCING-aware
+        // retry path absorbs the catch-up window. Meanwhile the actor
+        // remains responsive to RPC/aux-data queries against the
+        // checkpoint-loaded `canonical_state`, and to cancellation /
+        // runtime-stop signals.
         {
             let forkchoice = self.canonical_state.get_forkchoice();
             if !forkchoice.head_block_hash.is_zero() {
                 info!(
                     head = %forkchoice.head_block_hash,
-                    "sending initial forkchoice update to execution client, waiting for sync..."
+                    "sending initial forkchoice update to execution client"
                 );
-                loop {
-                    let status = match self.engine_client.commit_hash(*forkchoice).await {
-                        Ok(status) => status,
-                        Err(e) => {
-                            error!(target: "critical", "engine client error on initial forkchoice update: {e}");
-                            #[cfg(feature = "prom")]
-                            counter!("critical_errors_total", "reason" => "engine_client_error", "severity" => "critical")
-                                .increment(1);
-                            self.cancellation_token.cancel();
-                            return;
-                        }
-                    };
-                    if status.is_valid() {
-                        info!("execution client synced to checkpoint head, ready to replay blocks");
-                        break;
-                    } else if status.is_syncing() {
-                        warn!("execution client still syncing, waiting 5s...");
-                        self.context.sleep(Duration::from_secs(5)).await;
-                    } else {
-                        error!(target: "critical", "finalizer started with invalid forkchoice: {forkchoice:?}, height: {}, epoch: {}", self.canonical_state.get_latest_height(), self.canonical_state.get_epoch());
+                match self.engine_client.commit_hash(*forkchoice).await {
+                    Ok(status) if status.is_valid() => {
+                        info!(
+                            "execution client already synced to checkpoint head, \
+                             ready to replay blocks"
+                        );
+                    }
+                    Ok(status) if status.is_syncing() => {
+                        warn!(
+                            "execution client SYNCING toward checkpoint head; \
+                             entering main loop now, block-application retries \
+                             will cover the catch-up window"
+                        );
+                    }
+                    Ok(status) => {
+                        // INVALID (or any non-Valid/Syncing PayloadStatus) is
+                        // a critical mismatch. The checkpoint head is not a
+                        // valid block on the EL side. This validator cannot
+                        // safely continue.
+                        error!(
+                            target: "critical",
+                            ?forkchoice,
+                            ?status,
+                            height = self.canonical_state.get_latest_height(),
+                            epoch = self.canonical_state.get_epoch(),
+                            "finalizer started with invalid forkchoice"
+                        );
                         #[cfg(feature = "prom")]
-                        counter!("critical_errors_total", "reason" => "invalid_forkchoice", "severity" => "critical")
-                            .increment(1);
+                        counter!(
+                            "critical_errors_total",
+                            "reason" => "invalid_forkchoice",
+                            "severity" => "critical"
+                        )
+                        .increment(1);
+                        self.cancellation_token.cancel();
+                        return;
+                    }
+                    Err(e) => {
+                        error!(
+                            target: "critical",
+                            "engine client error on initial forkchoice update: {e}"
+                        );
+                        #[cfg(feature = "prom")]
+                        counter!(
+                            "critical_errors_total",
+                            "reason" => "engine_client_error",
+                            "severity" => "critical"
+                        )
+                        .increment(1);
                         self.cancellation_token.cancel();
                         return;
                     }

--- a/finalizer/src/actor.rs
+++ b/finalizer/src/actor.rs
@@ -191,6 +191,8 @@ pub struct Finalizer<
     // FIFO; each entry is retried independently because forks have independent
     // parent states which are re-resolved by `handle_notarized_block` on drain.
     pending_notarized: VecDeque<PendingNotarized>,
+    // Membership set for deduping `pending_notarized` by block digest.
+    pending_notarized_keys: HashSet<Digest>,
 
     // Whether either buffer has crossed the warn threshold since the last
     // time it was empty. Edge-triggered to avoid log spam on every tick.
@@ -202,6 +204,8 @@ pub struct Finalizer<
     // Soft threshold for emitting a warn log when either pending buffer grows.
     // No cap is enforced; observability only.
     buffered_blocks_warn_threshold: usize,
+    // Hard cap for unique deferred notarized blocks while the EL is SYNCING.
+    pending_notarized_max: usize,
 
     genesis_hash: [u8; 32],
     protocol_consts: ProtocolConsts,
@@ -307,9 +311,11 @@ impl<
                 orphaned_blocks: BTreeMap::new(),
                 pending_finalized: VecDeque::new(),
                 pending_notarized: VecDeque::new(),
+                pending_notarized_keys: HashSet::new(),
                 pending_warn_active: false,
                 drain_interval: cfg.drain_interval,
                 buffered_blocks_warn_threshold: cfg.buffered_blocks_warn_threshold,
+                pending_notarized_max: cfg.pending_notarized_max,
                 genesis_hash: cfg.genesis_hash,
                 protocol_consts: cfg.protocol_consts,
                 protocol_version_digest: Sha256::hash(&cfg.protocol_version.to_le_bytes()),
@@ -1106,11 +1112,37 @@ impl<
                         ?block_digest,
                         "deferring notarized block: execution layer is SYNCING"
                     );
-                    self.pending_notarized.push_back(PendingNotarized {
-                        block,
-                        first_attempt_at: Instant::now(),
-                    });
-                    self.update_pending_warn();
+                    if self.pending_notarized_keys.contains(&block_digest) {
+                        debug!(
+                            height,
+                            ?block_digest,
+                            "notarized block already pending while EL is SYNCING"
+                        );
+                    } else if self.pending_notarized.len() >= self.pending_notarized_max {
+                        error!(
+                            target: "critical",
+                            height,
+                            ?block_digest,
+                            pending_notarized = self.pending_notarized.len(),
+                            pending_notarized_max = self.pending_notarized_max,
+                            "pending notarized buffer reached hard cap while execution layer is SYNCING"
+                        );
+                        #[cfg(feature = "prom")]
+                        counter!("critical_errors_total", "reason" => "pending_notarized_cap", "severity" => "critical")
+                            .increment(1);
+                        return Err(anyhow!(
+                            "pending notarized buffer reached hard cap {} while executing block at height {}",
+                            self.pending_notarized_max,
+                            height
+                        ));
+                    } else {
+                        self.pending_notarized_keys.insert(block_digest);
+                        self.pending_notarized.push_back(PendingNotarized {
+                            block,
+                            first_attempt_at: Instant::now(),
+                        });
+                        self.update_pending_warn();
+                    }
                     outcome = HandleOutcome::Buffered(());
                     // The next block in `to_process` will be processed.
                     // Potential orphaned children of the current block won't
@@ -1221,6 +1253,8 @@ impl<
         }
 
         while let Some(entry) = self.pending_notarized.pop_front() {
+            let block_digest = entry.block.digest();
+            self.pending_notarized_keys.remove(&block_digest);
             match self.handle_notarized_block(entry.block).await? {
                 HandleOutcome::Applied => continue,
                 HandleOutcome::Buffered(()) => {

--- a/finalizer/src/actor.rs
+++ b/finalizer/src/actor.rs
@@ -23,7 +23,7 @@ use metrics::{counter, histogram};
 #[cfg(debug_assertions)]
 use prometheus_client::metrics::gauge::Gauge;
 use rand::Rng;
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
 use std::marker::PhantomData;
 use std::num::NonZero;
 use std::time::{Duration, Instant};
@@ -105,6 +105,62 @@ struct ForkState {
     consensus_state: ConsensusState,
 }
 
+/// Result of attempting to apply a block to the execution layer.
+#[derive(Debug)]
+enum ExecuteOutcome {
+    /// The EL accepted the payload and `state` has been advanced.
+    Applied,
+    /// The EL rejected the payload as invalid. `state` is unchanged.
+    /// Caller decides the policy (discard a notarized fork, shut down on a finalized block).
+    InvalidPayload,
+    /// The EL returned SYNCING. `state` is unchanged. Caller must buffer the
+    /// block and retry later.
+    Syncing,
+}
+
+/// Result of a single attempt to handle a notarized or finalized block.
+///
+/// Critical errors that should shut the validator down are returned as
+/// `Err(anyhow)` and are not represented here.
+///
+/// The type parameter `E` carries the deferred entry back to the caller on
+/// `Buffered`. The finalized handler uses `E = PendingFinalized<V>` so the
+/// caller can place the entry at the correct end of the buffer (drain →
+/// push_front to preserve height order; mailbox → push_back). The notarized
+/// handler uses `E = ()` and pushes internally. The `orphaned_blocks`
+/// mechanism re-resolves out-of-order dependencies on its own.
+#[derive(Debug)]
+enum HandleOutcome<E = ()> {
+    /// The block was applied (or correctly discarded as an outdated / dead-fork
+    /// block). No further attempt is needed.
+    Applied,
+    /// The execution layer returned SYNCING. The caller must re-queue the
+    /// carried entry (finalized) or knows the handler already did (notarized).
+    Buffered(E),
+}
+
+/// A finalized block waiting for the execution layer to finish SYNCING.
+struct PendingFinalized<V: Variant> {
+    block: Block,
+    finalization: Option<
+        Finalization<bls12381_multisig::Scheme<PublicKey, V>, <Block as Digestible>::Digest>,
+    >,
+    ack: Exact,
+    /// When the entry was first enqueued. Observability only — not used for bounding.
+    first_attempt_at: Instant,
+}
+
+/// A notarized block waiting for the execution layer to finish SYNCING.
+///
+/// We deliberately do not capture the parent's consensus state here. The drain
+/// path re-invokes `handle_notarized_block`, which re-resolves the parent from
+/// the current canonical / fork state.
+struct PendingNotarized {
+    block: Block,
+    /// When the entry was first enqueued. Observability only.
+    first_attempt_at: Instant,
+}
+
 pub struct Finalizer<
     R: Storage + Metrics + Clock + Spawner + governor::clock::Clock + Rng,
     C: EngineClient,
@@ -126,6 +182,26 @@ pub struct Finalizer<
 
     // Orphaned notarized blocks that arrived before their parent
     orphaned_blocks: BTreeMap<u64, HashMap<Digest, Vec<Block>>>,
+
+    // Finalized blocks deferred because the EL returned SYNCING.
+    // FIFO, drained in arrival (= height) order by `drain_pending`.
+    pending_finalized: VecDeque<PendingFinalized<V>>,
+
+    // Notarized blocks deferred because the EL returned SYNCING.
+    // FIFO; each entry is retried independently because forks have independent
+    // parent states which are re-resolved by `handle_notarized_block` on drain.
+    pending_notarized: VecDeque<PendingNotarized>,
+
+    // Whether either buffer has crossed the warn threshold since the last
+    // time it was empty. Edge-triggered to avoid log spam on every tick.
+    pending_warn_active: bool,
+
+    // How often `drain_pending` runs while the EL is recovering from SYNCING.
+    drain_interval: Duration,
+
+    // Soft threshold for emitting a warn log when either pending buffer grows.
+    // No cap is enforced; observability only.
+    buffered_blocks_warn_threshold: usize,
 
     genesis_hash: [u8; 32],
     protocol_consts: ProtocolConsts,
@@ -229,6 +305,11 @@ impl<
                 canonical_state: state.clone(),
                 fork_states: BTreeMap::new(),
                 orphaned_blocks: BTreeMap::new(),
+                pending_finalized: VecDeque::new(),
+                pending_notarized: VecDeque::new(),
+                pending_warn_active: false,
+                drain_interval: cfg.drain_interval,
+                buffered_blocks_warn_threshold: cfg.buffered_blocks_warn_threshold,
                 genesis_hash: cfg.genesis_hash,
                 protocol_consts: cfg.protocol_consts,
                 protocol_version_digest: Sha256::hash(&cfg.protocol_version.to_le_bytes()),
@@ -378,14 +459,43 @@ impl<
                                     // I don't think we need this
                                 }
                                 Update::FinalizedBlock((block, finalization), ack_tx) => {
-                                    if let Err(err) = self.handle_finalized_block(ack_tx, block, finalization, &mut orchestrator_mailbox, &mut last_committed_timestamp).await {
+                                    let entry = PendingFinalized {
+                                        block,
+                                        finalization,
+                                        ack: ack_tx,
+                                        first_attempt_at: Instant::now(),
+                                    };
+                                    // Preserve arrival order: if there are
+                                    // already buffered finalized blocks, the
+                                    // EL won't make progress on this one
+                                    // either. Enqueue without attempting,
+                                    // both to avoid a wasted check_payload
+                                    // and to keep the buffer in height order.
+                                    if !self.pending_finalized.is_empty() {
+                                        self.pending_finalized.push_back(entry);
+                                        self.update_pending_warn();
+                                    } else {
+                                        match self.handle_finalized_block(entry, &mut orchestrator_mailbox, &mut last_committed_timestamp).await {
+                                            Ok(HandleOutcome::Applied) => {}
+                                            Ok(HandleOutcome::Buffered(entry)) => {
+                                                // First-time arrival; buffer was empty so push_back is correct.
+                                                self.pending_finalized.push_back(entry);
+                                                self.update_pending_warn();
+                                            }
+                                            Err(err) => {
+                                                info!(?err, "finalizer triggering graceful shutdown");
+                                                self.cancellation_token.cancel();
+                                                break;
+                                            }
+                                        }
+                                    }
+                                }
+                                Update::NotarizedBlock(block) => {
+                                    if let Err(err) = self.handle_notarized_block(block).await {
                                         info!(?err, "finalizer triggering graceful shutdown");
                                         self.cancellation_token.cancel();
                                         break;
                                     }
-                                }
-                                Update::NotarizedBlock(block) => {
-                                    self.handle_notarized_block(block).await;
                                 }
                             }
                         },
@@ -452,6 +562,14 @@ impl<
                         },
                     }
                 }
+                _ = self.context.sleep(self.drain_interval).fuse() => {
+                    // Retry blocks that were deferred because the EL was SYNCING.
+                    if let Err(err) = self.drain_pending(&mut orchestrator_mailbox, &mut last_committed_timestamp).await {
+                        info!(?err, "finalizer triggering graceful shutdown");
+                        self.cancellation_token.cancel();
+                        break;
+                    }
+                }
                 _ = cancellation_token.cancelled().fuse() => {
                     info!("finalizer received cancellation signal, exiting");
                     break;
@@ -467,14 +585,16 @@ impl<
     #[allow(clippy::type_complexity)]
     async fn handle_finalized_block(
         &mut self,
-        ack_tx: Exact,
-        block: Block,
-        finalization: Option<
-            Finalization<bls12381_multisig::Scheme<PublicKey, V>, <Block as Digestible>::Digest>,
-        >,
+        entry: PendingFinalized<V>,
         orchestrator_mailbox: &mut summit_orchestrator::Mailbox,
         #[allow(unused_variables)] last_committed_timestamp: &mut Option<Instant>,
-    ) -> Result<()> {
+    ) -> Result<HandleOutcome<PendingFinalized<V>>> {
+        let PendingFinalized {
+            block,
+            finalization,
+            ack: ack_tx,
+            first_attempt_at,
+        } = entry;
         let height = block.height();
         let block_digest = block.digest();
 
@@ -504,7 +624,7 @@ impl<
                 ?block_digest,
                 "executing finalized block directly (no prior fork state)"
             );
-            let executed = match execute_block(
+            let outcome = match execute_block(
                 &mut self.engine_client,
                 &self.context,
                 &block,
@@ -514,40 +634,59 @@ impl<
             )
             .await
             {
-                Ok(executed) => executed,
+                Ok(outcome) => outcome,
                 Err(e) => {
                     error!(target: "critical", height, "engine client error while executing finalized block: {e}");
                     #[cfg(feature = "prom")]
                     counter!("critical_errors_total", "reason" => "engine_client_error", "severity" => "critical")
                         .increment(1);
-                    self.cancellation_token.cancel();
                     return Err(anyhow!(
                         "engine client error while executing finalized block at height {height}: {e}"
                     ));
                 }
             };
-            if !executed {
-                // Network finalized a block whose payload the local Reth instance rejects. Either
-                // Reth has diverged (bug, corruption, restart loss) or a byzantine
-                // quorum certified an invalid payload. In either case, this validator
-                // cannot continue safely.
-                error!(
-                    target: "critical",
-                    height,
-                    ?block_digest,
-                    "finalized block payload rejected by execution client"
-                );
-                #[cfg(feature = "prom")]
-                counter!(
-                    "critical_errors_total",
-                    "reason" => "finalized_block_invalid",
-                    "severity" => "critical"
-                )
-                .increment(1);
-                return Err(anyhow!(
-                    "finalized block at height {height} with digest {block_digest:?} \
-                     was rejected by the execution client"
-                ));
+            match outcome {
+                ExecuteOutcome::Applied => {}
+                ExecuteOutcome::Syncing => {
+                    // The EL is still catching up. Return the entry to the
+                    // caller; the caller decides where in `pending_finalized`
+                    // it goes. Drain re-pushes to the front to preserve
+                    // arrival order, mailbox pushes to the back.
+                    debug!(
+                        height,
+                        ?block_digest,
+                        "deferring finalized block: execution layer is SYNCING"
+                    );
+                    return Ok(HandleOutcome::Buffered(PendingFinalized {
+                        block,
+                        finalization,
+                        ack: ack_tx,
+                        first_attempt_at,
+                    }));
+                }
+                ExecuteOutcome::InvalidPayload => {
+                    // Network finalized a block whose payload the local Reth instance rejects. Either
+                    // Reth has diverged (bug, corruption, restart loss) or a byzantine
+                    // quorum certified an invalid payload. In either case, this validator
+                    // cannot continue safely.
+                    error!(
+                        target: "critical",
+                        height,
+                        ?block_digest,
+                        "finalized block payload rejected by execution client"
+                    );
+                    #[cfg(feature = "prom")]
+                    counter!(
+                        "critical_errors_total",
+                        "reason" => "finalized_block_invalid",
+                        "severity" => "critical"
+                    )
+                    .increment(1);
+                    return Err(anyhow!(
+                        "finalized block at height {height} with digest {block_digest:?} \
+                         was rejected by the execution client"
+                    ));
+                }
             }
         }
 
@@ -589,7 +728,6 @@ impl<
             #[cfg(feature = "prom")]
             counter!("critical_errors_total", "reason" => "engine_client_error", "severity" => "critical")
                 .increment(1);
-            self.cancellation_token.cancel();
             return Err(anyhow!("engine client error on canonical commit_hash: {e}"));
         }
 
@@ -842,14 +980,21 @@ impl<
                 "re-adopting orphaned blocks after finalization"
             );
             for child in children {
-                self.handle_notarized_block(child).await;
+                // Propagate engine-client errors as critical shutdown; Buffered
+                // is fine to ignore — the child is in `pending_notarized` now
+                // and the drain timer will retry it.
+                self.handle_notarized_block(child).await?;
             }
         }
-        Ok(())
+        Ok(HandleOutcome::Applied)
     }
 
-    async fn handle_notarized_block(&mut self, block: Block) {
+    async fn handle_notarized_block(&mut self, block: Block) -> Result<HandleOutcome> {
         let mut to_process = vec![block];
+        // If any iteration defers a block because the EL is SYNCING, signal
+        // `Buffered` so callers (including the drain timer) know to stop
+        // burning further attempts against the same SYNCING EL.
+        let mut outcome: HandleOutcome = HandleOutcome::Applied;
 
         while let Some(block) = to_process.pop() {
             let height = block.height();
@@ -932,7 +1077,7 @@ impl<
             // discard the block: certify will reject it on every honest validator, no
             // certify quorum will form, and no descendant can build on it (find_parent
             // gates on certified). The fork is dead; skip fork-state creation.
-            let executed = match execute_block(
+            let exec_outcome = match execute_block(
                 &mut self.engine_client,
                 &self.context,
                 &block,
@@ -942,25 +1087,47 @@ impl<
             )
             .await
             {
-                Ok(executed) => executed,
+                Ok(o) => o,
                 Err(e) => {
                     error!(target: "critical", height, ?block_digest, "engine client error while executing notarized block: {e}");
                     #[cfg(feature = "prom")]
                     counter!("critical_errors_total", "reason" => "engine_client_error", "severity" => "critical")
                         .increment(1);
-                    self.cancellation_token.cancel();
-                    return;
+                    return Err(anyhow!(
+                        "engine client error while executing notarized block at height {height}: {e}"
+                    ));
                 }
             };
-            if !executed {
-                warn!(
-                    height,
-                    ?block_digest,
-                    "discarding notarized block with invalid payload"
-                );
-                #[cfg(feature = "prom")]
-                counter!("notarized_block_invalid_total").increment(1);
-                continue;
+            match exec_outcome {
+                ExecuteOutcome::Applied => {}
+                ExecuteOutcome::Syncing => {
+                    debug!(
+                        height,
+                        ?block_digest,
+                        "deferring notarized block: execution layer is SYNCING"
+                    );
+                    self.pending_notarized.push_back(PendingNotarized {
+                        block,
+                        first_attempt_at: Instant::now(),
+                    });
+                    self.update_pending_warn();
+                    outcome = HandleOutcome::Buffered(());
+                    // The next block in `to_process` will be processed.
+                    // Potential orphaned children of the current block won't
+                    // be added to `to_process`, since the current block has to be
+                    // executed before them.
+                    continue;
+                }
+                ExecuteOutcome::InvalidPayload => {
+                    warn!(
+                        height,
+                        ?block_digest,
+                        "discarding notarized block with invalid payload"
+                    );
+                    #[cfg(feature = "prom")]
+                    counter!("notarized_block_invalid_total").increment(1);
+                    continue;
+                }
             }
 
             // Store the new fork state
@@ -984,8 +1151,9 @@ impl<
                 #[cfg(feature = "prom")]
                 counter!("critical_errors_total", "reason" => "engine_client_error", "severity" => "critical")
                     .increment(1);
-                self.cancellation_token.cancel();
-                return;
+                return Err(anyhow!(
+                    "engine client error on fork commit_hash at height {height}: {e}"
+                ));
             }
 
             let total_fork_count: usize = self.fork_states.values().map(|f| f.len()).sum();
@@ -1016,6 +1184,97 @@ impl<
                 );
                 to_process.extend(children.clone());
             }
+        }
+
+        Ok(outcome)
+    }
+
+    /// Retry any finalized / notarized blocks that were deferred because the
+    /// execution layer returned SYNCING. Called from the `drain_interval`
+    /// timer arm of the main `select!`.
+    ///
+    /// Finalized blocks must drain in arrival (= height) order, so we stop at
+    /// the first re-buffered entry. Notarized blocks go through the same EL;
+    /// once one of them re-buffers, we know the EL is still SYNCING and stop.
+    async fn drain_pending(
+        &mut self,
+        orchestrator_mailbox: &mut summit_orchestrator::Mailbox,
+        last_committed_timestamp: &mut Option<Instant>,
+    ) -> Result<()> {
+        while let Some(entry) = self.pending_finalized.pop_front() {
+            match self
+                .handle_finalized_block(entry, orchestrator_mailbox, last_committed_timestamp)
+                .await?
+            {
+                HandleOutcome::Applied => continue,
+                HandleOutcome::Buffered(entry) => {
+                    // EL is still SYNCING. Put the entry back at the FRONT
+                    // so the buffer stays in arrival (= height) order. Don't
+                    // try further finalized entries (they require this one
+                    // applied first) and don't try notarized entries (same
+                    // EL, same answer).
+                    self.pending_finalized.push_front(entry);
+                    self.update_pending_warn();
+                    return Ok(());
+                }
+            }
+        }
+
+        while let Some(entry) = self.pending_notarized.pop_front() {
+            match self.handle_notarized_block(entry.block).await? {
+                HandleOutcome::Applied => continue,
+                HandleOutcome::Buffered(()) => {
+                    self.update_pending_warn();
+                    return Ok(());
+                }
+            }
+        }
+
+        // Drained both buffers cleanly. Allow the warn to fire again if a
+        // subsequent SYNCING window pushes the buffer back over the threshold.
+        self.update_pending_warn();
+        Ok(())
+    }
+
+    /// Emit gauges for the pending-buffer sizes and edge-trigger a warn log
+    /// when either crosses `buffered_blocks_warn_threshold` (once per crossing,
+    /// not every tick).
+    fn update_pending_warn(&mut self) {
+        let finalized_len = self.pending_finalized.len();
+        let notarized_len = self.pending_notarized.len();
+
+        #[cfg(feature = "prom")]
+        {
+            metrics::gauge!("pending_finalized_blocks").set(finalized_len as f64);
+            metrics::gauge!("pending_notarized_blocks").set(notarized_len as f64);
+        }
+
+        let over_threshold = finalized_len >= self.buffered_blocks_warn_threshold
+            || notarized_len >= self.buffered_blocks_warn_threshold;
+        if over_threshold && !self.pending_warn_active {
+            // Age of the oldest buffered entry — gives the operator a sense
+            // of "how long has the EL been stuck" alongside the count.
+            let now = Instant::now();
+            let oldest_finalized_age_secs = self
+                .pending_finalized
+                .front()
+                .map(|e| now.saturating_duration_since(e.first_attempt_at).as_secs());
+            let oldest_notarized_age_secs = self
+                .pending_notarized
+                .front()
+                .map(|e| now.saturating_duration_since(e.first_attempt_at).as_secs());
+            warn!(
+                pending_finalized = finalized_len,
+                pending_notarized = notarized_len,
+                ?oldest_finalized_age_secs,
+                ?oldest_notarized_age_secs,
+                threshold = self.buffered_blocks_warn_threshold,
+                "execution-layer SYNCING is backing up the finalizer buffer"
+            );
+            self.pending_warn_active = true;
+        } else if !over_threshold && self.pending_warn_active {
+            // Edge-reset so a subsequent crossing fires the warn again.
+            self.pending_warn_active = false;
         }
     }
 
@@ -1481,12 +1740,16 @@ impl<
 /// Core execution logic that applies a block's state transitions to any ConsensusState.
 ///
 /// This method:
-/// - Calls check_payload on the engine client to validate the block on the EVM.
-/// - On invalid payload, returns `false` without mutating `state`. The caller decides
-///   the policy (discard a notarized fork, shut down on a finalized block, etc.).
-/// - On valid payload: applies consensus-layer state transitions (deposits, withdrawals,
+/// - Calls `check_payload` on the engine client to validate the block on the EVM.
+/// - On `SYNCING`: returns `ExecuteOutcome::Syncing` *without mutating `state`*. The
+///   caller is responsible for buffering the block and retrying later — looping inline
+///   here would starve the finalizer's mailbox.
+/// - On `INVALID` (or any other non-`VALID` payload status that isn't `SYNCING`):
+///   returns `ExecuteOutcome::InvalidPayload` without mutating `state`. The caller
+///   decides the policy (discard a notarized fork, shut down on a finalized block).
+/// - On `VALID`: applies consensus-layer state transitions (deposits, withdrawals,
 ///   validators), updates the forkchoice head, creates checkpoints at epoch boundaries,
-///   and returns `true`.
+///   and returns `ExecuteOutcome::Applied`.
 ///
 /// This does NOT handle epoch transitions (activate validators, increment epoch).
 /// Epoch transitions only happen at finalization since the last block of an epoch
@@ -1501,27 +1764,14 @@ async fn execute_block<
     state: &mut ConsensusState,
     consts: &ProtocolConsts,
     protocol_version_digest: Digest,
-) -> Result<bool, summit_types::EngineClientError> {
+) -> Result<ExecuteOutcome, summit_types::EngineClientError> {
     #[cfg(feature = "prom")]
     let block_processing_start = Instant::now();
 
     // check the payload
     #[cfg(feature = "prom")]
     let payload_check_start = Instant::now();
-    let payload_status = loop {
-        let status = engine_client.check_payload(block).await?;
-
-        if status.is_syncing() {
-            error!(
-                height = block.height(),
-                "execution client returned SYNCING, sending forkchoice update to trigger sync and retrying..."
-            );
-
-            context.sleep(Duration::from_secs(5)).await;
-            continue;
-        }
-        break status;
-    };
+    let payload_status = engine_client.check_payload(block).await?;
 
     let new_height = block.height();
 
@@ -1531,10 +1781,20 @@ async fn execute_block<
         histogram!("payload_check_duration_millis").record(payload_check_duration);
     }
 
+    // The EL is still catching up. Don't mutate `state`; the caller buffers and
+    // we'll retry on the next drain tick.
+    if payload_status.is_syncing() {
+        debug!(
+            height = new_height,
+            "execution client returned SYNCING; deferring block for later retry"
+        );
+        return Ok(ExecuteOutcome::Syncing);
+    }
+
     // Validate block against execution layer state
     // Note: withdrawals are validated in the application layer before voting
     if !payload_status.is_valid() {
-        return Ok(false);
+        return Ok(ExecuteOutcome::InvalidPayload);
     }
 
     let eth_hash = block.eth_block_hash();
@@ -1626,7 +1886,7 @@ async fn execute_block<
     let el_block_number = block.payload.payload_inner.payload_inner.block_number;
     state.capture_state_root(el_block_number);
 
-    Ok(true)
+    Ok(ExecuteOutcome::Applied)
 }
 
 async fn parse_execution_requests<

--- a/finalizer/src/config.rs
+++ b/finalizer/src/config.rs
@@ -36,5 +36,8 @@ pub struct FinalizerConfig<C: EngineClient, O: NetworkOracle<PublicKey>, V: Vari
     /// finalized or pending notarized buffer crosses this threshold, the
     /// finalizer emits a warn log (edge-triggered, once per crossing).
     pub buffered_blocks_warn_threshold: usize,
+    /// Hard cap for unique deferred notarized blocks while the execution
+    /// layer is SYNCING. Reaching this limit triggers graceful shutdown.
+    pub pending_notarized_max: usize,
     pub _variant_marker: PhantomData<V>,
 }

--- a/finalizer/src/config.rs
+++ b/finalizer/src/config.rs
@@ -1,6 +1,7 @@
 use commonware_cryptography::bls12381::primitives::variant::Variant;
 use commonware_runtime::buffer::paged::CacheRef;
 use std::marker::PhantomData;
+use std::time::Duration;
 use summit_types::network_oracle::NetworkOracle;
 use summit_types::{EngineClient, PublicKey, consensus_state::ConsensusState};
 use tokio_util::sync::CancellationToken;
@@ -28,5 +29,12 @@ pub struct FinalizerConfig<C: EngineClient, O: NetworkOracle<PublicKey>, V: Vari
     /// The node's own public key
     pub node_public_key: PublicKey,
     pub cancellation_token: CancellationToken,
+    /// How often the finalizer retries applying buffered blocks while the
+    /// execution layer is recovering from SYNCING.
+    pub drain_interval: Duration,
+    /// Soft threshold for the SYNCING-buffer size. When either the pending
+    /// finalized or pending notarized buffer crosses this threshold, the
+    /// finalizer emits a warn log (edge-triggered, once per crossing).
+    pub buffered_blocks_warn_threshold: usize,
     pub _variant_marker: PhantomData<V>,
 }

--- a/finalizer/src/tests/fork_handling.rs
+++ b/finalizer/src/tests/fork_handling.rs
@@ -57,7 +57,7 @@ fn create_test_block(parent_digest: Digest, height: u64, view: u64, unique_seed:
                 state_root: Default::default(),
                 transactions: Vec::new(),
             },
-            withdrawals: Vec::new().into(),
+            withdrawals: Vec::new(),
         },
         blob_gas_used: 0,
         excess_blob_gas: 0,
@@ -163,6 +163,8 @@ fn test_orphaned_block_processed_when_parent_arrives() {
             protocol_version: 1,
             node_public_key: node_key.public_key(),
             cancellation_token: CancellationToken::new(),
+            drain_interval: Duration::from_millis(100),
+            buffered_blocks_warn_threshold: 100,
             _variant_marker: PhantomData,
         };
 
@@ -244,6 +246,8 @@ fn test_multiple_forks_tracked() {
             protocol_version: 1,
             node_public_key: node_key.public_key(),
             cancellation_token: CancellationToken::new(),
+            drain_interval: Duration::from_millis(100),
+            buffered_blocks_warn_threshold: 100,
             _variant_marker: PhantomData,
         };
 
@@ -326,6 +330,8 @@ fn test_dead_fork_block_discarded() {
             protocol_version: 1,
             node_public_key: node_key.public_key(),
             cancellation_token: CancellationToken::new(),
+            drain_interval: Duration::from_millis(100),
+            buffered_blocks_warn_threshold: 100,
             _variant_marker: PhantomData,
         };
 
@@ -424,6 +430,8 @@ fn test_fork_states_pruned_after_finalization() {
             protocol_version: 1,
             node_public_key: node_key.public_key(),
             cancellation_token: CancellationToken::new(),
+            drain_interval: Duration::from_millis(100),
+            buffered_blocks_warn_threshold: 100,
             _variant_marker: PhantomData,
         };
 
@@ -541,6 +549,8 @@ fn test_orphaned_blocks_pruned_after_finalization() {
             protocol_version: 1,
             node_public_key: node_key.public_key(),
             cancellation_token: CancellationToken::new(),
+            drain_interval: Duration::from_millis(100),
+            buffered_blocks_warn_threshold: 100,
             _variant_marker: PhantomData,
         };
 
@@ -650,6 +660,8 @@ fn test_fork_state_reused_when_notarized_then_finalized() {
             protocol_version: 1,
             node_public_key: node_key.public_key(),
             cancellation_token: CancellationToken::new(),
+            drain_interval: Duration::from_millis(100),
+            buffered_blocks_warn_threshold: 100,
             _variant_marker: PhantomData,
         };
 
@@ -755,6 +767,8 @@ fn test_competing_fork_pruned_on_finalization() {
             protocol_version: 1,
             node_public_key: node_key.public_key(),
             cancellation_token: CancellationToken::new(),
+            drain_interval: Duration::from_millis(100),
+            buffered_blocks_warn_threshold: 100,
             _variant_marker: PhantomData,
         };
 

--- a/finalizer/src/tests/fork_handling.rs
+++ b/finalizer/src/tests/fork_handling.rs
@@ -165,6 +165,7 @@ fn test_orphaned_block_processed_when_parent_arrives() {
             cancellation_token: CancellationToken::new(),
             drain_interval: Duration::from_millis(100),
             buffered_blocks_warn_threshold: 100,
+            pending_notarized_max: 1000,
             _variant_marker: PhantomData,
         };
 
@@ -248,6 +249,7 @@ fn test_multiple_forks_tracked() {
             cancellation_token: CancellationToken::new(),
             drain_interval: Duration::from_millis(100),
             buffered_blocks_warn_threshold: 100,
+            pending_notarized_max: 1000,
             _variant_marker: PhantomData,
         };
 
@@ -332,6 +334,7 @@ fn test_dead_fork_block_discarded() {
             cancellation_token: CancellationToken::new(),
             drain_interval: Duration::from_millis(100),
             buffered_blocks_warn_threshold: 100,
+            pending_notarized_max: 1000,
             _variant_marker: PhantomData,
         };
 
@@ -432,6 +435,7 @@ fn test_fork_states_pruned_after_finalization() {
             cancellation_token: CancellationToken::new(),
             drain_interval: Duration::from_millis(100),
             buffered_blocks_warn_threshold: 100,
+            pending_notarized_max: 1000,
             _variant_marker: PhantomData,
         };
 
@@ -551,6 +555,7 @@ fn test_orphaned_blocks_pruned_after_finalization() {
             cancellation_token: CancellationToken::new(),
             drain_interval: Duration::from_millis(100),
             buffered_blocks_warn_threshold: 100,
+            pending_notarized_max: 1000,
             _variant_marker: PhantomData,
         };
 
@@ -662,6 +667,7 @@ fn test_fork_state_reused_when_notarized_then_finalized() {
             cancellation_token: CancellationToken::new(),
             drain_interval: Duration::from_millis(100),
             buffered_blocks_warn_threshold: 100,
+            pending_notarized_max: 1000,
             _variant_marker: PhantomData,
         };
 
@@ -769,6 +775,7 @@ fn test_competing_fork_pruned_on_finalization() {
             cancellation_token: CancellationToken::new(),
             drain_interval: Duration::from_millis(100),
             buffered_blocks_warn_threshold: 100,
+            pending_notarized_max: 1000,
             _variant_marker: PhantomData,
         };
 

--- a/finalizer/src/tests/state_queries.rs
+++ b/finalizer/src/tests/state_queries.rs
@@ -63,7 +63,7 @@ fn create_test_block_with_epoch(
                 state_root: Default::default(),
                 transactions: Vec::new(),
             },
-            withdrawals: Vec::new().into(),
+            withdrawals: Vec::new(),
         },
         blob_gas_used: 0,
         excess_blob_gas: 0,
@@ -172,6 +172,8 @@ fn test_get_latest_epoch() {
             protocol_version: 1,
             node_public_key: node_key.public_key(),
             cancellation_token: CancellationToken::new(),
+            drain_interval: Duration::from_millis(100),
+            buffered_blocks_warn_threshold: 100,
             _variant_marker: PhantomData,
         };
 
@@ -281,6 +283,8 @@ fn test_get_epoch_genesis_hash() {
             protocol_version: 1,
             node_public_key: node_key.public_key(),
             cancellation_token: CancellationToken::new(),
+            drain_interval: Duration::from_millis(100),
+            buffered_blocks_warn_threshold: 100,
             _variant_marker: PhantomData,
         };
 
@@ -378,6 +382,8 @@ fn test_get_aux_data_from_canonical_chain() {
             protocol_version: 1,
             node_public_key: node_key.public_key(),
             cancellation_token: CancellationToken::new(),
+            drain_interval: Duration::from_millis(100),
+            buffered_blocks_warn_threshold: 100,
             _variant_marker: PhantomData,
         };
 
@@ -449,6 +455,8 @@ fn test_get_aux_data_returns_none_for_invalid_parent() {
             protocol_version: 1,
             node_public_key: node_key.public_key(),
             cancellation_token: CancellationToken::new(),
+            drain_interval: Duration::from_millis(100),
+            buffered_blocks_warn_threshold: 100,
             _variant_marker: PhantomData,
         };
 

--- a/finalizer/src/tests/state_queries.rs
+++ b/finalizer/src/tests/state_queries.rs
@@ -174,6 +174,7 @@ fn test_get_latest_epoch() {
             cancellation_token: CancellationToken::new(),
             drain_interval: Duration::from_millis(100),
             buffered_blocks_warn_threshold: 100,
+            pending_notarized_max: 1000,
             _variant_marker: PhantomData,
         };
 
@@ -285,6 +286,7 @@ fn test_get_epoch_genesis_hash() {
             cancellation_token: CancellationToken::new(),
             drain_interval: Duration::from_millis(100),
             buffered_blocks_warn_threshold: 100,
+            pending_notarized_max: 1000,
             _variant_marker: PhantomData,
         };
 
@@ -384,6 +386,7 @@ fn test_get_aux_data_from_canonical_chain() {
             cancellation_token: CancellationToken::new(),
             drain_interval: Duration::from_millis(100),
             buffered_blocks_warn_threshold: 100,
+            pending_notarized_max: 1000,
             _variant_marker: PhantomData,
         };
 
@@ -457,6 +460,7 @@ fn test_get_aux_data_returns_none_for_invalid_parent() {
             cancellation_token: CancellationToken::new(),
             drain_interval: Duration::from_millis(100),
             buffered_blocks_warn_threshold: 100,
+            pending_notarized_max: 1000,
             _variant_marker: PhantomData,
         };
 

--- a/finalizer/src/tests/syncing.rs
+++ b/finalizer/src/tests/syncing.rs
@@ -57,7 +57,7 @@ fn create_test_block(parent_digest: Digest, height: u64, view: u64, unique_seed:
                 state_root: Default::default(),
                 transactions: Vec::new(),
             },
-            withdrawals: Vec::new().into(),
+            withdrawals: Vec::new(),
         },
         blob_gas_used: 0,
         excess_blob_gas: 0,
@@ -547,6 +547,233 @@ fn test_checkpoint_startup_full_flow() {
 
         let height = mailbox.get_latest_height().await;
         assert_eq!(height, 8, "third block should process immediately");
+
+        context.auditor().state()
+    });
+}
+
+/// If the execution layer keeps returning SYNCING for a finalized block, the
+/// finalizer's `execute_block` retries indefinitely in an unbounded inline
+/// loop. While that loop is running the finalizer task is parked inside
+/// `select! { mailbox.next() => handle_finalized_block(...) }`, so no other
+/// mailbox arm can fire — aux-data requests, consensus-state queries,
+/// orchestrator messages and even cancellation all wait for local EL
+/// recovery. This is a liveness/DoS risk for a lagging, restarting or
+/// catching-up validator whose EL stays in SYNCING.
+///
+/// Setup: a single-finalizer harness whose `MockEngineClient` has many
+/// SYNCING responses queued for `check_payload` (1000 > any reasonable
+/// retry budget). A finalized block is reported to the finalizer, which
+/// drives it into the SYNCING retry loop.
+///
+/// Assertion: after the block has had time to enter `execute_block`, an
+/// unrelated mailbox query (`get_latest_height`) must respond within a
+/// bounded virtual time. Today the mailbox is fully blocked while the EL
+/// is SYNCING, so the bounded sleep wins the race and the test fails —
+/// directly exposing the audit's "finalizer mailbox stalled during catch-up"
+/// claim. Any fix that bounds the retry (critical-shutdown on cap, or
+/// moves the wait to a background task) will make the query resolve.
+#[test]
+fn test_finalizer_mailbox_responsive_under_persistent_syncing() {
+    use futures::FutureExt;
+    use futures::pin_mut;
+
+    let cfg = deterministic::Config::default().with_seed(7);
+    let executor = Runner::from(cfg);
+    executor.start(|context| async move {
+        let genesis_hash = [0xAAu8; 32];
+        let initial_state = create_test_initial_state(genesis_hash, NonZeroU64::new(10).unwrap());
+
+        let (orchestrator_tx, _orchestrator_rx) = futures_mpsc::channel(100);
+        let orchestrator_mailbox = summit_orchestrator::Mailbox::new(orchestrator_tx);
+
+        let node_key = ed25519::PrivateKey::from_seed(0);
+
+        let engine_client = MockEngineClient::new();
+        // Effectively infinite for the test window: at 5s per retry, 1000
+        // SYNCING responses cover 5000 virtual seconds — far more than the
+        // 1s race window we use below to detect a blocked mailbox.
+        engine_client.queue_check_payload_syncing(1000);
+
+        let finalizer_cfg = FinalizerConfig::<MockEngineClient, MockNetworkOracle, MinPk> {
+            mailbox_size: 100,
+            db_prefix: "test_persistent_syncing_mailbox".to_string(),
+            engine_client,
+            oracle: MockNetworkOracle,
+            protocol_consts: default_protocol_consts(),
+
+            page_cache: CacheRef::from_pooler(
+                &context,
+                std::num::NonZero::new(4096).unwrap(),
+                NZUsize!(100),
+            ),
+            genesis_hash,
+            initial_state,
+            protocol_version: 1,
+            node_public_key: node_key.public_key(),
+            cancellation_token: CancellationToken::new(),
+            _variant_marker: PhantomData,
+        };
+
+        let (finalizer, _state, mut mailbox) =
+            Finalizer::<_, MockEngineClient, MockNetworkOracle, ed25519::PrivateKey, MinPk>::new(
+                context.with_label("finalizer"),
+                finalizer_cfg,
+            )
+            .await;
+
+        let _handle = finalizer.start(orchestrator_mailbox);
+        // Let the finalizer reach its main mailbox loop.
+        context.sleep(Duration::from_millis(100)).await;
+
+        // Drive the finalizer into execute_block. With persistent SYNCING
+        // it enters the unbounded retry loop and the actor task stops
+        // servicing other mailbox messages.
+        let genesis_block = Block::genesis(genesis_hash);
+        let block1 = create_test_block(genesis_block.digest(), 1, 1, 7001);
+        let (ack, _waiter) = Exact::handle();
+        mailbox
+            .report(Update::FinalizedBlock((block1, None), ack))
+            .await;
+
+        // Give the finalizer enough virtual time to dequeue the
+        // FinalizedBlock update and enter execute_block's SYNCING loop.
+        context.sleep(Duration::from_millis(200)).await;
+
+        // Now issue an unrelated mailbox query and race it against a
+        // bounded virtual-time deadline. If the finalizer is responsive,
+        // `get_latest_height` resolves quickly. If the mailbox is blocked
+        // by the SYNCING loop, the deadline wins.
+        let query_mailbox = mailbox.clone();
+        let query_fut = async move { query_mailbox.get_latest_height().await }.fuse();
+        let deadline_fut = context.sleep(Duration::from_secs(1)).fuse();
+        pin_mut!(query_fut, deadline_fut);
+
+        futures::select! {
+            _height = query_fut => {
+                // mailbox responded — finalizer remained responsive
+                // while the EL was stuck in SYNCING.
+            }
+            _ = deadline_fut => {
+                panic!(
+                    "finalizer mailbox stalled while EL was SYNCING: \
+                     get_latest_height did not resolve within 1 virtual \
+                     second of dispatch. The finalizer-side execute_block \
+                     SYNCING loop is monopolising the actor task; a \
+                     lagging/restarting/catch-up validator can lose \
+                     mailbox liveness indefinitely until the EL recovers."
+                );
+            }
+        }
+
+        context.auditor().state()
+    });
+}
+
+/// The finalizer's startup `commit_hash` loop (finalizer/src/actor.rs:271)
+/// runs *before* the main mailbox loop begins. If the EL keeps returning
+/// SYNCING during that initial forkchoice update, the actor never enters
+/// its `select!` — every mailbox arm is starved (queries, cancellation,
+/// finalized/notarized updates, runtime stop), and queries against the
+/// already-loaded checkpoint state are silently rejected even though the
+/// data is available.
+///
+/// Setup: a finalizer restarted from a checkpoint at height 5. The
+/// `MockEngineClient` has many SYNCING responses queued for `commit_hash`
+/// (1000 > the test's 1-second race window).
+///
+/// Assertion: shortly after starting the finalizer, an unrelated mailbox
+/// query (`get_latest_height`) must resolve within a bounded virtual time
+/// and return the checkpoint-loaded height. Today the startup loop blocks
+/// the actor before it ever reaches the mailbox `select!`, so the bounded
+/// sleep wins the race and the test fails. Any fix that drops the startup
+/// retry loop (one-shot `commit_hash` + fall-through on SYNCING) or moves
+/// the wait off the actor task will let the query resolve from the
+/// checkpoint-loaded `canonical_state`.
+#[test]
+fn test_finalizer_mailbox_responsive_during_startup_syncing() {
+    use futures::FutureExt;
+    use futures::pin_mut;
+
+    let cfg = deterministic::Config::default().with_seed(11);
+    let executor = Runner::from(cfg);
+    executor.start(|context| async move {
+        let checkpoint_hash = [0xCDu8; 32];
+        // Checkpoint at height 5, epoch 0.
+        let initial_state =
+            create_checkpoint_initial_state(checkpoint_hash, 5, 0, NonZeroU64::new(10).unwrap());
+
+        let (orchestrator_tx, _orchestrator_rx) = futures_mpsc::channel(100);
+        let orchestrator_mailbox = summit_orchestrator::Mailbox::new(orchestrator_tx);
+
+        let node_key = ed25519::PrivateKey::from_seed(0);
+
+        let engine_client = MockEngineClient::new();
+        // Effectively infinite SYNCING for the test window: 1000 * 5s =
+        // 5000 virtual seconds, far longer than the 1s deadline below.
+        engine_client.queue_commit_hash_syncing(1000);
+
+        let finalizer_cfg = FinalizerConfig::<MockEngineClient, MockNetworkOracle, MinPk> {
+            mailbox_size: 100,
+            db_prefix: "test_startup_syncing_mailbox".to_string(),
+            engine_client,
+            oracle: MockNetworkOracle,
+            protocol_consts: default_protocol_consts(),
+
+            page_cache: CacheRef::from_pooler(
+                &context,
+                std::num::NonZero::new(4096).unwrap(),
+                NZUsize!(100),
+            ),
+            genesis_hash: checkpoint_hash,
+            initial_state,
+            protocol_version: 1,
+            node_public_key: node_key.public_key(),
+            cancellation_token: CancellationToken::new(),
+            _variant_marker: PhantomData,
+        };
+
+        let (finalizer, _state, mailbox) =
+            Finalizer::<_, MockEngineClient, MockNetworkOracle, ed25519::PrivateKey, MinPk>::new(
+                context.with_label("finalizer"),
+                finalizer_cfg,
+            )
+            .await;
+
+        let _handle = finalizer.start(orchestrator_mailbox);
+        // Give the finalizer task time to be scheduled and enter the
+        // startup `commit_hash` path.
+        context.sleep(Duration::from_millis(100)).await;
+
+        // Issue an unrelated mailbox query and race it against a bounded
+        // virtual-time deadline. If the actor entered its main mailbox
+        // loop, the query resolves quickly from the checkpoint-loaded
+        // `canonical_state` (height = 5). If the startup `commit_hash`
+        // loop is still blocking the actor, the deadline wins.
+        let query_mailbox = mailbox.clone();
+        let query_fut = async move { query_mailbox.get_latest_height().await }.fuse();
+        let deadline_fut = context.sleep(Duration::from_secs(1)).fuse();
+        pin_mut!(query_fut, deadline_fut);
+
+        futures::select! {
+            height = query_fut => {
+                assert_eq!(
+                    height, 5,
+                    "expected the checkpoint-loaded latest height to be visible \
+                     via the mailbox once the actor enters its main loop"
+                );
+            }
+            _ = deadline_fut => {
+                panic!(
+                    "finalizer mailbox stalled at startup while EL was SYNCING: \
+                     get_latest_height did not resolve within 1 virtual second of \
+                     dispatch. The startup commit_hash loop is blocking the actor \
+                     before its main `select!` begins; on a checkpoint-restart, a \
+                     validator whose EL needs to catch up cannot answer any RPC or \
+                     mailbox query until the EL recovers."
+                );
+            }
+        }
 
         context.auditor().state()
     });

--- a/finalizer/src/tests/syncing.rs
+++ b/finalizer/src/tests/syncing.rs
@@ -193,6 +193,8 @@ fn test_initial_startup_sync_waits_for_valid() {
             protocol_version: 1,
             node_public_key: node_key.public_key(),
             cancellation_token: CancellationToken::new(),
+            drain_interval: Duration::from_millis(100),
+            buffered_blocks_warn_threshold: 100,
             _variant_marker: PhantomData,
         };
 
@@ -263,6 +265,8 @@ fn test_initial_startup_sync_zero_forkchoice_skips_sync() {
             protocol_version: 1,
             node_public_key: node_key.public_key(),
             cancellation_token: CancellationToken::new(),
+            drain_interval: Duration::from_millis(100),
+            buffered_blocks_warn_threshold: 100,
             _variant_marker: PhantomData,
         };
 
@@ -333,6 +337,8 @@ fn test_execute_block_retries_on_syncing() {
             protocol_version: 1,
             node_public_key: node_key.public_key(),
             cancellation_token: CancellationToken::new(),
+            drain_interval: Duration::from_millis(100),
+            buffered_blocks_warn_threshold: 100,
             _variant_marker: PhantomData,
         };
 
@@ -418,6 +424,8 @@ fn test_notarized_block_retries_on_syncing() {
             protocol_version: 1,
             node_public_key: node_key.public_key(),
             cancellation_token: CancellationToken::new(),
+            drain_interval: Duration::from_millis(100),
+            buffered_blocks_warn_threshold: 100,
             _variant_marker: PhantomData,
         };
 
@@ -495,6 +503,8 @@ fn test_checkpoint_startup_full_flow() {
             protocol_version: 1,
             node_public_key: node_key.public_key(),
             cancellation_token: CancellationToken::new(),
+            drain_interval: Duration::from_millis(100),
+            buffered_blocks_warn_threshold: 100,
             _variant_marker: PhantomData,
         };
 
@@ -612,6 +622,8 @@ fn test_finalizer_mailbox_responsive_under_persistent_syncing() {
             protocol_version: 1,
             node_public_key: node_key.public_key(),
             cancellation_token: CancellationToken::new(),
+            drain_interval: Duration::from_millis(100),
+            buffered_blocks_warn_threshold: 100,
             _variant_marker: PhantomData,
         };
 
@@ -730,6 +742,8 @@ fn test_finalizer_mailbox_responsive_during_startup_syncing() {
             protocol_version: 1,
             node_public_key: node_key.public_key(),
             cancellation_token: CancellationToken::new(),
+            drain_interval: Duration::from_millis(100),
+            buffered_blocks_warn_threshold: 100,
             _variant_marker: PhantomData,
         };
 
@@ -774,6 +788,121 @@ fn test_finalizer_mailbox_responsive_during_startup_syncing() {
                 );
             }
         }
+
+        context.auditor().state()
+    });
+}
+
+/// Regression test for an ordering bug in the finalized SYNCING buffer.
+///
+/// Two finalized blocks at heights H and H+1 arrive during an EL-SYNCING
+/// window. Both enter the pending buffer. While they are buffered, the EL
+/// finishes catching up. The drain timer must apply them in arrival order
+/// (H before H+1); applying H+1 first would mutate `canonical_state` past
+/// the height of H, and the subsequent apply of H would silently regress
+/// `latest_height` — corrupting Summit's view of the chain while Reth has
+/// already moved on.
+///
+/// Concrete failure mode this test catches (with the broken implementation
+/// that calls `pending_finalized.push_back` from inside the handler on
+/// Syncing, regardless of whether the caller is the mailbox or the drain
+/// timer):
+///
+///   1. mailbox brings A (height 1); EL returns SYNCING. Buffer = `[A]`.
+///   2. mailbox brings B (height 2); EL returns SYNCING. Buffer = `[A, B]`.
+///   3. drain pops A; EL returns SYNCING; handler push_back's A.
+///      **Buffer = `[B, A]` — ordering broken.**
+///   4. Between ticks the EL catches up.
+///   5. drain pops B first; `check_payload` returns VALID; `execute_block`
+///      sets `latest_height` to 2. Then drain pops A; VALID; `set_latest_height`
+///      to 1. Final `latest_height` = 1, B's deposit/withdrawal effects already
+///      committed to Reth. Summit's state diverges from the EL.
+///
+/// We queue exactly three SYNCING responses (A#1 via mailbox, B#1 via
+/// mailbox, A#2 via drain). The fourth `check_payload` call falls through
+/// to VALID. The expected final `latest_height` is 2 *with both blocks
+/// applied in order*. Any fix that preserves drain ordering will pass.
+#[test]
+fn test_finalizer_finalized_buffer_drains_in_order() {
+    let cfg = deterministic::Config::default().with_seed(13);
+    let executor = Runner::from(cfg);
+    executor.start(|context| async move {
+        let genesis_hash = [0u8; 32];
+        let initial_state = create_test_initial_state(genesis_hash, NonZeroU64::new(10).unwrap());
+
+        let (orchestrator_tx, _orchestrator_rx) = futures_mpsc::channel(100);
+        let orchestrator_mailbox = summit_orchestrator::Mailbox::new(orchestrator_tx);
+
+        let node_key = ed25519::PrivateKey::from_seed(0);
+
+        let engine_client = MockEngineClient::new();
+        // Exactly enough SYNCING responses to force the ordering bug under
+        // the broken implementation: A#1 (mailbox), B#1 (mailbox), A#2
+        // (drain retry). Subsequent calls fall through to VALID.
+        engine_client.queue_check_payload_syncing(3);
+
+        let finalizer_cfg = FinalizerConfig::<MockEngineClient, MockNetworkOracle, MinPk> {
+            mailbox_size: 100,
+            db_prefix: "test_finalized_buffer_in_order".to_string(),
+            engine_client,
+            oracle: MockNetworkOracle,
+            protocol_consts: default_protocol_consts(),
+
+            page_cache: CacheRef::from_pooler(
+                &context,
+                std::num::NonZero::new(4096).unwrap(),
+                NZUsize!(100),
+            ),
+            genesis_hash,
+            initial_state,
+            protocol_version: 1,
+            node_public_key: node_key.public_key(),
+            cancellation_token: CancellationToken::new(),
+            // Fast drain so the test doesn't have to sleep for the default 5s.
+            drain_interval: Duration::from_millis(50),
+            buffered_blocks_warn_threshold: 100,
+            _variant_marker: PhantomData,
+        };
+
+        let (finalizer, _state, mut mailbox) =
+            Finalizer::<_, MockEngineClient, MockNetworkOracle, ed25519::PrivateKey, MinPk>::new(
+                context.with_label("finalizer"),
+                finalizer_cfg,
+            )
+            .await;
+
+        let _handle = finalizer.start(orchestrator_mailbox);
+        // Let the finalizer reach its main mailbox loop.
+        context.sleep(Duration::from_millis(20)).await;
+
+        // Send finalized blocks in height order.
+        let genesis_block = Block::genesis(genesis_hash);
+        let block_a = create_test_block(genesis_block.digest(), 1, 1, 13001);
+        let block_b = create_test_block(block_a.digest(), 2, 2, 13002);
+
+        let (ack_a, _waiter_a) = Exact::handle();
+        mailbox
+            .report(Update::FinalizedBlock((block_a, None), ack_a))
+            .await;
+
+        // Small gap so A's mailbox path runs (and buffers) before B arrives.
+        context.sleep(Duration::from_millis(10)).await;
+
+        let (ack_b, _waiter_b) = Exact::handle();
+        mailbox
+            .report(Update::FinalizedBlock((block_b, None), ack_b))
+            .await;
+
+        // Give the drain timer multiple ticks to exhaust the queued SYNCING
+        // responses and apply both blocks. Three SYNCING responses at 50ms
+        // drain_interval is at most ~200ms of real work; 1s is comfortable.
+        context.sleep(Duration::from_secs(1)).await;
+
+        let height = mailbox.get_latest_height().await;
+        assert_eq!(
+            height, 2,
+            "finalized buffer must drain in arrival order. Got latest_height = {height}."
+        );
 
         context.auditor().state()
     });

--- a/finalizer/src/tests/syncing.rs
+++ b/finalizer/src/tests/syncing.rs
@@ -195,6 +195,7 @@ fn test_initial_startup_sync_waits_for_valid() {
             cancellation_token: CancellationToken::new(),
             drain_interval: Duration::from_millis(100),
             buffered_blocks_warn_threshold: 100,
+            pending_notarized_max: 1000,
             _variant_marker: PhantomData,
         };
 
@@ -267,6 +268,7 @@ fn test_initial_startup_sync_zero_forkchoice_skips_sync() {
             cancellation_token: CancellationToken::new(),
             drain_interval: Duration::from_millis(100),
             buffered_blocks_warn_threshold: 100,
+            pending_notarized_max: 1000,
             _variant_marker: PhantomData,
         };
 
@@ -339,6 +341,7 @@ fn test_execute_block_retries_on_syncing() {
             cancellation_token: CancellationToken::new(),
             drain_interval: Duration::from_millis(100),
             buffered_blocks_warn_threshold: 100,
+            pending_notarized_max: 1000,
             _variant_marker: PhantomData,
         };
 
@@ -426,6 +429,7 @@ fn test_notarized_block_retries_on_syncing() {
             cancellation_token: CancellationToken::new(),
             drain_interval: Duration::from_millis(100),
             buffered_blocks_warn_threshold: 100,
+            pending_notarized_max: 1000,
             _variant_marker: PhantomData,
         };
 
@@ -505,6 +509,7 @@ fn test_checkpoint_startup_full_flow() {
             cancellation_token: CancellationToken::new(),
             drain_interval: Duration::from_millis(100),
             buffered_blocks_warn_threshold: 100,
+            pending_notarized_max: 1000,
             _variant_marker: PhantomData,
         };
 
@@ -624,6 +629,7 @@ fn test_finalizer_mailbox_responsive_under_persistent_syncing() {
             cancellation_token: CancellationToken::new(),
             drain_interval: Duration::from_millis(100),
             buffered_blocks_warn_threshold: 100,
+            pending_notarized_max: 1000,
             _variant_marker: PhantomData,
         };
 
@@ -744,6 +750,7 @@ fn test_finalizer_mailbox_responsive_during_startup_syncing() {
             cancellation_token: CancellationToken::new(),
             drain_interval: Duration::from_millis(100),
             buffered_blocks_warn_threshold: 100,
+            pending_notarized_max: 1000,
             _variant_marker: PhantomData,
         };
 
@@ -788,6 +795,74 @@ fn test_finalizer_mailbox_responsive_during_startup_syncing() {
                 );
             }
         }
+
+        context.auditor().state()
+    });
+}
+
+#[test]
+fn test_finalizer_shuts_down_when_pending_notarized_cap_is_reached() {
+    let cfg = deterministic::Config::default().with_seed(17);
+    let executor = Runner::from(cfg);
+    executor.start(|context| async move {
+        let genesis_hash = [0xEFu8; 32];
+        let initial_state = create_test_initial_state(genesis_hash, NonZeroU64::new(10).unwrap());
+
+        let (orchestrator_tx, _orchestrator_rx) = futures_mpsc::channel(100);
+        let orchestrator_mailbox = summit_orchestrator::Mailbox::new(orchestrator_tx);
+
+        let node_key = ed25519::PrivateKey::from_seed(0);
+        let engine_client = MockEngineClient::new();
+        engine_client.queue_check_payload_syncing(10);
+
+        let cancellation_token = CancellationToken::new();
+        let finalizer_cfg = FinalizerConfig::<MockEngineClient, MockNetworkOracle, MinPk> {
+            mailbox_size: 100,
+            db_prefix: "test_pending_notarized_cap".to_string(),
+            engine_client,
+            oracle: MockNetworkOracle,
+            protocol_consts: default_protocol_consts(),
+            page_cache: CacheRef::from_pooler(
+                &context,
+                std::num::NonZero::new(4096).unwrap(),
+                NZUsize!(100),
+            ),
+            genesis_hash,
+            initial_state,
+            protocol_version: 1,
+            node_public_key: node_key.public_key(),
+            cancellation_token: cancellation_token.clone(),
+            drain_interval: Duration::from_millis(100),
+            buffered_blocks_warn_threshold: 100,
+            pending_notarized_max: 2,
+            _variant_marker: PhantomData,
+        };
+
+        let (finalizer, _state, mut mailbox) =
+            Finalizer::<_, MockEngineClient, MockNetworkOracle, ed25519::PrivateKey, MinPk>::new(
+                context.with_label("finalizer"),
+                finalizer_cfg,
+            )
+            .await;
+
+        let _handle = finalizer.start(orchestrator_mailbox);
+        context.sleep(Duration::from_millis(20)).await;
+
+        let genesis_block = Block::genesis(genesis_hash);
+        let block_a = create_test_block(genesis_block.digest(), 1, 1, 17001);
+        let block_b = create_test_block(genesis_block.digest(), 1, 1, 17002);
+        let block_c = create_test_block(genesis_block.digest(), 1, 1, 17003);
+
+        mailbox.report(Update::NotarizedBlock(block_a)).await;
+        mailbox.report(Update::NotarizedBlock(block_b)).await;
+        mailbox.report(Update::NotarizedBlock(block_c)).await;
+
+        context.sleep(Duration::from_millis(50)).await;
+
+        assert!(
+            cancellation_token.is_cancelled(),
+            "finalizer should trigger graceful shutdown once pending_notarized reaches its hard cap"
+        );
 
         context.auditor().state()
     });
@@ -861,6 +936,7 @@ fn test_finalizer_finalized_buffer_drains_in_order() {
             // Fast drain so the test doesn't have to sleep for the default 5s.
             drain_interval: Duration::from_millis(50),
             buffered_blocks_warn_threshold: 100,
+            pending_notarized_max: 1000,
             _variant_marker: PhantomData,
         };
 

--- a/finalizer/src/tests/validator_lifecycle.rs
+++ b/finalizer/src/tests/validator_lifecycle.rs
@@ -353,6 +353,9 @@ fn last_block_exit_dominates_concurrent_max_stake_reduction() {
             protocol_version: 1,
             node_public_key: local_node_pubkey,
             cancellation_token,
+            drain_interval: Duration::from_millis(100),
+            buffered_blocks_warn_threshold: 100,
+            pending_notarized_max: 1000,
             _variant_marker: PhantomData,
         };
 

--- a/finalizer/src/tests/validator_lifecycle.rs
+++ b/finalizer/src/tests/validator_lifecycle.rs
@@ -75,7 +75,7 @@ fn create_test_block_with_requests(
                 state_root: Default::default(),
                 transactions: Vec::new(),
             },
-            withdrawals: Vec::new().into(),
+            withdrawals: Vec::new(),
         },
         blob_gas_used: 0,
         excess_blob_gas: 0,
@@ -220,6 +220,8 @@ fn test_validator_exit_triggers_cancellation() {
             protocol_version: 1,
             node_public_key: node_pubkey,
             cancellation_token,
+            drain_interval: Duration::from_millis(100),
+            buffered_blocks_warn_threshold: 100,
             _variant_marker: PhantomData,
         };
 

--- a/finalizer/src/tests/validator_lifecycle.rs
+++ b/finalizer/src/tests/validator_lifecycle.rs
@@ -222,6 +222,7 @@ fn test_validator_exit_triggers_cancellation() {
             cancellation_token,
             drain_interval: Duration::from_millis(100),
             buffered_blocks_warn_threshold: 100,
+            pending_notarized_max: 1000,
             _variant_marker: PhantomData,
         };
 

--- a/node/src/args.rs
+++ b/node/src/args.rs
@@ -1,7 +1,7 @@
 use crate::{
     config::{
-        BACKFILLER_CHANNEL, BROADCASTER_CHANNEL, EngineConfig, MESSAGE_BACKLOG, PENDING_CHANNEL,
-        RECOVERED_CHANNEL, RESOLVER_CHANNEL, expect_key_store,
+        BACKFILLER_CHANNEL, BROADCASTER_CHANNEL, EngineConfig, FINALIZER_PENDING_NOTARIZED_MAX,
+        MESSAGE_BACKLOG, PENDING_CHANNEL, RECOVERED_CHANNEL, RESOLVER_CHANNEL, expect_key_store,
     },
     engine::Engine,
     keys::KeySubCmd,
@@ -160,6 +160,10 @@ pub struct RunFlags {
     /// The value is a derivation index that produces a distinct identity from the base node key.
     #[arg(long)]
     pub observer: Option<u32>,
+
+    /// Hard cap on unique deferred notarized blocks while the execution layer is SYNCING.
+    #[arg(long, default_value_t = FINALIZER_PENDING_NOTARIZED_MAX)]
+    pub finalizer_pending_notarized_max: usize,
 }
 
 impl Command {
@@ -659,6 +663,7 @@ where
         initial_state,
         checkpoint_last_block,
         checkpoint_finalized_header,
+        flags.finalizer_pending_notarized_max,
     )
     .unwrap();
 

--- a/node/src/bin/observer.rs
+++ b/node/src/bin/observer.rs
@@ -515,5 +515,6 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         bootstrappers: None,
         critical_log_dir: None,
         observer: None,
+        finalizer_pending_notarized_max: 1000,
     }
 }

--- a/node/src/bin/protocol_params.rs
+++ b/node/src/bin/protocol_params.rs
@@ -414,5 +414,6 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         bootstrappers: None,
         critical_log_dir: None,
         observer: None,
+        finalizer_pending_notarized_max: 1000,
     }
 }

--- a/node/src/bin/stake_and_checkpoint.rs
+++ b/node/src/bin/stake_and_checkpoint.rs
@@ -701,6 +701,7 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         bootstrappers: None,
         critical_log_dir: None,
         observer: None,
+        finalizer_pending_notarized_max: 1000,
     }
 }
 

--- a/node/src/bin/stake_and_join_with_outdated_ckpt.rs
+++ b/node/src/bin/stake_and_join_with_outdated_ckpt.rs
@@ -819,6 +819,7 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         bootstrappers: None,
         critical_log_dir: None,
         observer: None,
+        finalizer_pending_notarized_max: 1000,
     }
 }
 

--- a/node/src/bin/sync_from_genesis.rs
+++ b/node/src/bin/sync_from_genesis.rs
@@ -684,5 +684,6 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         bootstrappers: None,
         critical_log_dir: None,
         observer: None,
+        finalizer_pending_notarized_max: 1000,
     }
 }

--- a/node/src/bin/testnet.rs
+++ b/node/src/bin/testnet.rs
@@ -201,5 +201,6 @@ fn get_node_flags(node: usize) -> RunFlags {
         bootstrappers: None,
         critical_log_dir: None,
         observer: None,
+        finalizer_pending_notarized_max: 1000,
     }
 }

--- a/node/src/bin/verify_consensus_state_proof.rs
+++ b/node/src/bin/verify_consensus_state_proof.rs
@@ -561,5 +561,6 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         bootstrappers: None,
         critical_log_dir: None,
         observer: None,
+        finalizer_pending_notarized_max: 1000,
     }
 }

--- a/node/src/bin/withdraw_and_exit.rs
+++ b/node/src/bin/withdraw_and_exit.rs
@@ -409,5 +409,6 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         bootstrappers: None,
         critical_log_dir: None,
         observer: None,
+        finalizer_pending_notarized_max: 1000,
     }
 }

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -25,6 +25,9 @@ pub const FINALIZER_DRAIN_INTERVAL: Duration = Duration::from_secs(5);
 /// emitted (edge-triggered, once per crossing). No cap is enforced.
 /// See [`summit_finalizer::FinalizerConfig`].
 pub const FINALIZER_BUFFERED_BLOCKS_WARN_THRESHOLD: usize = 100;
+/// Hard cap on unique deferred notarized blocks while the execution layer is
+/// SYNCING. Reaching this limit triggers graceful shutdown.
+pub const FINALIZER_PENDING_NOTARIZED_MAX: usize = 1000;
 
 const FETCH_TIMEOUT: Duration = Duration::from_secs(5);
 const FETCH_CONCURRENT: usize = 8;
@@ -41,6 +44,7 @@ pub struct EngineConfig<C: EngineClient, S: Signer, O: NetworkOracle<S::PublicKe
     pub key_store: KeyStore<S>,
     pub participants: Vec<(PublicKey, bls12381::PublicKey)>,
     pub mailbox_size: usize,
+    pub finalizer_pending_notarized_max: usize,
     pub backfill_quota: Quota,
     pub deque_size: usize,
 
@@ -79,6 +83,7 @@ impl<C: EngineClient, S: Signer, O: NetworkOracle<S::PublicKey>> EngineConfig<C,
         initial_state: ConsensusState,
         checkpoint_last_block: Option<Block>,
         checkpoint_finalized_header: Option<FinalizedHeader<MultisigScheme>>,
+        finalizer_pending_notarized_max: usize,
     ) -> Result<Self> {
         Ok(Self {
             engine_client,
@@ -87,6 +92,7 @@ impl<C: EngineClient, S: Signer, O: NetworkOracle<S::PublicKey>> EngineConfig<C,
             participants,
             oracle,
             mailbox_size: MAILBOX_SIZE,
+            finalizer_pending_notarized_max,
             backfill_quota: Quota::per_second(NonZeroU32::new(BACKFILL_QUOTA).unwrap()),
             deque_size: DEQUE_SIZE,
             leader_timeout: Duration::from_millis(genesis.leader_timeout_ms),

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -18,6 +18,13 @@ pub const RESOLVER_CHANNEL: u64 = 2;
 pub const BROADCASTER_CHANNEL: u64 = 3;
 pub const BACKFILLER_CHANNEL: u64 = 4;
 pub const MAILBOX_SIZE: usize = 16384;
+/// How often the finalizer retries applying blocks that were deferred because
+/// the execution layer returned `SYNCING`. See [`summit_finalizer::FinalizerConfig`].
+pub const FINALIZER_DRAIN_INTERVAL: Duration = Duration::from_secs(5);
+/// Soft threshold on the finalizer's SYNCING buffer above which a warn log is
+/// emitted (edge-triggered, once per crossing). No cap is enforced.
+/// See [`summit_finalizer::FinalizerConfig`].
+pub const FINALIZER_BUFFERED_BLOCKS_WARN_THRESHOLD: usize = 100;
 
 const FETCH_TIMEOUT: Duration = Duration::from_secs(5);
 const FETCH_CONCURRENT: usize = 8;

--- a/node/src/engine.rs
+++ b/node/src/engine.rs
@@ -162,6 +162,7 @@ where
                 cancellation_token: cancellation_token.clone(),
                 drain_interval: FINALIZER_DRAIN_INTERVAL,
                 buffered_blocks_warn_threshold: FINALIZER_BUFFERED_BLOCKS_WARN_THRESHOLD,
+                pending_notarized_max: cfg.finalizer_pending_notarized_max,
                 _variant_marker: PhantomData,
             },
         )

--- a/node/src/engine.rs
+++ b/node/src/engine.rs
@@ -1,4 +1,6 @@
-use crate::config::EngineConfig;
+use crate::config::{
+    EngineConfig, FINALIZER_BUFFERED_BLOCKS_WARN_THRESHOLD, FINALIZER_DRAIN_INTERVAL,
+};
 use commonware_broadcast::buffered;
 use commonware_codec::{DecodeExt, Encode};
 use commonware_consensus::simplex::scheme::Scheme;
@@ -158,6 +160,8 @@ where
                 protocol_version: PROTOCOL_VERSION,
                 node_public_key: cfg.key_store.node_key.public_key().clone(),
                 cancellation_token: cancellation_token.clone(),
+                drain_interval: FINALIZER_DRAIN_INTERVAL,
+                buffered_blocks_warn_threshold: FINALIZER_BUFFERED_BLOCKS_WARN_THRESHOLD,
                 _variant_marker: PhantomData,
             },
         )

--- a/node/src/test_harness/common.rs
+++ b/node/src/test_harness/common.rs
@@ -39,6 +39,11 @@ use tokio::sync::mpsc;
 
 pub const DEFAULT_BLOCKS_PER_EPOCH: u64 = 10;
 
+/// State-root convergence polling (see `assert_state_root_consensus_synced`).
+/// Virtual time, so the cap costs only scheduler steps, not wall-clock.
+const STATE_ROOT_POLL_INTERVAL: Duration = Duration::from_millis(500);
+const STATE_ROOT_MAX_POLLS: usize = 600; // ~5 min of virtual time
+
 pub const GENESIS_HASH: &str = "0x683713729fcb72be6f3d8b88c8cda3e10569d73b9640d3bf6f5184d94bd97616";
 
 pub async fn link_validators<E: Clock>(
@@ -283,6 +288,41 @@ pub fn run_until_height(
 
         context.auditor().state()
     })
+}
+
+/// Wait until every active (non-skipped) validator has captured state at the same
+/// `el_block_number`, then assert their state roots agree.
+///
+/// Validators finalize asynchronously and can be a block apart when sampled, so
+/// comparing their "current" state roots directly is a height race (it compares
+/// state at different heights and spuriously fails). This drives the deterministic
+/// runtime forward with virtual sleeps until heights converge, then compares.
+/// Bounded, so a genuine non-convergence (e.g. a stuck validator) still surfaces
+/// via the follow-up assertion, which reports the per-validator block numbers.
+pub async fn assert_state_root_consensus_synced<E: Clock>(
+    context: &E,
+    queries: &HashMap<usize, FinalizerMailbox<MultisigScheme, Block>>,
+    skip: &[usize],
+) {
+    // Normal convergence takes a block or two (a straggler finalizing one more
+    // block); the cap is a generous safety bound after which we fall through to
+    // the assertion so a genuinely non-converging cluster fails (with block
+    // numbers) rather than hanging forever.
+    for _ in 0..STATE_ROOT_MAX_POLLS {
+        let mut blocks = std::collections::HashSet::new();
+        for (&idx, mailbox) in queries.iter() {
+            if skip.contains(&idx) {
+                continue;
+            }
+            let (_root, el_block_number) = mailbox.get_state_root().await;
+            blocks.insert(el_block_number);
+        }
+        if blocks.len() <= 1 {
+            break;
+        }
+        context.sleep(STATE_ROOT_POLL_INTERVAL).await;
+    }
+    assert_state_root_consensus_skip(queries, skip).await;
 }
 
 /// Assert that all validators share the same state trie root.

--- a/node/src/test_harness/common.rs
+++ b/node/src/test_harness/common.rs
@@ -642,6 +642,7 @@ where
         key_store,
         participants,
         mailbox_size: 1024,
+        finalizer_pending_notarized_max: 1000,
         deque_size: 10,
         backfill_quota: Quota::per_second(NonZeroU32::new(512).unwrap()),
         leader_timeout: Duration::from_secs(1),

--- a/node/src/tests/execution_requests/withdrawals.rs
+++ b/node/src/tests/execution_requests/withdrawals.rs
@@ -448,7 +448,7 @@ fn test_partial_withdrawal_balance_below_minimum_stake() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus(&consensus_state_queries).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[]).await;
 
         context.auditor().state()
     })


### PR DESCRIPTION
Building on https://github.com/SeismicSystems/summit/pull/167 and https://github.com/SeismicSystems/summit/pull/192.

This addresses https://github.com/SeismicSystems/summit/issues/197.

Changes:
- Removes retries of block execution in unbounded loop when the EL is syncing.
- Introduces buffers for the notarized and finalized blocks. If the EL returns `SYNCING`, the block is buffered and the main loop of the finalizer actor can continue. The block buffers are drained periodically. The interval is `FINALIZER_DRAIN_INTERVAL`, currently set to 5 secs.
- The buffers are unbounded. After either one of them reached `FINALIZER_BUFFERED_BLOCKS_WARN_THRESHOLD`, warnings will be fired through logs and metrics.
- Regression tests are added to verify the correct behavior.
