### PR TITLE
fix: handle malformed deposit requests

### DIFF
--- a/finalizer/src/actor.rs
+++ b/finalizer/src/actor.rs
@@ -32,7 +32,9 @@ use summit_syncer::Update;
 use summit_types::account::{ValidatorAccount, ValidatorStatus};
 use summit_types::checkpoint::Checkpoint;
 use summit_types::consensus_state_query::{ConsensusStateRequest, ConsensusStateResponse};
-use summit_types::execution_request::{DepositRequest, ExecutionRequest, WithdrawalRequest};
+use summit_types::execution_request::{
+    DepositRequest, ExecutionRequest, ParsedExecutionRequest, WithdrawalRequest,
+};
 use summit_types::ext_private_key::derive_observer_keys;
 use summit_types::network_oracle::NetworkOracle;
 use summit_types::protocol_params::ProtocolParam;
@@ -56,6 +58,12 @@ const WRITE_BUFFER: NonZero<usize> = NZUsize!(1024 * 1024);
 enum DepositRejectionReason {
     Refund,
     InvalidSignature,
+    /// Deposit chunk's Ed25519 / BLS key bytes did not decode. A single
+    /// malformed chunk in a grouped EIP-7685 deposit entry must not poison
+    /// the valid chunks alongside it. Routing this through the same refund
+    /// branch as `InvalidSignature` keeps the malformed chunk's depositor
+    /// whole.
+    MalformedKey,
 }
 
 fn deposit_refund_key(domain_tag: u8, withdrawal_address: Address, deposit_index: u64) -> [u8; 32] {
@@ -96,6 +104,72 @@ fn pubkeys_with_buffered_full_exit(state: &ConsensusState) -> BTreeSet<[u8; 32]>
         }
     }
     pubkeys
+}
+
+fn malformed_deposit_refund_key(withdrawal_address: Address, deposit_index: u64) -> [u8; 32] {
+    deposit_refund_key(0xFD, withdrawal_address, deposit_index)
+}
+
+/// Queue an immediate refund withdrawal for a deposit that was rejected
+/// before any balance was credited. Shared between `verify_deposit_request`
+/// failures (`Refund` / `InvalidSignature`) and per-chunk parse failures
+/// (`MalformedKey`) so a malformed deposit chunk follows the same
+/// no-account, balance_deduction=0 refund path as a signature-invalid one.
+fn queue_deposit_refund(
+    state: &mut ConsensusState,
+    withdrawal_credentials_bytes: [u8; 32],
+    amount: u64,
+    deposit_index: u64,
+    reason: DepositRejectionReason,
+    consts: &ProtocolConsts,
+) {
+    let withdrawal_address = match parse_withdrawal_credentials(withdrawal_credentials_bytes) {
+        Ok(addr) => addr,
+        Err(e) => {
+            // The deposited funds are lost in this case. The deposit
+            // contract verifies that withdrawal credentials follow the
+            // expected format, so this should never happen.
+            error!(
+                target: "critical",
+                reason = "failed to parse withdrawal credentials (this is not a Summit error)",
+                withdrawal_credentials = ?withdrawal_credentials_bytes,
+                amount,
+                deposit_index,
+                rejection_reason = ?reason,
+            );
+            #[cfg(feature = "prom")]
+            counter!(
+                "critical_errors_total",
+                "reason" => "invalid_withdrawal_credentials",
+                "severity" => "critical",
+            )
+            .increment(1);
+            warn!("Failed to parse withdrawal credentials: {e}");
+            return;
+        }
+    };
+
+    let refund_pubkey = match reason {
+        DepositRejectionReason::Refund => refunded_deposit_key(withdrawal_address, deposit_index),
+        DepositRejectionReason::InvalidSignature => {
+            invalid_signature_refund_key(withdrawal_address, deposit_index)
+        }
+        DepositRejectionReason::MalformedKey => {
+            malformed_deposit_refund_key(withdrawal_address, deposit_index)
+        }
+    };
+
+    let withdrawal_request = WithdrawalRequest {
+        source_address: withdrawal_address,
+        validator_pubkey: refund_pubkey,
+        amount,
+    };
+    let withdrawal_epoch = state.get_epoch() + consts.validator_withdrawal_num_epochs;
+    state.push_withdrawal_request(
+        withdrawal_request,
+        withdrawal_epoch,
+        0, // deposit was never credited to balance
+    );
 }
 
 /// Tracks the consensus state for a notarized (but not yet finalized) block
