### PR TITLE
fix: update state proof batch result alignment

### DIFF
--- a/docs/ssz-merklization.md
+++ b/docs/ssz-merklization.md
@@ -371,19 +371,32 @@ The state root appears on-chain in EL block `el_block_number + 1`.
 
 ### `getStateProof`
 
-Takes a list of key strings and returns the state root, EL block number, and an `SszProof` for each key.
+Takes a list of key strings and returns the state root, EL block number, and one result for each key. Each result echoes the requested key and contains either an `SszProof` or an error for a key that is absent or out of range.
 
 ```json
 // Request
-{"jsonrpc":"2.0","method":"getStateProof","params":[["epoch","validator:0xABCD..."]],"id":1}
+{"jsonrpc":"2.0","method":"getStateProof","params":[["epoch","validator:0xABCD...","deposit:999999"]],"id":1}
 
 // Response
 {
   "root": "0x...",
   "el_block_number": 42,
-  "proofs": [
-    { "gindex": 32, "leaf": "0x...", "branch": ["0x...", ...] },
-    { "gindex": 1408, "leaf": "0x...", "branch": ["0x...", ...] }
+  "results": [
+    {
+      "key": "epoch",
+      "proof": { "gindex": 32, "leaf": "0x...", "branch": ["0x...", ...] },
+      "error": null
+    },
+    {
+      "key": "validator:0xABCD...",
+      "proof": { "gindex": 1408, "leaf": "0x...", "branch": ["0x...", ...] },
+      "error": null
+    },
+    {
+      "key": "deposit:999999",
+      "proof": null,
+      "error": "key is absent or out of range"
+    }
   ]
 }
 ```

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -133,7 +133,7 @@ Tests end-to-end SSZ proof verification on-chain — the full pipeline from Summ
 - **Contracts**: EIP-4788 beacon roots contract (`0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02`, built into Reth); deploys the embedded `SszProofVerifier.sol` bytecode at runtime.
 - **Flow**: Waits for the network to finalize several blocks so the SSZ proof tree is captured, then:
   - **TEST A** — reads the `parent_beacon_block_root` via the beacon-roots contract and asserts it matches Summit's captured state root.
-  - **TEST B** — deploys `SszProofVerifier`, requests scalar proofs via `getStateProof(["epoch", "latest_height"])`, and verifies each proof on-chain against the beacon root.
+  - **TEST B** — deploys `SszProofVerifier`, requests scalar proof results via `getStateProof(["epoch", "latest_height"])`, and verifies each proof on-chain against the beacon root.
   - **TEST C** — requests a collection (validator) proof for genesis validator 0 and verifies it on-chain via the same verifier.
 - **Verifies**: Both scalar and collection SSZ proofs verify on-chain against the beacon root surfaced by EIP-4788, confirming the end-to-end trust chain from Summit consensus state → Reth EL block → Solidity verifier.
 

