### PR TITLE
fix: bind genesis RPC server to loopback

### DIFF
--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -193,13 +193,18 @@ pub async fn start_rpc_server_for_genesis(
 
     let methods = rpc_impl.into_rpc();
 
-    let server = builder::RpcServerBuilder::new(port)
-        .with_cors(Some("*".to_string()))
+    // First-boot genesis provisioning installs the chain's authoritative
+    // identity (namespace, execution genesis hash, validator committee,
+    // peer addresses, initial protocol params). Bind to loopback so a
+    // remote caller cannot install genesis on this node before startup
+    // loads it.
+    let server = builder::RpcServerBuilder::new_localhost(port)
         .build()
         .await?;
+    let addr = server.local_addr()?;
     let handle = server.start(methods);
 
-    tracing::info!("Genesis RPC Server listening on http://0.0.0.0:{port}");
+    tracing::info!("Genesis RPC Server listening on http://{}", addr);
 
     cancel_token.cancelled().await;
     tracing::info!("Genesis RPC server stopped");
@@ -218,8 +223,9 @@ pub async fn start_rpc_server_for_genesis_with_handle(
 
     let methods = rpc_impl.into_rpc();
 
-    let server = builder::RpcServerBuilder::new(port)
-        .with_cors(Some("*".to_string()))
+    // See note on the production variant: localhost-only binding for the
+    // first-boot genesis writer.
+    let server = builder::RpcServerBuilder::new_localhost(port)
         .build()
         .await?;
     let addr = server.local_addr()?;

--- a/rpc/tests/integration_test.rs
+++ b/rpc/tests/integration_test.rs
@@ -228,6 +228,34 @@ withdrawal_credentials = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
     handle.stop().unwrap();
 }
 
+/// The genesis provisioning RPC installs the chain's authoritative identity
+/// (namespace, execution genesis hash, validator committee, peer addresses,
+/// initial protocol params) before the node finishes startup. It must bind
+/// to loopback so a remote caller cannot install genesis on first boot.
+#[tokio::test]
+async fn test_genesis_rpc_binds_to_loopback() {
+    let temp_dir = create_test_keystore().unwrap();
+    let key_store_path = temp_dir.path().to_str().unwrap().to_string();
+
+    let genesis_dir = tempfile::tempdir().unwrap();
+    let genesis_path = genesis_dir.path().join("genesis.toml");
+    let genesis_path_str = genesis_path.to_str().unwrap().to_string();
+
+    let path_sender = PathSender::new(genesis_path_str, None);
+
+    let (handle, addr) = start_rpc_server_for_genesis_with_handle(path_sender, key_store_path, 0)
+        .await
+        .unwrap();
+
+    assert!(
+        addr.ip().is_loopback(),
+        "genesis RPC must bind to loopback (got {})",
+        addr.ip()
+    );
+
+    handle.stop().unwrap();
+}
+
 #[tokio::test]
 async fn test_get_minimum_stake() {
     use summit_rpc::SummitApiClient;
@@ -345,7 +373,7 @@ async fn test_is_paused_open_access() {
     let url = format!("http://{}", addr);
     let client = HttpClientBuilder::default().build(&url).unwrap();
 
-    assert_eq!(client.is_paused().await.unwrap(), false);
+    assert!(!client.is_paused().await.unwrap());
 
     handle.stop().unwrap();
 }


### PR DESCRIPTION
Builds on https://github.com/SeismicSystems/summit/pull/193.

This addresses https://github.com/SeismicSystems/summit/issues/195.

Changes:
- Binds the genesis RPC server to 127.0.0.1.
- Adds a regression test.

I didn't add an authentication token for this endpoint, because this endpoint won't be used until we switch to TEEs. How this endpoint will be authenticated will be decided then.