@@ -1611,11 +1685,34 @@ async fn parse_execution_requests<
     all_requests.extend(block.execution_requests.iter().cloned());
 
     for request_bytes in &all_requests {
-        match ExecutionRequest::try_from_eth_entry(request_bytes.as_ref()) {
-            Ok(execution_requests) => {
-                for execution_request in execution_requests {
-                    match execution_request {
-                        ExecutionRequest::Deposit(deposit_request) => {
+        match ExecutionRequest::parse_eth_entry(request_bytes.as_ref()) {
+            Ok(parsed_requests) => {
+                for parsed in parsed_requests {
+                    match parsed {
+                        ParsedExecutionRequest::MalformedDeposit(chunk) => {
+                            // EIP-6110 grouping concatenates same-block deposit logs
+                            // into one entry; a single contract-accepted but
+                            // parser-invalid chunk must not poison the others.
+                            // Route it through the same refund branch as a
+                            // signature-invalid deposit.
+                            info!(
+                                reason = chunk.reason,
+                                amount = chunk.amount,
+                                index = chunk.index,
+                                "refunding malformed deposit chunk",
+                            );
+                            queue_deposit_refund(
+                                state,
+                                chunk.withdrawal_credentials,
+                                chunk.amount,
+                                chunk.index,
+                                DepositRejectionReason::MalformedKey,
+                                consts,
+                            );
+                        }
+                        ParsedExecutionRequest::Valid(ExecutionRequest::Deposit(
+                            deposit_request,
+                        )) => {
                             match verify_deposit_request(
                                 context,
                                 &deposit_request,
@@ -1673,51 +1770,20 @@ async fn parse_execution_requests<
                                     state.push_deposit(deposit_request.clone());
                                 }
                                 Err(reason) => {
-                                    let withdrawal_credentials = match parse_withdrawal_credentials(
+                                    queue_deposit_refund(
+                                        state,
                                         deposit_request.withdrawal_credentials,
-                                    ) {
-                                        Ok(withdrawal_credentials) => withdrawal_credentials,
-                                        Err(e) => {
-                                            // The deposited funds would be lost in this case.
-                                            // The deposit contract verifies that the withdrawal credentials
-                                            // follow the expected format, so this should never happen.
-                                            error!(target: "critical", reason = "failed to parse withdrawal credentials (this is not a Summit error)", ?deposit_request);
-                                            #[cfg(feature = "prom")]
-                                            counter!("critical_errors_total", "reason" => "invalid_withdrawal_credentials", "severity" => "critical").increment(1);
-                                            warn!("Failed to parse withdrawal credentials: {e}");
-                                            continue;
-                                        }
-                                    };
-
-                                    let refund_pubkey = match reason {
-                                        DepositRejectionReason::Refund => refunded_deposit_key(
-                                            withdrawal_credentials,
-                                            deposit_request.index,
-                                        ),
-                                        DepositRejectionReason::InvalidSignature => {
-                                            invalid_signature_refund_key(
-                                                withdrawal_credentials,
-                                                deposit_request.index,
-                                            )
-                                        }
-                                    };
-                                    let withdrawal_request = WithdrawalRequest {
-                                        source_address: withdrawal_credentials,
-                                        validator_pubkey: refund_pubkey,
-                                        amount: deposit_request.amount,
-                                    };
-                                    let withdrawal_epoch =
-                                        state.get_epoch() + consts.validator_withdrawal_num_epochs;
-
-                                    state.push_withdrawal_request(
-                                        withdrawal_request.clone(),
-                                        withdrawal_epoch,
-                                        0, // deposit was never credited to balance
+                                        deposit_request.amount,
+                                        deposit_request.index,
+                                        reason,
+                                        consts,
                                     );
                                 }
                             }
                         }
-                        ExecutionRequest::Withdrawal(mut withdrawal_request) => {
+                        ParsedExecutionRequest::Valid(ExecutionRequest::Withdrawal(
+                            mut withdrawal_request,
+                        )) => {
                             // Only add the withdrawal request if the validator exists and has sufficient balance
                             if let Some(mut account) = state
                                 .get_account(&withdrawal_request.validator_pubkey)
@@ -1829,7 +1895,9 @@ async fn parse_execution_requests<
                                 );
                             }
                         }
-                        ExecutionRequest::ProtocolParam(protocol_param_request) => {
+                        ParsedExecutionRequest::Valid(ExecutionRequest::ProtocolParam(
+                            protocol_param_request,
+                        )) => {
                             info!("Received protocol param request: {protocol_param_request:?}");
 
                             // Buffer protocol param requests landing on the last block of

--- a/finalizer/src/actor.rs
+++ b/finalizer/src/actor.rs
@@ -94,11 +94,11 @@ fn invalid_signature_refund_key(withdrawal_address: Address, deposit_index: u64)
 fn pubkeys_with_buffered_full_exit(state: &ConsensusState) -> BTreeSet<[u8; 32]> {
     let mut pubkeys = BTreeSet::new();
     for entry in state.pending_execution_requests() {
-        let Ok(parsed) = ExecutionRequest::try_from_eth_entry(entry.as_ref()) else {
+        let Ok(parsed) = ExecutionRequest::parse_eth_entry(entry.as_ref()) else {
             continue;
         };
         for req in parsed {
-            if let ExecutionRequest::Withdrawal(w) = req {
+            if let ParsedExecutionRequest::Valid(ExecutionRequest::Withdrawal(w)) = req {
                 pubkeys.insert(w.validator_pubkey);
             }
         }

--- a/types/src/execution_request.rs
+++ b/types/src/execution_request.rs
@@ -15,6 +15,30 @@ pub enum ExecutionRequest {
     ProtocolParam(ProtocolParamRequest),
 }
 
+/// Refund metadata extracted from a 288-byte deposit chunk whose Ed25519 or
+/// BLS key fields could not be decoded. Withdrawal credentials, amount, and
+/// index live at fixed offsets and are recoverable from the raw chunk even
+/// when key decoding fails.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MalformedDepositRequest {
+    pub withdrawal_credentials: [u8; 32],
+    pub amount: u64,
+    pub index: u64,
+    pub reason: &'static str,
+}
+
+/// Per-chunk outcome of parsing a grouped EIP-7685 entry.
+/// `MalformedDeposit` is parse-time only and never round-trips through the
+/// Summit-internal codec — it exists so the finalizer can route a single
+/// bad chunk through the refund branch instead of dropping every chunk in
+/// the entry.
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug, Clone, PartialEq)]
+pub enum ParsedExecutionRequest {
+    Valid(ExecutionRequest),
+    MalformedDeposit(MalformedDepositRequest),
+}
+
 impl ExecutionRequest {
     pub fn try_from_eth_bytes(bytes: &[u8]) -> Result<Self, &'static str> {
         if bytes.is_empty() {
@@ -43,31 +67,69 @@ impl ExecutionRequest {
         }
     }
 
-    pub fn try_from_eth_entry(bytes: &[u8]) -> Result<Vec<Self>, &'static str> {
+    /// Parse a grouped EIP-7685 entry chunk-by-chunk. The outer `Err`
+    /// captures entry-level structural failures (empty buffer, unknown type
+    /// byte, length not a multiple of the per-chunk size). Within a `0x00`
+    /// (deposit) entry, individual chunks whose Ed25519 / BLS keys cannot
+    /// be decoded surface as `MalformedDeposit` carrying the refund
+    /// metadata so the caller can isolate them from chunks that decoded
+    /// cleanly.
+    ///
+    /// Reth's EIP-6110 extraction concatenates same-block deposit logs into
+    /// one type-0x00 entry, so a single contract-accepted but
+    /// parser-invalid deposit would otherwise poison every legitimate
+    /// deposit alongside it.
+    pub fn parse_eth_entry(bytes: &[u8]) -> Result<Vec<ParsedExecutionRequest>, &'static str> {
         if bytes.is_empty() {
             return Err("ExecutionRequest cannot be empty");
         }
 
         match bytes[0] {
-            0x00 => DepositRequest::try_from_eth_entry_bytes(&bytes[1..]).map(|requests| {
-                requests
-                    .into_iter()
-                    .map(ExecutionRequest::Deposit)
-                    .collect::<Vec<_>>()
-            }),
-            0x01 => WithdrawalRequest::try_from_eth_entry_bytes(&bytes[1..]).map(|requests| {
-                requests
-                    .into_iter()
-                    .map(ExecutionRequest::Withdrawal)
-                    .collect::<Vec<_>>()
-            }),
-            0xFF => ProtocolParamRequest::try_from_eth_entry_bytes(&bytes[1..]).map(|requests| {
-                requests
-                    .into_iter()
-                    .map(ExecutionRequest::ProtocolParam)
-                    .collect::<Vec<_>>()
-            }),
+            0x00 => {
+                let body = &bytes[1..];
+                if !body
+                    .len()
+                    .is_multiple_of(<DepositRequest as FixedSize>::SIZE)
+                {
+                    return Err("DepositRequest payload length must be a multiple of 288 bytes");
+                }
+                Ok(body
+                    .chunks_exact(<DepositRequest as FixedSize>::SIZE)
+                    .map(parse_deposit_chunk)
+                    .collect())
+            }
+            0x01 => Ok(WithdrawalRequest::try_from_eth_entry_bytes(&bytes[1..])?
+                .into_iter()
+                .map(|w| ParsedExecutionRequest::Valid(ExecutionRequest::Withdrawal(w)))
+                .collect()),
+            0xFF => Ok(ProtocolParamRequest::try_from_eth_entry_bytes(&bytes[1..])?
+                .into_iter()
+                .map(|p| ParsedExecutionRequest::Valid(ExecutionRequest::ProtocolParam(p)))
+                .collect()),
             _request_type => Err("Unknown execution request type"),
+        }
+    }
+}
+
+fn parse_deposit_chunk(chunk: &[u8]) -> ParsedExecutionRequest {
+    match DepositRequest::try_from_eth_bytes(chunk) {
+        Ok(deposit) => ParsedExecutionRequest::Valid(ExecutionRequest::Deposit(deposit)),
+        Err(reason) => {
+            // try_from_eth_bytes only fails for key-decode errors on a
+            // 288-byte chunk, so these byte slices are guaranteed to be
+            // extractable.
+            let withdrawal_credentials: [u8; 32] =
+                chunk[80..112].try_into().expect("288-byte deposit chunk");
+            let amount =
+                u64::from_le_bytes(chunk[112..120].try_into().expect("288-byte deposit chunk"));
+            let index =
+                u64::from_le_bytes(chunk[280..288].try_into().expect("288-byte deposit chunk"));
+            ParsedExecutionRequest::MalformedDeposit(MalformedDepositRequest {
+                withdrawal_credentials,
+                amount,
+                index,
+                reason,
+            })
         }
     }
 }
@@ -787,6 +849,131 @@ mod tests {
         } else {
             panic!("Expected Invalid error");
         }
+    }
+
+    /// Build a valid 288-byte deposit chunk by serializing a real
+    /// `DepositRequest` whose keys decode cleanly.
+    fn valid_deposit_chunk(
+        seed: u64,
+        withdrawal_credentials: [u8; 32],
+        amount: u64,
+        index: u64,
+    ) -> ([u8; 288], DepositRequest) {
+        let node_private_key = commonware_cryptography::ed25519::PrivateKey::from_seed(seed);
+        let consensus_private_key = bls12381::PrivateKey::from_seed(seed);
+        let deposit = DepositRequest {
+            node_pubkey: node_private_key.public_key(),
+            consensus_pubkey: consensus_private_key.public_key(),
+            withdrawal_credentials,
+            amount,
+            node_signature: [seed as u8; 64],
+            consensus_signature: [seed as u8; 96],
+            index,
+        };
+        let mut buf = BytesMut::new();
+        deposit.write(&mut buf);
+        let chunk: [u8; 288] = buf.as_ref().try_into().unwrap();
+        (chunk, deposit)
+    }
+
+    /// Build a 288-byte chunk that the public deposit contract would accept
+    /// (length / withdrawal-credentials shape look fine) but whose BLS
+    /// consensus pubkey field bytes cannot be decoded as a G1 point. Returns
+    /// the chunk together with the embedded refund metadata so the test can
+    /// pin what the per-chunk parser should surface.
+    fn parser_invalid_deposit_chunk(
+        withdrawal_credentials: [u8; 32],
+        amount: u64,
+        index: u64,
+    ) -> [u8; 288] {
+        let mut chunk = [0u8; 288];
+        // node_pubkey: 32 bytes that pass Ed25519 decoding (any byte pattern
+        // works here — Ed25519 decode does not reject curve points up front).
+        chunk[0..32].copy_from_slice(&[0x01u8; 32]);
+        // consensus_pubkey: 48 bytes that fail BLS12-381 G1 decoding.
+        // Compressed-form flag bits set but x coordinate = 2^381 - 1, which
+        // is far above the field modulus p, so decode must reject.
+        chunk[32] = 0x9F;
+        for b in chunk.iter_mut().take(80).skip(33) {
+            *b = 0xFF;
+        }
+        // withdrawal_credentials (32 bytes): copied verbatim by the parser.
+        chunk[80..112].copy_from_slice(&withdrawal_credentials);
+        // amount (8 bytes, little-endian).
+        chunk[112..120].copy_from_slice(&amount.to_le_bytes());
+        // node_signature (64 bytes) + consensus_signature (96 bytes): not
+        // decoded at parse time; leave as zero.
+        // index (8 bytes, little-endian).
+        chunk[280..288].copy_from_slice(&index.to_le_bytes());
+        chunk
+    }
+
+    /// Regression test for the grouped-deposit poisoning attack. Reth's
+    /// EIP-6110 deposit extraction concatenates every same-block deposit
+    /// log into a single type-0x00 EIP-7685 entry. Summit's per-chunk
+    /// parser must surface the valid chunk as `Valid(Deposit(_))` and the
+    /// contract-accepted-but-parser-invalid chunk as `MalformedDeposit(_)`
+    /// carrying the refund metadata — without dropping either.
+    #[test]
+    fn parse_eth_entry_isolates_malformed_chunk_in_grouped_deposit_entry() {
+        let valid_creds = [0x01u8; 32];
+        let valid_amount = 32_000_000_000u64; // 32 ETH in gwei
+        let valid_index = 7u64;
+        let (valid_chunk, valid_deposit) =
+            valid_deposit_chunk(11, valid_creds, valid_amount, valid_index);
+
+        let bad_creds = [0x01u8; 32];
+        let bad_amount = 1_000_000_000u64; // 1 ETH minimum
+        let bad_index = 8u64;
+        let bad_chunk = parser_invalid_deposit_chunk(bad_creds, bad_amount, bad_index);
+
+        // Sanity: each chunk on its own behaves as we expect, so the
+        // grouped-entry test below is exercising the poisoning path and
+        // nothing else.
+        assert!(
+            DepositRequest::try_from_eth_bytes(&bad_chunk).is_err(),
+            "test setup: parser_invalid_deposit_chunk did not fail decoding"
+        );
+        assert!(
+            DepositRequest::try_from_eth_bytes(&valid_chunk).is_ok(),
+            "test setup: valid_deposit_chunk did not parse on its own"
+        );
+
+        // Build the 0x00 entry the way Reth/EIP-6110 would: one type byte
+        // followed by concatenated 288-byte chunks.
+        let mut entry = vec![0x00];
+        entry.extend_from_slice(&valid_chunk);
+        entry.extend_from_slice(&bad_chunk);
+
+        let parsed = ExecutionRequest::parse_eth_entry(&entry)
+            .expect("entry-level structure is valid (length is a multiple of 288)");
+        assert_eq!(parsed.len(), 2);
+
+        match &parsed[0] {
+            ParsedExecutionRequest::Valid(ExecutionRequest::Deposit(d)) => {
+                assert_eq!(d, &valid_deposit)
+            }
+            other => panic!("valid chunk was not surfaced as Valid(Deposit): {other:?}"),
+        }
+        match &parsed[1] {
+            ParsedExecutionRequest::MalformedDeposit(m) => {
+                assert_eq!(m.withdrawal_credentials, bad_creds);
+                assert_eq!(m.amount, bad_amount);
+                assert_eq!(m.index, bad_index);
+            }
+            other => panic!("parser-invalid chunk was not surfaced as MalformedDeposit: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_eth_entry_rejects_deposit_entry_with_truncated_length() {
+        // 1 (type byte) + 287 bytes is not a valid deposit entry — the body
+        // must be a multiple of 288. This is an entry-level structural
+        // failure that cannot be recovered per-chunk.
+        let mut entry = vec![0x00];
+        entry.extend_from_slice(&[0u8; 287]);
+        let err = ExecutionRequest::parse_eth_entry(&entry).unwrap_err();
+        assert!(err.contains("multiple of 288"), "unexpected error: {err}");
     }
 
     #[test]


### PR DESCRIPTION
Builds on https://github.com/SeismicSystems/summit/pull/202 (which builds on https://github.com/SeismicSystems/summit/pull/167 and https://github.com/SeismicSystems/summit/pull/192).

This addresses https://github.com/SeismicSystems/summit/issues/201.

Changes:
- Introduces an enum `ParsedExecutionRequest` with variants `Valid(ExecutionRequest)` and `MalformedDeposit(MalformedDepositRequest)`. `ExecutionRequest` is the already existing execution request type, and `MalformedDepositRequest` is a new type for a deposit request with invalid keys.
```rust
pub enum ParsedExecutionRequest {
    Valid(ExecutionRequest),
    MalformedDeposit(MalformedDepositRequest),
}
```
- Arriving execution requests are parsed into `ParsedExecutionRequest` first, and then processed. Malformed deposit requests will be rejected and a withdrawal will be initiated similarly to deposit requests that contain invalid signatures.
- Unit tests are added to ensure that a malformed deposit request cannot drop valid same-entry deposit requests.