--- a/finalizer/src/actor.rs
+++ b/finalizer/src/actor.rs
@@ -1231,9 +1231,9 @@ impl<
             }
             ConsensusStateRequest::GenerateStateProof(keys) => {
                 let proof_tree = self.canonical_state.proof_tree();
-                let proofs: Vec<SszProof> = keys
+                let proofs: Vec<Option<SszProof>> = keys
                     .iter()
-                    .filter_map(|key| match key {
+                    .map(|key| match key {
                         SszStateKey::Scalar(leaf_index) => {
                             Some(proof_tree.generate_scalar_proof(*leaf_index))
                         }

--- a/finalizer/src/ingress.rs
+++ b/finalizer/src/ingress.rs
@@ -454,7 +454,11 @@ impl<S: Scheme<B::Digest>, B: ConsensusBlock> FinalizerMailbox<S, B> {
     pub async fn generate_state_proof(
         &self,
         keys: Vec<summit_types::ssz_tree_key::SszStateKey>,
-    ) -> ([u8; 32], u64, Vec<summit_types::ssz_state_tree::SszProof>) {
+    ) -> (
+        [u8; 32],
+        u64,
+        Vec<Option<summit_types::ssz_state_tree::SszProof>>,
+    ) {
         let (response, rx) = oneshot::channel();
         let request = ConsensusStateRequest::GenerateStateProof(keys);
         let _ = self

--- a/finalizer/src/tests/state_queries.rs
+++ b/finalizer/src/tests/state_queries.rs
@@ -24,6 +24,7 @@ use std::time::Duration;
 use summit_syncer::Update;
 use summit_types::account::{ValidatorAccount, ValidatorStatus};
 use summit_types::consensus_state::ConsensusState;
+use summit_types::ssz_tree_key::SszStateKey;
 use summit_types::{Block, Digest};
 use tokio_util::sync::CancellationToken;
 
@@ -132,6 +133,88 @@ fn create_test_initial_state(genesis_hash: [u8; 32], epoch_length: NonZeroU64) -
     );
     state.set_validator_accounts(validator_accounts);
     state
+}
+
+#[test]
+fn test_generate_state_proof_preserves_batch_cardinality_for_missing_keys() {
+    let cfg = deterministic::Config::default().with_seed(56);
+    let executor = Runner::from(cfg);
+    executor.start(|context| async move {
+        let genesis_hash = [0x56u8; 32];
+        let initial_state = create_test_initial_state(genesis_hash, NonZeroU64::new(5).unwrap());
+
+        let (orchestrator_tx, _orchestrator_rx) = futures_mpsc::channel(100);
+        let orchestrator_mailbox = summit_orchestrator::Mailbox::new(orchestrator_tx);
+
+        let node_key = ed25519::PrivateKey::from_seed(0);
+
+        let finalizer_cfg = FinalizerConfig::<MockEngineClient, MockNetworkOracle, MinPk> {
+            mailbox_size: 100,
+            db_prefix: "test_state_proof_cardinality".to_string(),
+            engine_client: MockEngineClient::new(),
+            oracle: MockNetworkOracle,
+            protocol_consts: ProtocolConsts {
+                validator_num_warm_up_epochs: 2,
+                validator_withdrawal_num_epochs: 2,
+            },
+
+            page_cache: CacheRef::from_pooler(
+                &context,
+                std::num::NonZero::new(4096).unwrap(),
+                NZUsize!(100),
+            ),
+            genesis_hash,
+            initial_state,
+            protocol_version: 1,
+            node_public_key: node_key.public_key(),
+            cancellation_token: CancellationToken::new(),
+            _variant_marker: PhantomData,
+        };
+
+        let (finalizer, _state, mailbox) =
+            Finalizer::<_, MockEngineClient, MockNetworkOracle, ed25519::PrivateKey, MinPk>::new(
+                context.with_label("finalizer"),
+                finalizer_cfg,
+            )
+            .await;
+
+        let _handle = finalizer.start(orchestrator_mailbox);
+        context.sleep(Duration::from_millis(100)).await;
+
+        let requested_keys = vec![
+            SszStateKey::Scalar(summit_types::ssz_state_tree::EPOCH),
+            SszStateKey::Deposit(0),
+            SszStateKey::Scalar(summit_types::ssz_state_tree::LATEST_HEIGHT),
+        ];
+        let (root, _el_block_number, proofs) =
+            mailbox.generate_state_proof(requested_keys.clone()).await;
+
+        assert_eq!(
+            proofs.len(),
+            requested_keys.len(),
+            "state proof batches must preserve one response slot per requested key"
+        );
+        assert!(
+            proofs[0]
+                .as_ref()
+                .expect("first response slot should contain the epoch proof")
+                .verify(&root),
+            "first response slot should contain the epoch proof"
+        );
+        assert!(
+            proofs[1].is_none(),
+            "second response slot should mark the missing deposit proof"
+        );
+        assert!(
+            proofs[2]
+                .as_ref()
+                .expect("third response slot should contain the latest_height proof")
+                .verify(&root),
+            "third response slot should contain the latest_height proof"
+        );
+
+        context.auditor().state()
+    });
 }
 
 #[test]

--- a/node/src/bin/verify_consensus_state_proof.rs
+++ b/node/src/bin/verify_consensus_state_proof.rs
@@ -200,10 +200,22 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             println!("  root: 0x{}", alloy::hex::encode(proof_resp.root));
             println!("  el_block_number: {}", proof_resp.el_block_number);
-            println!("  proofs returned: {}", proof_resp.proofs.len());
-            for (i, proof) in proof_resp.proofs.iter().enumerate() {
-                println!("  proof[{i}]: gindex={}, leaf=0x{}, branch_len={}",
-                    proof.gindex, alloy::hex::encode(proof.leaf), proof.branch.len());
+            println!("  results returned: {}", proof_resp.results.len());
+            for (i, result) in proof_resp.results.iter().enumerate() {
+                match &result.proof {
+                    Some(proof) => println!(
+                        "  result[{i}] {}: gindex={}, leaf=0x{}, branch_len={}",
+                        result.key,
+                        proof.gindex,
+                        alloy::hex::encode(proof.leaf),
+                        proof.branch.len()
+                    ),
+                    None => println!(
+                        "  result[{i}] {}: missing ({})",
+                        result.key,
+                        result.error.as_deref().unwrap_or("unknown error")
+                    ),
+                }
             }
 
             // Build alloy provider with a funded wallet (for contract deploy)
@@ -290,7 +302,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             let verify_selector = &keccak256(
                 "verify(uint256,uint256,bytes32,bytes32[])"
             )[..4];
-            for (i, proof) in proof_resp.proofs.iter().enumerate() {
+            for (i, result) in proof_resp.results.iter().enumerate() {
+                let proof = result
+                    .proof
+                    .as_ref()
+                    .expect("scalar state proof should be present");
                 let calldata = encode_verify(
                     timestamp,
                     proof.gindex,
@@ -327,10 +343,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .await
                 .expect("getStateProof (validator) failed");
             println!("  root: 0x{}", alloy::hex::encode(val_proof_resp.root));
-            println!("  proofs returned: {}", val_proof_resp.proofs.len());
-            assert!(
-                !val_proof_resp.proofs.is_empty(),
-                "No proofs returned for validator"
+            println!("  results returned: {}", val_proof_resp.results.len());
+            assert_eq!(
+                val_proof_resp.results.len(),
+                1,
+                "Expected one result for validator"
             );
 
             // Wait for the target block to exist (might be a newer capture)
@@ -350,7 +367,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .expect("Block not found");
             let val_timestamp = val_block.header.timestamp;
 
-            let vp = &val_proof_resp.proofs[0];
+            let vp = val_proof_resp.results[0]
+                .proof
+                .as_ref()
+                .expect("No proof returned for validator");
             {
                 let calldata = encode_verify(
                     val_timestamp,
@@ -399,12 +419,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .await
                 .expect("getStateProof (balance field) failed");
             println!("  root: 0x{}", alloy::hex::encode(balance_proof_resp.root));
-            assert!(
-                !balance_proof_resp.proofs.is_empty(),
-                "No proofs returned for balance field"
+            assert_eq!(
+                balance_proof_resp.results.len(),
+                1,
+                "Expected one result for balance field"
             );
 
-            let bp = &balance_proof_resp.proofs[0];
+            let bp = balance_proof_resp.results[0]
+                .proof
+                .as_ref()
+                .expect("No proof returned for balance field");
             println!(
                 "  gindex={}, leaf=0x{}, branch_len={}",
                 bp.gindex,

--- a/rpc/src/server.rs
+++ b/rpc/src/server.rs
@@ -7,7 +7,7 @@ use crate::error::RpcError;
 use crate::types::{
     CheckpointInfoRes, CheckpointRes, DepositResponse, DepositTransactionResponse,
     EpochBoundsResponse, FinalizedHeaderRes, PendingWithdrawalResponse, PublicKeysResponse,
-    StateProofResponse, StateRootResponse, ValidatorAccountResponse,
+    StateProofResponse, StateProofResult, StateRootResponse, ValidatorAccountResponse,
 };
 use alloy_primitives::{Address, U256, hex::FromHex as _};
 use async_trait::async_trait;
@@ -416,15 +416,34 @@ impl SummitProofApiServer for SummitRpcServer {
             .map(|k| summit_types::ssz_tree_key::parse_key(k).map_err(RpcError::InvalidKey))
             .collect::<Result<Vec<_>, _>>()?;
 
+        let requested_len = keys.len();
         let (root, el_block_number, proofs) = self
             .finalizer_mailbox
             .generate_state_proof(parsed_keys)
             .await;
+        if proofs.len() != requested_len {
+            return Err(RpcError::Internal(format!(
+                "state proof response length mismatch: requested {requested_len}, got {}",
+                proofs.len()
+            ))
+            .into());
+        }
+
+        let results = keys
+            .into_iter()
+            .zip(proofs)
+            .map(|(key, proof)| {
+                let error = proof
+                    .is_none()
+                    .then(|| "key is absent or out of range".to_string());
+                StateProofResult { key, proof, error }
+            })
+            .collect();
 
         Ok(StateProofResponse {
             root,
             el_block_number,
-            proofs,
+            results,
         })
     }
 }

--- a/rpc/src/types.rs
+++ b/rpc/src/types.rs
@@ -18,5 +18,6 @@ pub struct DepositTransactionResponse {
 
 pub use summit_types::rpc::{
     CheckpointInfoRes, CheckpointRes, DepositResponse, EpochBoundsResponse, FinalizedHeaderRes,
-    PendingWithdrawalResponse, StateProofResponse, StateRootResponse, ValidatorAccountResponse,
+    PendingWithdrawalResponse, StateProofResponse, StateProofResult, StateRootResponse,
+    ValidatorAccountResponse,
 };

--- a/types/src/consensus_state_query.rs
+++ b/types/src/consensus_state_query.rs
@@ -62,7 +62,7 @@ pub enum ConsensusStateResponse<S: Scheme> {
     StateProof {
         root: [u8; 32],
         el_block_number: u64,
-        proofs: Vec<SszProof>,
+        proofs: Vec<Option<SszProof>>,
     },
 }
 

--- a/types/src/rpc.rs
+++ b/types/src/rpc.rs
@@ -69,7 +69,14 @@ pub struct StateProofResponse {
     /// The EL block number at capture time. The root appears on-chain in EL block
     /// `el_block_number + 1` — query that block's timestamp via the beacon roots contract.
     pub el_block_number: u64,
-    pub proofs: Vec<crate::ssz_state_tree::SszProof>,
+    pub results: Vec<StateProofResult>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct StateProofResult {
+    pub key: String,
+    pub proof: Option<crate::ssz_state_tree::SszProof>,
+    pub error: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]


### PR DESCRIPTION
Addresses https://github.com/SeismicSystems/summit/issues/260.

  Changes:

  - Preserve one internal proof result per requested key with Option<SszProof>.
  - Return keyed RPC results[] entries with proof or error.
  - Add a regression test for mixed valid/missing batched keys.
  - Update docs and the e2e proof verifier for the new response shape.
  - Adds unit test `test_generate_state_proof_preserves_batch_cardinality_for_missing_keys` .