### PR TITLE
fix: protect finalizer loop from expensive RPC requests

### DIFF
--- a/finalizer/src/actor.rs
+++ b/finalizer/src/actor.rs
@@ -1910,7 +1910,7 @@ impl<
                     el_block_number,
                 });
             }
-            ConsensusStateRequest::GenerateStateProof(keys) => {
+            ConsensusStateRequest::GenerateStateProof(keys, permit) => {
                 let proof_tree = self.canonical_state.proof_tree_snapshot();
                 let validator_keys = self.canonical_state.proof_validator_keys_snapshot();
                 let root = self.canonical_state.get_state_root();
@@ -1929,6 +1929,18 @@ impl<
                             el_block_number,
                             proofs,
                         });
+                        // Release the rpc concurrency permit (if any) only now
+                        // that the proof work has actually finished. The permit
+                        // must be consumed inside this detached task because
+                        // moving it here is what ties the in-flight-proof count
+                        // to real work. If it instead dropped on the rpc handler
+                        // future, a caller could connect, wait for the spawn,
+                        // disconnect, and repeat to pile up proof tasks under a
+                        // slot count that reads as idle. The explicit drop also
+                        // forces the move closure to capture it rather than
+                        // dropping it on the finalizer loop when the match arm
+                        // ends.
+                        drop(permit);
                     });
             }
         }

--- a/finalizer/src/actor.rs
+++ b/finalizer/src/actor.rs
@@ -17,7 +17,7 @@ use commonware_storage::translator::EightCap;
 use commonware_utils::acknowledgement::{Acknowledgement, Exact};
 use commonware_utils::{NZU64, NZUsize, hex};
 use futures::channel::{mpsc, oneshot};
-use futures::{FutureExt, StreamExt as _, select};
+use futures::{FutureExt, StreamExt as _, select_biased};
 #[cfg(feature = "prom")]
 use metrics::{counter, histogram};
 #[cfg(debug_assertions)]
@@ -31,7 +31,9 @@ use summit_orchestrator::Message;
 use summit_syncer::Update;
 use summit_types::account::{ValidatorAccount, ValidatorStatus};
 use summit_types::checkpoint::Checkpoint;
-use summit_types::consensus_state_query::{ConsensusStateRequest, ConsensusStateResponse};
+use summit_types::consensus_state_query::{
+    ConsensusStateQuery, ConsensusStateRequest, ConsensusStateResponse,
+};
 use summit_types::execution_request::{
     DepositRequest, ExecutionRequest, ParsedExecutionRequest, WithdrawalRequest,
 };
@@ -40,7 +42,7 @@ use summit_types::ext_private_key::derive_observer_keys;
 use summit_types::network_oracle::NetworkOracle;
 use summit_types::protocol_params::ProtocolParam;
 use summit_types::scheme::EpochTransition;
-use summit_types::ssz_state_tree::SszProof;
+use summit_types::ssz_state_tree::{SszProof, SszStateTree};
 use summit_types::ssz_tree_key::SszStateKey;
 use summit_types::utils::{
     is_first_block_of_epoch, is_last_block_of_epoch, is_penultimate_block_of_epoch,
@@ -55,6 +57,55 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, trace, warn};
 
 const WRITE_BUFFER: NonZero<usize> = NZUsize!(1024 * 1024);
+
+type FinalizerScheme<V> = bls12381_multisig::Scheme<PublicKey, V>;
+type StateQueryResponse<V> = ConsensusStateResponse<FinalizerScheme<V>>;
+type StateQueryMessage<V> = (
+    ConsensusStateRequest,
+    oneshot::Sender<StateQueryResponse<V>>,
+);
+
+/// Generate one proof slot per requested key, preserving positional alignment:
+/// the i-th result corresponds to the i-th key, and a key that resolves to no
+/// proof (missing collection entry, etc.) yields `None` rather than being
+/// dropped. Callers rely on this one-result-per-key invariant — see #260/#267 —
+/// so this must stay a `map` (not `filter_map`) into `Vec<Option<SszProof>>`.
+fn generate_state_proofs(
+    proof_tree: &SszStateTree,
+    validator_keys: &[[u8; 32]],
+    keys: &[SszStateKey],
+) -> Vec<Option<SszProof>> {
+    keys.iter()
+        .map(|key| match key {
+            SszStateKey::Scalar(leaf_index) => Some(proof_tree.generate_scalar_proof(*leaf_index)),
+            SszStateKey::Validator(pubkey) => {
+                proof_tree.generate_validator_proof(pubkey, validator_keys)
+            }
+            SszStateKey::ValidatorField(pubkey, field_index) => {
+                proof_tree.generate_validator_field_proof(pubkey, *field_index, validator_keys)
+            }
+            SszStateKey::Deposit(index) => proof_tree.generate_deposit_proof(*index),
+            SszStateKey::DepositField(index, field_index) => {
+                proof_tree.generate_deposit_field_proof(*index, *field_index)
+            }
+            SszStateKey::Withdrawal(pubkey) => proof_tree.generate_withdrawal_proof_by_key(pubkey),
+            SszStateKey::WithdrawalField(pubkey, field_index) => {
+                proof_tree.generate_withdrawal_field_proof_by_key(pubkey, *field_index)
+            }
+            SszStateKey::ProtocolParam(index) => proof_tree.generate_protocol_param_proof(*index),
+            SszStateKey::ProtocolParamField(index, field_index) => {
+                proof_tree.generate_protocol_param_field_proof(*index, *field_index)
+            }
+            SszStateKey::AddedValidator(index) => proof_tree.generate_added_validator_proof(*index),
+            SszStateKey::AddedValidatorField(index, field_index) => {
+                proof_tree.generate_added_validator_field_proof(*index, *field_index)
+            }
+            SszStateKey::RemovedValidator(index) => {
+                proof_tree.generate_removed_validator_proof(*index)
+            }
+        })
+        .collect()
+}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum DepositRejectionReason {
@@ -245,6 +296,7 @@ pub struct Finalizer<
     V: Variant,
 > {
     mailbox: mpsc::Receiver<FinalizerMessage<bls12381_multisig::Scheme<PublicKey, V>, Block>>,
+    state_query: mpsc::Receiver<StateQueryMessage<V>>,
     pending_height_notifys: BTreeMap<(u64, Digest), Vec<oneshot::Sender<bool>>>,
     context: ContextCell<R>,
     engine_client: C,
@@ -317,8 +369,10 @@ impl<
         Self,
         ConsensusState,
         FinalizerMailbox<bls12381_multisig::Scheme<PublicKey, V>, Block>,
+        ConsensusStateQuery<bls12381_multisig::Scheme<PublicKey, V>>,
     ) {
         let (tx, rx) = mpsc::channel(cfg.mailbox_size);
+        let (state_query, state_query_rx) = ConsensusStateQuery::new(cfg.mailbox_size);
         let state_cfg = StateConfig {
             log: commonware_storage::journal::contiguous::variable::Config {
                 partition: format!("{}-finalizer_state-log", cfg.db_prefix),
@@ -384,6 +438,7 @@ impl<
             Self {
                 context: ContextCell::new(context),
                 mailbox: rx,
+                state_query: state_query_rx,
                 engine_client: cfg.engine_client,
                 oracle: cfg.oracle,
                 pending_height_notifys: BTreeMap::new(),
@@ -417,6 +472,7 @@ impl<
             },
             shared_state,
             FinalizerMailbox::new(tx),
+            state_query,
         )
     }
 
@@ -428,6 +484,8 @@ impl<
         let mut last_committed_timestamp: Option<Instant> = None;
         let mut signal = self.context.stopped().fuse();
         let cancellation_token = self.cancellation_token.clone();
+        let (_, empty_state_query) = mpsc::channel(1);
+        let mut state_query = Some(std::mem::replace(&mut self.state_query, empty_state_query));
 
         // Initialize the current epoch with the validator set
         // This ensures the orchestrator can start consensus immediately
@@ -542,7 +600,16 @@ impl<
                 self.cancellation_token.cancel();
                 break;
             }
-            select! {
+            let query_message = async {
+                match state_query.as_mut() {
+                    Some(state_query) => state_query.next().await,
+                    None => std::future::pending().await,
+                }
+            }
+            .fuse();
+            futures::pin_mut!(query_message);
+
+            select_biased! {
                 mailbox_message = self.mailbox.next() => {
                     let mail = mailbox_message.expect("Finalizer mailbox closed");
                     match mail {
@@ -702,6 +769,17 @@ impl<
                 sig = &mut signal => {
                     info!("runtime terminated, shutting down finalizer: {}", sig.unwrap());
                     break;
+                },
+                query_message = query_message => {
+                    match query_message {
+                        Some((request, response)) => {
+                            self.handle_consensus_state_query(request, response).await;
+                        }
+                        None => {
+                            warn!("finalizer state query mailbox closed");
+                            state_query = None;
+                        }
+                    }
                 }
             }
         }
@@ -1833,57 +1911,25 @@ impl<
                 });
             }
             ConsensusStateRequest::GenerateStateProof(keys) => {
-                let proof_tree = self.canonical_state.proof_tree();
-                let proofs: Vec<Option<SszProof>> = keys
-                    .iter()
-                    .map(|key| match key {
-                        SszStateKey::Scalar(leaf_index) => {
-                            Some(proof_tree.generate_scalar_proof(*leaf_index))
-                        }
-                        SszStateKey::Validator(pubkey) => proof_tree.generate_validator_proof(
-                            pubkey,
-                            self.canonical_state.proof_validator_keys(),
-                        ),
-                        SszStateKey::ValidatorField(pubkey, field_index) => proof_tree
-                            .generate_validator_field_proof(
-                                pubkey,
-                                *field_index,
-                                self.canonical_state.proof_validator_keys(),
-                            ),
-                        SszStateKey::Deposit(index) => proof_tree.generate_deposit_proof(*index),
-                        SszStateKey::DepositField(index, field_index) => {
-                            proof_tree.generate_deposit_field_proof(*index, *field_index)
-                        }
-                        SszStateKey::Withdrawal(pubkey) => {
-                            proof_tree.generate_withdrawal_proof_by_key(pubkey)
-                        }
-                        SszStateKey::WithdrawalField(pubkey, field_index) => {
-                            proof_tree.generate_withdrawal_field_proof_by_key(pubkey, *field_index)
-                        }
-                        SszStateKey::ProtocolParam(index) => {
-                            proof_tree.generate_protocol_param_proof(*index)
-                        }
-                        SszStateKey::ProtocolParamField(index, field_index) => {
-                            proof_tree.generate_protocol_param_field_proof(*index, *field_index)
-                        }
-                        SszStateKey::AddedValidator(index) => {
-                            proof_tree.generate_added_validator_proof(*index)
-                        }
-                        SszStateKey::AddedValidatorField(index, field_index) => {
-                            proof_tree.generate_added_validator_field_proof(*index, *field_index)
-                        }
-                        SszStateKey::RemovedValidator(index) => {
-                            proof_tree.generate_removed_validator_proof(*index)
-                        }
-                    })
-                    .collect();
+                let proof_tree = self.canonical_state.proof_tree_snapshot();
+                let validator_keys = self.canonical_state.proof_validator_keys_snapshot();
                 let root = self.canonical_state.get_state_root();
                 let el_block_number = self.canonical_state.get_proof_el_block_number();
-                let _ = sender.send(ConsensusStateResponse::StateProof {
-                    root,
-                    el_block_number,
-                    proofs,
-                });
+                self.context
+                    .with_label("state_proof")
+                    .shared(true)
+                    .spawn(move |_| async move {
+                        let proofs = generate_state_proofs(
+                            proof_tree.as_ref(),
+                            validator_keys.as_slice(),
+                            &keys,
+                        );
+                        let _ = sender.send(ConsensusStateResponse::StateProof {
+                            root,
+                            el_block_number,
+                            proofs,
+                        });
+                    });
             }
         }
     }

--- a/finalizer/src/ingress.rs
+++ b/finalizer/src/ingress.rs
@@ -478,7 +478,7 @@ impl<S: Scheme<B::Digest>, B: ConsensusBlock> FinalizerMailbox<S, B> {
         Vec<Option<summit_types::ssz_state_tree::SszProof>>,
     ) {
         let (response, rx) = oneshot::channel();
-        let request = ConsensusStateRequest::GenerateStateProof(keys);
+        let request = ConsensusStateRequest::GenerateStateProof(keys, None);
         let _ = self
             .sender
             .clone()

--- a/finalizer/src/tests/fork_handling.rs
+++ b/finalizer/src/tests/fork_handling.rs
@@ -266,7 +266,7 @@ fn test_fork_aux_data_does_not_finalize_unfinalized_fork_head() {
             _variant_marker: PhantomData,
         };
 
-        let (finalizer, _state, mut mailbox) =
+        let (finalizer, _state, mut mailbox, _state_query) =
             Finalizer::<_, MockEngineClient, MockNetworkOracle, ed25519::PrivateKey, MinPk>::new(
                 context.with_label("finalizer"),
                 finalizer_cfg,

--- a/finalizer/src/tests/fork_handling.rs
+++ b/finalizer/src/tests/fork_handling.rs
@@ -171,7 +171,7 @@ fn test_orphaned_block_processed_when_parent_arrives() {
             _variant_marker: PhantomData,
         };
 
-        let (finalizer, _state, mut mailbox) =
+        let (finalizer, _state, mut mailbox, _state_query) =
             Finalizer::<_, MockEngineClient, MockNetworkOracle, ed25519::PrivateKey, MinPk>::new(
                 context.with_label("finalizer"),
                 finalizer_cfg,
@@ -374,7 +374,7 @@ fn test_losing_height_waiter_resolves_false_on_conflicting_finalization() {
             _variant_marker: PhantomData,
         };
 
-        let (finalizer, _state, mut mailbox) =
+        let (finalizer, _state, mut mailbox, _state_query) =
             Finalizer::<_, MockEngineClient, MockNetworkOracle, ed25519::PrivateKey, MinPk>::new(
                 context.with_label("finalizer"),
                 finalizer_cfg,
@@ -463,7 +463,7 @@ fn test_competing_digest_waiter_stays_pending_until_finalization() {
             _variant_marker: PhantomData,
         };
 
-        let (finalizer, _state, mut mailbox) =
+        let (finalizer, _state, mut mailbox, _state_query) =
             Finalizer::<_, MockEngineClient, MockNetworkOracle, ed25519::PrivateKey, MinPk>::new(
                 context.with_label("finalizer"),
                 finalizer_cfg,
@@ -553,7 +553,7 @@ fn test_finalization_resolves_lower_waiters_and_preserves_future_waiters() {
             _variant_marker: PhantomData,
         };
 
-        let (finalizer, _state, mut mailbox) =
+        let (finalizer, _state, mut mailbox, _state_query) =
             Finalizer::<_, MockEngineClient, MockNetworkOracle, ed25519::PrivateKey, MinPk>::new(
                 context.with_label("finalizer"),
                 finalizer_cfg,
@@ -643,7 +643,7 @@ fn test_multiple_forks_tracked() {
             _variant_marker: PhantomData,
         };
 
-        let (finalizer, _state, mut mailbox) =
+        let (finalizer, _state, mut mailbox, _state_query) =
             Finalizer::<_, MockEngineClient, MockNetworkOracle, ed25519::PrivateKey, MinPk>::new(
                 context.with_label("finalizer"),
                 finalizer_cfg,
@@ -729,7 +729,7 @@ fn test_dead_fork_block_discarded() {
             _variant_marker: PhantomData,
         };
 
-        let (finalizer, _state, mut mailbox) =
+        let (finalizer, _state, mut mailbox, _state_query) =
             Finalizer::<_, MockEngineClient, MockNetworkOracle, ed25519::PrivateKey, MinPk>::new(
                 context.with_label("finalizer"),
                 finalizer_cfg,
@@ -831,7 +831,7 @@ fn test_fork_states_pruned_after_finalization() {
             _variant_marker: PhantomData,
         };
 
-        let (finalizer, _state, mut mailbox) =
+        let (finalizer, _state, mut mailbox, _state_query) =
             Finalizer::<_, MockEngineClient, MockNetworkOracle, ed25519::PrivateKey, MinPk>::new(
                 context.with_label("finalizer"),
                 finalizer_cfg,
@@ -952,7 +952,7 @@ fn test_orphaned_blocks_pruned_after_finalization() {
             _variant_marker: PhantomData,
         };
 
-        let (finalizer, _state, mut mailbox) =
+        let (finalizer, _state, mut mailbox, _state_query) =
             Finalizer::<_, MockEngineClient, MockNetworkOracle, ed25519::PrivateKey, MinPk>::new(
                 context.with_label("finalizer"),
                 finalizer_cfg,
@@ -1065,7 +1065,7 @@ fn test_fork_state_reused_when_notarized_then_finalized() {
             _variant_marker: PhantomData,
         };
 
-        let (finalizer, _state, mut mailbox) =
+        let (finalizer, _state, mut mailbox, _state_query) =
             Finalizer::<_, MockEngineClient, MockNetworkOracle, ed25519::PrivateKey, MinPk>::new(
                 context.with_label("finalizer"),
                 finalizer_cfg,
@@ -1174,7 +1174,7 @@ fn test_competing_fork_pruned_on_finalization() {
             _variant_marker: PhantomData,
         };
 
-        let (finalizer, _state, mut mailbox) =
+        let (finalizer, _state, mut mailbox, _state_query) =
             Finalizer::<_, MockEngineClient, MockNetworkOracle, ed25519::PrivateKey, MinPk>::new(
                 context.with_label("finalizer"),
                 finalizer_cfg,

--- a/finalizer/src/tests/state_queries.rs
+++ b/finalizer/src/tests/state_queries.rs
@@ -417,7 +417,7 @@ fn test_first_post_epoch_boundary_aux_data_uses_post_transition_state_root() {
             _variant_marker: PhantomData,
         };
 
-        let (finalizer, _state, mut mailbox) =
+        let (finalizer, _state, mut mailbox, _state_query) =
             Finalizer::<_, MockEngineClient, MockNetworkOracle, ed25519::PrivateKey, MinPk>::new(
                 context.with_label("finalizer"),
                 finalizer_cfg,
@@ -540,7 +540,7 @@ fn test_epoch_boundary_post_transition_root_survives_restart() {
             _variant_marker: PhantomData,
         };
 
-        let (finalizer, _state, mut mailbox) =
+        let (finalizer, _state, mut mailbox, _state_query) =
             Finalizer::<_, MockEngineClient, MockNetworkOracle, ed25519::PrivateKey, MinPk>::new(
                 context.with_label("finalizer"),
                 finalizer_cfg,
@@ -589,7 +589,7 @@ fn test_epoch_boundary_post_transition_root_survives_restart() {
 
         // Restart from the same DB. The reloaded consensus state must expose the
         // same post-transition root, proving it was persisted post re-capture.
-        let (restarted, reloaded_state, _mailbox) =
+        let (restarted, reloaded_state, _mailbox, _state_query) =
             Finalizer::<_, MockEngineClient, MockNetworkOracle, ed25519::PrivateKey, MinPk>::new(
                 context.with_label("finalizer_restart"),
                 FinalizerConfig {
@@ -779,7 +779,7 @@ fn test_get_epoch_genesis_hash_for_past_epoch() {
             _variant_marker: PhantomData,
         };
 
-        let (finalizer, _state, mut mailbox) =
+        let (finalizer, _state, mut mailbox, _state_query) =
             Finalizer::<_, MockEngineClient, MockNetworkOracle, ed25519::PrivateKey, MinPk>::new(
                 context.with_label("finalizer"),
                 finalizer_cfg,
@@ -901,7 +901,7 @@ fn test_get_epoch_genesis_hash_for_future_epoch() {
             _variant_marker: PhantomData,
         };
 
-        let (finalizer, _state, mut mailbox) =
+        let (finalizer, _state, mut mailbox, _state_query) =
             Finalizer::<_, MockEngineClient, MockNetworkOracle, ed25519::PrivateKey, MinPk>::new(
                 context.with_label("finalizer"),
                 finalizer_cfg,

--- a/finalizer/src/tests/state_queries.rs
+++ b/finalizer/src/tests/state_queries.rs
@@ -214,7 +214,7 @@ fn test_generate_state_proof_preserves_batch_cardinality_for_missing_keys() {
             _variant_marker: PhantomData,
         };
 
-        let (finalizer, _state, mailbox) =
+        let (finalizer, _state, mailbox, _state_query) =
             Finalizer::<_, MockEngineClient, MockNetworkOracle, ed25519::PrivateKey, MinPk>::new(
                 context.with_label("finalizer"),
                 finalizer_cfg,
@@ -306,7 +306,7 @@ fn test_get_latest_epoch() {
             _variant_marker: PhantomData,
         };
 
-        let (finalizer, _state, mut mailbox) =
+        let (finalizer, _state, mut mailbox, _state_query) =
             Finalizer::<_, MockEngineClient, MockNetworkOracle, ed25519::PrivateKey, MinPk>::new(
                 context.with_label("finalizer"),
                 finalizer_cfg,
@@ -678,7 +678,7 @@ fn test_get_epoch_genesis_hash() {
             _variant_marker: PhantomData,
         };
 
-        let (finalizer, _state, mut mailbox) =
+        let (finalizer, _state, mut mailbox, _state_query) =
             Finalizer::<_, MockEngineClient, MockNetworkOracle, ed25519::PrivateKey, MinPk>::new(
                 context.with_label("finalizer"),
                 finalizer_cfg,
@@ -965,7 +965,7 @@ fn test_get_aux_data_from_canonical_chain() {
             _variant_marker: PhantomData,
         };
 
-        let (finalizer, _state, mut mailbox) =
+        let (finalizer, _state, mut mailbox, _state_query) =
             Finalizer::<_, MockEngineClient, MockNetworkOracle, ed25519::PrivateKey, MinPk>::new(
                 context.with_label("finalizer"),
                 finalizer_cfg,
@@ -1040,7 +1040,7 @@ fn test_get_aux_data_returns_none_for_invalid_parent() {
             _variant_marker: PhantomData,
         };
 
-        let (finalizer, _state, mut mailbox) =
+        let (finalizer, _state, mut mailbox, _state_query) =
             Finalizer::<_, MockEngineClient, MockNetworkOracle, ed25519::PrivateKey, MinPk>::new(
                 context.with_label("finalizer"),
                 finalizer_cfg,

--- a/finalizer/src/tests/syncing.rs
+++ b/finalizer/src/tests/syncing.rs
@@ -1045,7 +1045,7 @@ fn test_duplicate_finalized_delivery_is_idempotent() {
             _variant_marker: PhantomData,
         };
 
-        let (finalizer, _state, mut mailbox) =
+        let (finalizer, _state, mut mailbox, _state_query) =
             Finalizer::<_, MockEngineClient, MockNetworkOracle, ed25519::PrivateKey, MinPk>::new(
                 context.with_label("finalizer"),
                 finalizer_cfg,

--- a/finalizer/src/tests/syncing.rs
+++ b/finalizer/src/tests/syncing.rs
@@ -201,7 +201,7 @@ fn test_initial_startup_sync_waits_for_valid() {
             _variant_marker: PhantomData,
         };
 
-        let (finalizer, _state, mut mailbox) =
+        let (finalizer, _state, mut mailbox, _state_query) =
             Finalizer::<_, MockEngineClient, MockNetworkOracle, ed25519::PrivateKey, MinPk>::new(
                 context.with_label("finalizer"),
                 finalizer_cfg,
@@ -275,7 +275,7 @@ fn test_initial_startup_sync_zero_forkchoice_skips_sync() {
             _variant_marker: PhantomData,
         };
 
-        let (finalizer, _state, mut mailbox) =
+        let (finalizer, _state, mut mailbox, _state_query) =
             Finalizer::<_, MockEngineClient, MockNetworkOracle, ed25519::PrivateKey, MinPk>::new(
                 context.with_label("finalizer"),
                 finalizer_cfg,
@@ -349,7 +349,7 @@ fn test_execute_block_retries_on_syncing() {
             _variant_marker: PhantomData,
         };
 
-        let (finalizer, _state, mut mailbox) =
+        let (finalizer, _state, mut mailbox, _state_query) =
             Finalizer::<_, MockEngineClient, MockNetworkOracle, ed25519::PrivateKey, MinPk>::new(
                 context.with_label("finalizer"),
                 finalizer_cfg,
@@ -438,7 +438,7 @@ fn test_notarized_block_retries_on_syncing() {
             _variant_marker: PhantomData,
         };
 
-        let (finalizer, _state, mut mailbox) =
+        let (finalizer, _state, mut mailbox, _state_query) =
             Finalizer::<_, MockEngineClient, MockNetworkOracle, ed25519::PrivateKey, MinPk>::new(
                 context.with_label("finalizer"),
                 finalizer_cfg,
@@ -519,7 +519,7 @@ fn test_checkpoint_startup_full_flow() {
             _variant_marker: PhantomData,
         };
 
-        let (finalizer, _state, mut mailbox) =
+        let (finalizer, _state, mut mailbox, _state_query) =
             Finalizer::<_, MockEngineClient, MockNetworkOracle, ed25519::PrivateKey, MinPk>::new(
                 context.with_label("finalizer"),
                 finalizer_cfg,
@@ -640,7 +640,7 @@ fn test_finalizer_mailbox_responsive_under_persistent_syncing() {
             _variant_marker: PhantomData,
         };
 
-        let (finalizer, _state, mut mailbox) =
+        let (finalizer, _state, mut mailbox, _state_query) =
             Finalizer::<_, MockEngineClient, MockNetworkOracle, ed25519::PrivateKey, MinPk>::new(
                 context.with_label("finalizer"),
                 finalizer_cfg,
@@ -762,7 +762,7 @@ fn test_finalizer_mailbox_responsive_during_startup_syncing() {
             _variant_marker: PhantomData,
         };
 
-        let (finalizer, _state, mailbox) =
+        let (finalizer, _state, mailbox, _state_query) =
             Finalizer::<_, MockEngineClient, MockNetworkOracle, ed25519::PrivateKey, MinPk>::new(
                 context.with_label("finalizer"),
                 finalizer_cfg,
@@ -847,7 +847,7 @@ fn test_finalizer_shuts_down_when_pending_notarized_cap_is_reached() {
             _variant_marker: PhantomData,
         };
 
-        let (finalizer, _state, mut mailbox) =
+        let (finalizer, _state, mut mailbox, _state_query) =
             Finalizer::<_, MockEngineClient, MockNetworkOracle, ed25519::PrivateKey, MinPk>::new(
                 context.with_label("finalizer"),
                 finalizer_cfg,
@@ -950,7 +950,7 @@ fn test_finalizer_finalized_buffer_drains_in_order() {
             _variant_marker: PhantomData,
         };
 
-        let (finalizer, _state, mut mailbox) =
+        let (finalizer, _state, mut mailbox, _state_query) =
             Finalizer::<_, MockEngineClient, MockNetworkOracle, ed25519::PrivateKey, MinPk>::new(
                 context.with_label("finalizer"),
                 finalizer_cfg,

--- a/finalizer/src/tests/validator_lifecycle.rs
+++ b/finalizer/src/tests/validator_lifecycle.rs
@@ -231,7 +231,7 @@ fn test_checkpoint_restart_keeps_submitted_exit_request_validator_in_current_epo
             _variant_marker: PhantomData,
         };
 
-        let (finalizer, _state, _mailbox) =
+        let (finalizer, _state, _mailbox, _state_query) =
             Finalizer::<_, MockEngineClient, MockNetworkOracle, ed25519::PrivateKey, MinPk>::new(
                 context.with_label("finalizer"),
                 finalizer_cfg,

--- a/finalizer/src/tests/validator_lifecycle.rs
+++ b/finalizer/src/tests/validator_lifecycle.rs
@@ -453,7 +453,7 @@ fn test_finalizer_rejects_finalized_block_with_wrong_parent() {
             _variant_marker: PhantomData,
         };
 
-        let (finalizer, _state, mut mailbox) =
+        let (finalizer, _state, mut mailbox, _state_query) =
             Finalizer::<_, MockEngineClient, MockNetworkOracle, ed25519::PrivateKey, MinPk>::new(
                 context.with_label("finalizer"),
                 finalizer_cfg,
@@ -589,7 +589,7 @@ fn test_joining_validator_peer_tier_follows_activation() {
             _variant_marker: PhantomData,
         };
 
-        let (finalizer, _state, mut mailbox) = Finalizer::<
+        let (finalizer, _state, mut mailbox, _state_query) = Finalizer::<
             _,
             MockEngineClient,
             RecordingNetworkOracle,
@@ -738,7 +738,7 @@ fn epoch_transition_deltas_are_cleared_before_persisted_state_ack() {
             _variant_marker: PhantomData,
         };
 
-        let (finalizer, _state, mut mailbox) =
+        let (finalizer, _state, mut mailbox, _state_query) =
             Finalizer::<_, MockEngineClient, MockNetworkOracle, ed25519::PrivateKey, MinPk>::new(
                 context.with_label("finalizer"),
                 finalizer_cfg,
@@ -776,7 +776,7 @@ fn epoch_transition_deltas_are_cleared_before_persisted_state_ack() {
         handle.abort();
         context.sleep(Duration::from_millis(50)).await;
 
-        let (restarted, reloaded_state, _mailbox) =
+        let (restarted, reloaded_state, _mailbox, _state_query) =
             Finalizer::<_, MockEngineClient, MockNetworkOracle, ed25519::PrivateKey, MinPk>::new(
                 context.with_label("finalizer_restart"),
                 FinalizerConfig {
@@ -914,7 +914,7 @@ fn epoch_boundary_commit_failure_withholds_ack_and_shuts_down() {
             _variant_marker: PhantomData,
         };
 
-        let (finalizer, _state, mut mailbox) =
+        let (finalizer, _state, mut mailbox, _state_query) =
             Finalizer::<_, MockEngineClient, MockNetworkOracle, ed25519::PrivateKey, MinPk>::new(
                 context.with_label("finalizer"),
                 finalizer_cfg,
@@ -970,7 +970,7 @@ fn epoch_boundary_commit_failure_withholds_ack_and_shuts_down() {
         context.sleep(Duration::from_millis(50)).await;
 
         // Restart from the same DB: the epoch must NOT have durably advanced.
-        let (restarted, reloaded_state, _mailbox) =
+        let (restarted, reloaded_state, _mailbox, _state_query) =
             Finalizer::<_, MockEngineClient, MockNetworkOracle, ed25519::PrivateKey, MinPk>::new(
                 context.with_label("finalizer_restart"),
                 FinalizerConfig {
@@ -1274,7 +1274,7 @@ fn joining_validator_withdrawal_excludes_it_from_oracle_tracking() {
             _variant_marker: PhantomData,
         };
 
-        let (finalizer, _state, mut mailbox) =
+        let (finalizer, _state, mut mailbox, _state_query) =
             Finalizer::<_, MockEngineClient, RecordingOracle, ed25519::PrivateKey, MinPk>::new(
                 context.with_label("finalizer"),
                 finalizer_cfg,

--- a/finalizer/src/tests/validator_lifecycle.rs
+++ b/finalizer/src/tests/validator_lifecycle.rs
@@ -323,7 +323,7 @@ fn test_validator_exit_triggers_cancellation() {
             _variant_marker: PhantomData,
         };
 
-        let (finalizer, _state, mut mailbox) =
+        let (finalizer, _state, mut mailbox, _state_query) =
             Finalizer::<_, MockEngineClient, MockNetworkOracle, ed25519::PrivateKey, MinPk>::new(
                 context.with_label("finalizer"),
                 finalizer_cfg,
@@ -1062,7 +1062,7 @@ fn last_block_exit_dominates_concurrent_max_stake_reduction() {
             _variant_marker: PhantomData,
         };
 
-        let (finalizer, _state, mut mailbox) =
+        let (finalizer, _state, mut mailbox, _state_query) =
             Finalizer::<_, MockEngineClient, MockNetworkOracle, ed25519::PrivateKey, MinPk>::new(
                 context.with_label("finalizer"),
                 finalizer_cfg,

--- a/node/src/args.rs
+++ b/node/src/args.rs
@@ -882,7 +882,7 @@ where
     #[cfg(feature = "permissioned")]
     let paused = engine.paused.clone();
 
-    let finalizer_mailbox = engine.finalizer_mailbox.clone();
+    let finalizer_state_query = engine.finalizer_state_query.clone();
     let engine = engine.start(pending, recovered, resolver, broadcaster, backfiller);
 
     let p2p = network.start();
@@ -898,7 +898,7 @@ where
     let stop_signal = context.stopped();
     let rpc_handle = context.with_label("rpc").spawn(move |_context| async move {
         if let Err(e) = start_rpc_server(
-            finalizer_mailbox,
+            finalizer_state_query,
             key_store_path,
             genesis_hash,
             namespace,

--- a/node/src/engine.rs
+++ b/node/src/engine.rs
@@ -30,6 +30,7 @@ use summit_application::ApplicationConfig;
 use summit_finalizer::actor::Finalizer;
 use summit_finalizer::{FinalizerConfig, FinalizerMailbox, ProtocolConsts};
 use summit_syncer::{SyncCheckpoint, SyncStart};
+use summit_types::consensus_state_query::ConsensusStateQuery;
 use summit_types::dynamic_epocher::DynamicEpocher;
 use summit_types::network_oracle::NetworkOracle;
 use summit_types::scheme::{MultisigScheme, SummitSchemeProvider};
@@ -102,6 +103,7 @@ pub struct Engine<
     syncer_mailbox: summit_syncer::Mailbox<MultisigScheme, Block>,
     finalizer: Finalizer<E, C, O, S, MinPk>,
     pub finalizer_mailbox: FinalizerMailbox<MultisigScheme, Block>,
+    pub finalizer_state_query: ConsensusStateQuery<MultisigScheme>,
     orchestrator: summit_orchestrator::Actor<
         E,
         O,
@@ -153,7 +155,7 @@ where
         let paused = Arc::new(AtomicBool::new(false));
 
         // create finalizer
-        let (finalizer, initial_state, finalizer_mailbox) = Finalizer::new(
+        let (finalizer, initial_state, finalizer_mailbox, finalizer_state_query) = Finalizer::new(
             context.with_label("finalizer"),
             FinalizerConfig {
                 mailbox_size: cfg.mailbox_size,
@@ -368,6 +370,7 @@ where
             syncer_mailbox,
             finalizer,
             finalizer_mailbox,
+            finalizer_state_query,
             orchestrator,
             orchestrator_mailbox,
             oracle: cfg.oracle,

--- a/rpc/src/error.rs
+++ b/rpc/src/error.rs
@@ -13,6 +13,14 @@ pub enum RpcError {
     InvalidGenesis(String),
     IoError(String),
     InvalidKey(String),
+    StateProofKeyLimit {
+        max: usize,
+        actual: usize,
+    },
+    StateProofCostLimit {
+        max: usize,
+        actual: usize,
+    },
     Internal(String),
     DisabledInObserverMode,
     #[cfg(feature = "permissioned")]
@@ -58,6 +66,16 @@ impl From<RpcError> for ErrorObjectOwned {
             RpcError::InvalidKey(msg) => {
                 ErrorObjectOwned::owned(3002, "Invalid key descriptor", Some(msg))
             }
+            RpcError::StateProofKeyLimit { max, actual } => ErrorObjectOwned::owned(
+                3005,
+                "State proof key limit exceeded",
+                Some(format!("requested {actual} keys, maximum is {max}")),
+            ),
+            RpcError::StateProofCostLimit { max, actual } => ErrorObjectOwned::owned(
+                3006,
+                "State proof cost limit exceeded",
+                Some(format!("requested cost {actual}, maximum is {max}")),
+            ),
             RpcError::Internal(msg) => ErrorObjectOwned::owned(5000, "Internal error", Some(msg)),
             RpcError::DisabledInObserverMode => ErrorObjectOwned::owned(
                 4003,

--- a/rpc/src/error.rs
+++ b/rpc/src/error.rs
@@ -21,6 +21,9 @@ pub enum RpcError {
         max: usize,
         actual: usize,
     },
+    StateProofBusy {
+        max: usize,
+    },
     Internal(String),
     DisabledInObserverMode,
     #[cfg(feature = "permissioned")]
@@ -75,6 +78,13 @@ impl From<RpcError> for ErrorObjectOwned {
                 3006,
                 "State proof cost limit exceeded",
                 Some(format!("requested cost {actual}, maximum is {max}")),
+            ),
+            RpcError::StateProofBusy { max } => ErrorObjectOwned::owned(
+                3007,
+                "State proof generation at capacity",
+                Some(format!(
+                    "at the limit of {max} concurrent state proof requests; retry shortly"
+                )),
             ),
             RpcError::Internal(msg) => ErrorObjectOwned::owned(5000, "Internal error", Some(msg)),
             RpcError::DisabledInObserverMode => ErrorObjectOwned::owned(

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -25,8 +25,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 #[cfg(feature = "permissioned")]
 use std::sync::atomic::AtomicBool;
-use summit_finalizer::FinalizerMailbox;
-use summit_types::Block;
+use summit_types::consensus_state_query::ConsensusStateQuery;
 use summit_types::scheme::MultisigScheme;
 use tokio_util::sync::CancellationToken;
 
@@ -49,7 +48,7 @@ impl Default for RpcBodyLimits {
 
 #[allow(clippy::too_many_arguments)]
 pub async fn start_rpc_server(
-    finalizer_mailbox: FinalizerMailbox<MultisigScheme, Block>,
+    state_query: ConsensusStateQuery<MultisigScheme>,
     key_store_path: String,
     genesis_hash: [u8; 32],
     namespace: Vec<u8>,
@@ -62,7 +61,7 @@ pub async fn start_rpc_server(
 ) -> anyhow::Result<()> {
     let rpc_impl = SummitRpcServer::new(
         key_store_path,
-        finalizer_mailbox,
+        state_query,
         genesis_hash,
         &namespace,
         observer_node_key,
@@ -121,7 +120,7 @@ pub struct RpcHandles {
 /// Starts only the public RPC listener and returns its handle/address. Used
 /// by tests that don't exercise the admin RPC surface.
 pub async fn start_rpc_server_with_handle(
-    finalizer_mailbox: FinalizerMailbox<MultisigScheme, Block>,
+    state_query: ConsensusStateQuery<MultisigScheme>,
     key_store_path: String,
     genesis_hash: [u8; 32],
     namespace: Vec<u8>,
@@ -130,7 +129,7 @@ pub async fn start_rpc_server_with_handle(
 ) -> anyhow::Result<(ServerHandle, SocketAddr)> {
     let rpc_impl = SummitRpcServer::new(
         key_store_path,
-        finalizer_mailbox,
+        state_query,
         genesis_hash,
         &namespace,
         // This helper is only used by tests of validator-mode behavior, so
@@ -167,7 +166,7 @@ pub async fn start_rpc_server_with_handle(
 /// the OS to allocate a free port.
 #[allow(clippy::too_many_arguments)]
 pub async fn start_rpc_server_pair_with_handle(
-    finalizer_mailbox: FinalizerMailbox<MultisigScheme, Block>,
+    state_query: ConsensusStateQuery<MultisigScheme>,
     key_store_path: String,
     genesis_hash: [u8; 32],
     namespace: Vec<u8>,
@@ -178,7 +177,7 @@ pub async fn start_rpc_server_pair_with_handle(
 ) -> anyhow::Result<RpcHandles> {
     let rpc_impl = SummitRpcServer::new(
         key_store_path,
-        finalizer_mailbox,
+        state_query,
         genesis_hash,
         &namespace,
         observer_node_key,

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -8,7 +8,7 @@ mod server;
 mod types;
 
 pub use genesis::{PathSender, SummitGenesisRpcServer};
-pub use server::SummitRpcServer;
+pub use server::{MAX_CONCURRENT_STATE_PROOFS, SummitRpcServer};
 pub use types::*;
 
 pub use api::{

--- a/rpc/src/server.rs
+++ b/rpc/src/server.rs
@@ -21,18 +21,21 @@ use ssz::Encode as _;
 use std::sync::Arc;
 #[cfg(feature = "permissioned")]
 use std::sync::atomic::{AtomicBool, Ordering};
-use summit_finalizer::FinalizerMailbox;
-use summit_types::Block;
+use summit_types::consensus_state_query::ConsensusStateQuery;
 use summit_types::scheme::MultisigScheme;
+use summit_types::ssz_tree_key::SszStateKey;
 use summit_types::{
     Digest, KeyPaths, PublicKey, deposit_signature_domain,
     execution_request::{DepositRequest, compute_deposit_data_root},
 };
 
+const MAX_STATE_PROOF_KEYS: usize = 128;
+const MAX_STATE_PROOF_COST: usize = 512;
+
 #[derive(Clone)]
 pub struct SummitRpcServer {
     key_store_path: String,
-    finalizer_mailbox: FinalizerMailbox<MultisigScheme, Block>,
+    state_query: ConsensusStateQuery<MultisigScheme>,
     deposit_signature_domain: Digest,
     /// The derived child public key (hex) used as the live P2P identity when
     /// the node runs with `--observer`; `None` on validator nodes. Observers
@@ -47,7 +50,7 @@ pub struct SummitRpcServer {
 impl SummitRpcServer {
     pub fn new(
         key_store_path: String,
-        finalizer_mailbox: FinalizerMailbox<MultisigScheme, Block>,
+        state_query: ConsensusStateQuery<MultisigScheme>,
         genesis_hash: [u8; 32],
         namespace: &[u8],
         observer_node_key: Option<String>,
@@ -55,12 +58,29 @@ impl SummitRpcServer {
     ) -> Self {
         Self {
             key_store_path,
-            finalizer_mailbox,
+            state_query,
             deposit_signature_domain: deposit_signature_domain(genesis_hash, namespace),
             observer_node_key,
             #[cfg(feature = "permissioned")]
             paused,
         }
+    }
+}
+
+fn state_proof_key_cost(key: &SszStateKey) -> usize {
+    match key {
+        SszStateKey::Scalar(_) => 1,
+        SszStateKey::Validator(_)
+        | SszStateKey::Deposit(_)
+        | SszStateKey::Withdrawal(_)
+        | SszStateKey::ProtocolParam(_)
+        | SszStateKey::AddedValidator(_)
+        | SszStateKey::RemovedValidator(_) => 4,
+        SszStateKey::ValidatorField(_, _)
+        | SszStateKey::DepositField(_, _)
+        | SszStateKey::WithdrawalField(_, _)
+        | SszStateKey::ProtocolParamField(_, _)
+        | SszStateKey::AddedValidatorField(_, _) => 8,
     }
 }
 
@@ -95,18 +115,14 @@ impl SummitApiServer for SummitRpcServer {
     }
 
     async fn get_checkpoint(&self, epoch: u64) -> RpcResult<CheckpointRes> {
-        let maybe_checkpoint = self.finalizer_mailbox.clone().get_checkpoint(epoch).await;
+        let maybe_checkpoint = self.state_query.clone().get_checkpoint(epoch).await;
 
         let Some((checkpoint, last_block)) = maybe_checkpoint else {
             return Err(RpcError::CheckpointNotFound.into());
         };
 
         // try to get the finalized header for this epoch
-        let maybe_header = self
-            .finalizer_mailbox
-            .clone()
-            .get_finalized_header(epoch)
-            .await;
+        let maybe_header = self.state_query.clone().get_finalized_header(epoch).await;
 
         let Some(header) = maybe_header else {
             return Err(RpcError::CheckpointNotFound.into());
@@ -122,18 +138,14 @@ impl SummitApiServer for SummitRpcServer {
     }
 
     async fn get_latest_checkpoint(&self) -> RpcResult<CheckpointRes> {
-        let maybe_checkpoint = self.finalizer_mailbox.clone().get_latest_checkpoint().await;
+        let maybe_checkpoint = self.state_query.clone().get_latest_checkpoint().await;
 
         let (Some((checkpoint, last_block)), epoch) = maybe_checkpoint else {
             return Err(RpcError::CheckpointNotFound.into());
         };
 
         // try to get the finalized header for this epoch
-        let maybe_header = self
-            .finalizer_mailbox
-            .clone()
-            .get_finalized_header(epoch)
-            .await;
+        let maybe_header = self.state_query.clone().get_finalized_header(epoch).await;
 
         let Some(header) = maybe_header else {
             return Err(RpcError::CheckpointNotFound.into());
@@ -149,7 +161,7 @@ impl SummitApiServer for SummitRpcServer {
     }
 
     async fn get_latest_checkpoint_info(&self) -> RpcResult<CheckpointInfoRes> {
-        let maybe_checkpoint = self.finalizer_mailbox.clone().get_latest_checkpoint().await;
+        let maybe_checkpoint = self.state_query.clone().get_latest_checkpoint().await;
 
         let (Some((checkpoint, _)), epoch) = maybe_checkpoint else {
             return Err(RpcError::CheckpointNotFound.into());
@@ -162,11 +174,7 @@ impl SummitApiServer for SummitRpcServer {
     }
 
     async fn get_finalized_header(&self, epoch: u64) -> RpcResult<FinalizedHeaderRes> {
-        let maybe_header = self
-            .finalizer_mailbox
-            .clone()
-            .get_finalized_header(epoch)
-            .await;
+        let maybe_header = self.state_query.clone().get_finalized_header(epoch).await;
 
         let Some(header) = maybe_header else {
             return Err(RpcError::FinalizedHeaderNotFound.into());
@@ -196,12 +204,12 @@ impl SummitApiServer for SummitRpcServer {
     }
 
     async fn get_latest_height(&self) -> RpcResult<u64> {
-        let height = self.finalizer_mailbox.get_latest_height().await;
+        let height = self.state_query.get_latest_height().await;
         Ok(height)
     }
 
     async fn get_latest_epoch(&self) -> RpcResult<u64> {
-        let epoch = self.finalizer_mailbox.get_latest_epoch().await;
+        let epoch = self.state_query.get_latest_epoch().await;
         Ok(epoch)
     }
 
@@ -212,10 +220,7 @@ impl SummitApiServer for SummitRpcServer {
         let public_key = PublicKey::decode(&*key_bytes)
             .map_err(|_| RpcError::InvalidPublicKey("Unable to decode public key".to_string()))?;
 
-        let balance = self
-            .finalizer_mailbox
-            .get_validator_balance(public_key)
-            .await;
+        let balance = self.state_query.get_validator_balance(public_key).await;
 
         match balance {
             Some(balance) => Ok(balance),
@@ -233,10 +238,7 @@ impl SummitApiServer for SummitRpcServer {
         let public_key = PublicKey::decode(&*key_bytes)
             .map_err(|_| RpcError::InvalidPublicKey("Unable to decode public key".to_string()))?;
 
-        let account = self
-            .finalizer_mailbox
-            .get_validator_account(public_key)
-            .await;
+        let account = self.state_query.get_validator_account(public_key).await;
 
         match account {
             Some(a) => Ok(ValidatorAccountResponse {
@@ -254,32 +256,32 @@ impl SummitApiServer for SummitRpcServer {
     }
 
     async fn get_minimum_stake(&self) -> RpcResult<u64> {
-        let minimum_stake = self.finalizer_mailbox.get_minimum_stake().await;
+        let minimum_stake = self.state_query.get_minimum_stake().await;
         Ok(minimum_stake)
     }
 
     async fn get_maximum_stake(&self) -> RpcResult<u64> {
-        let maximum_stake = self.finalizer_mailbox.get_maximum_stake().await;
+        let maximum_stake = self.state_query.get_maximum_stake().await;
         Ok(maximum_stake)
     }
 
     async fn get_epoch_length(&self) -> RpcResult<u64> {
-        let epoch_length = self.finalizer_mailbox.get_epoch_length().await;
+        let epoch_length = self.state_query.get_epoch_length().await;
         Ok(epoch_length)
     }
 
     async fn get_allowed_timestamp_future(&self) -> RpcResult<u64> {
-        let ms = self.finalizer_mailbox.get_allowed_timestamp_future().await;
+        let ms = self.state_query.get_allowed_timestamp_future().await;
         Ok(ms)
     }
 
     async fn get_treasury_address(&self) -> RpcResult<String> {
-        let address = self.finalizer_mailbox.get_treasury_address().await;
+        let address = self.state_query.get_treasury_address().await;
         Ok(address.to_string())
     }
 
     async fn get_epoch_bounds(&self, epoch: u64) -> RpcResult<EpochBoundsResponse> {
-        let bounds = self.finalizer_mailbox.get_epoch_bounds(epoch).await;
+        let bounds = self.state_query.get_epoch_bounds(epoch).await;
         match bounds {
             Some((first_height, last_height)) => Ok(EpochBoundsResponse {
                 first_height,
@@ -290,7 +292,7 @@ impl SummitApiServer for SummitRpcServer {
     }
 
     async fn get_deposit(&self, index: usize) -> RpcResult<DepositResponse> {
-        let deposit = self.finalizer_mailbox.get_deposit(index).await;
+        let deposit = self.state_query.get_deposit(index).await;
         match deposit {
             Some(d) => Ok(DepositResponse {
                 node_pubkey: d
@@ -310,7 +312,7 @@ impl SummitApiServer for SummitRpcServer {
     }
 
     async fn get_deposit_count(&self) -> RpcResult<usize> {
-        let count = self.finalizer_mailbox.get_deposit_count().await;
+        let count = self.state_query.get_deposit_count().await;
         Ok(count)
     }
 
@@ -325,7 +327,7 @@ impl SummitApiServer for SummitRpcServer {
             .try_into()
             .map_err(|_| RpcError::InvalidPublicKey("pubkey must be 32 bytes".to_string()))?;
 
-        let withdrawal = self.finalizer_mailbox.get_withdrawal(pubkey).await;
+        let withdrawal = self.state_query.get_withdrawal(pubkey).await;
         match withdrawal {
             Some(w) => Ok(PendingWithdrawalResponse {
                 withdrawal_index: w.inner.index,
@@ -449,7 +451,7 @@ impl SummitPermissionedApiServer for SummitRpcServer {
 #[async_trait]
 impl SummitProofApiServer for SummitRpcServer {
     async fn get_state_root(&self) -> RpcResult<StateRootResponse> {
-        let (root, el_block_number) = self.finalizer_mailbox.get_state_root().await;
+        let (root, el_block_number) = self.state_query.get_state_root().await;
         Ok(StateRootResponse {
             root,
             el_block_number,
@@ -457,16 +459,34 @@ impl SummitProofApiServer for SummitRpcServer {
     }
 
     async fn get_state_proof(&self, keys: Vec<String>) -> RpcResult<StateProofResponse> {
+        if keys.len() > MAX_STATE_PROOF_KEYS {
+            return Err(RpcError::StateProofKeyLimit {
+                max: MAX_STATE_PROOF_KEYS,
+                actual: keys.len(),
+            }
+            .into());
+        }
+
         let parsed_keys = keys
             .iter()
             .map(|k| summit_types::ssz_tree_key::parse_key(k).map_err(RpcError::InvalidKey))
             .collect::<Result<Vec<_>, _>>()?;
 
+        let cost = parsed_keys.iter().map(state_proof_key_cost).sum::<usize>();
+        if cost > MAX_STATE_PROOF_COST {
+            return Err(RpcError::StateProofCostLimit {
+                max: MAX_STATE_PROOF_COST,
+                actual: cost,
+            }
+            .into());
+        }
+
         let requested_len = keys.len();
-        let (root, el_block_number, proofs) = self
-            .finalizer_mailbox
-            .generate_state_proof(parsed_keys)
-            .await;
+        let (root, el_block_number, proofs) =
+            self.state_query.generate_state_proof(parsed_keys).await;
+        // Preserve one-result-per-requested-key alignment (#260/#267): the
+        // off-loop generator returns a positional `Vec<Option<SszProof>>`, so a
+        // missing key must surface as an error slot, never be dropped.
         if proofs.len() != requested_len {
             return Err(RpcError::Internal(format!(
                 "state proof response length mismatch: requested {requested_len}, got {}",

--- a/rpc/src/server.rs
+++ b/rpc/src/server.rs
@@ -505,9 +505,8 @@ impl SummitProofApiServer for SummitRpcServer {
         // Bound concurrent proof generation. The per-request key/cost limits cap
         // each request, but without this a remote caller could still flood the
         // node with accepted requests and pile up off-loop proof tasks on the
-        // shared pool. Acquire a slot or reject (retryable) — never queue — so
-        // task count and memory stay bounded under load. The RAII guard releases
-        // the slot on every exit path, including the await being cancelled.
+        // shared pool. Acquire a slot or reject (retryable), never queue, so
+        // task count and memory stay bounded under load.
         if self
             .in_flight_state_proofs
             .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |n| {
@@ -520,11 +519,21 @@ impl SummitProofApiServer for SummitRpcServer {
             }
             .into());
         }
-        let _slot = StateProofSlot(Arc::clone(&self.in_flight_state_proofs));
+        // Hand the slot guard to the proof task rather than holding it on this
+        // handler future. Acquisition stays here so a flood is rejected at
+        // admission, but ownership travels through the query channel into the
+        // finalizer's detached proof task, which drops it only once generation
+        // finishes. That keeps the in-flight count tied to real proof work: if
+        // the client disconnects (or this future is cancelled) after the task
+        // is spawned, the slot must not be freed while the work is still
+        // running.
+        let slot = StateProofSlot(Arc::clone(&self.in_flight_state_proofs));
 
         let requested_len = keys.len();
-        let (root, el_block_number, proofs) =
-            self.state_query.generate_state_proof(parsed_keys).await;
+        let (root, el_block_number, proofs) = self
+            .state_query
+            .generate_state_proof(parsed_keys, Box::new(slot))
+            .await;
         // Preserve one-result-per-requested-key alignment (#260/#267): the
         // off-loop generator returns a positional `Vec<Option<SszProof>>`, so a
         // missing key must surface as an error slot, never be dropped.

--- a/rpc/src/server.rs
+++ b/rpc/src/server.rs
@@ -17,10 +17,10 @@ use commonware_cryptography::Signer;
 use commonware_utils::from_hex_formatted;
 use jsonrpsee::core::RpcResult;
 use ssz::Encode as _;
-#[cfg(feature = "permissioned")]
 use std::sync::Arc;
 #[cfg(feature = "permissioned")]
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use summit_types::consensus_state_query::ConsensusStateQuery;
 use summit_types::scheme::MultisigScheme;
 use summit_types::ssz_tree_key::SszStateKey;
@@ -31,6 +31,13 @@ use summit_types::{
 
 const MAX_STATE_PROOF_KEYS: usize = 128;
 const MAX_STATE_PROOF_COST: usize = 512;
+/// Maximum number of state-proof generations allowed to be in flight at once.
+/// Each accepted request spawns an off-loop proof task in the finalizer; this
+/// caps how many run concurrently so a flood of individually limit-respecting
+/// requests cannot just move the pressure onto the shared task pool. At capacity
+/// further requests are rejected (retryable) rather than queued, keeping task
+/// count and memory bounded under load.
+pub const MAX_CONCURRENT_STATE_PROOFS: usize = 16;
 
 #[derive(Clone)]
 pub struct SummitRpcServer {
@@ -43,8 +50,21 @@ pub struct SummitRpcServer {
     /// sign with the validator keystore, so keystore-signing methods are
     /// disabled when this is set.
     observer_node_key: Option<String>,
+    /// Count of in-flight state-proof generations, shared across all cloned
+    /// handler instances so the cap is global to the server.
+    in_flight_state_proofs: Arc<AtomicUsize>,
     #[cfg(feature = "permissioned")]
     paused: Arc<AtomicBool>,
+}
+
+/// Releases one in-flight state-proof slot on drop — covers normal completion,
+/// early return, and future cancellation alike.
+struct StateProofSlot(Arc<AtomicUsize>);
+
+impl Drop for StateProofSlot {
+    fn drop(&mut self) {
+        self.0.fetch_sub(1, Ordering::SeqCst);
+    }
 }
 
 impl SummitRpcServer {
@@ -61,6 +81,7 @@ impl SummitRpcServer {
             state_query,
             deposit_signature_domain: deposit_signature_domain(genesis_hash, namespace),
             observer_node_key,
+            in_flight_state_proofs: Arc::new(AtomicUsize::new(0)),
             #[cfg(feature = "permissioned")]
             paused,
         }
@@ -480,6 +501,26 @@ impl SummitProofApiServer for SummitRpcServer {
             }
             .into());
         }
+
+        // Bound concurrent proof generation. The per-request key/cost limits cap
+        // each request, but without this a remote caller could still flood the
+        // node with accepted requests and pile up off-loop proof tasks on the
+        // shared pool. Acquire a slot or reject (retryable) — never queue — so
+        // task count and memory stay bounded under load. The RAII guard releases
+        // the slot on every exit path, including the await being cancelled.
+        if self
+            .in_flight_state_proofs
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |n| {
+                (n < MAX_CONCURRENT_STATE_PROOFS).then_some(n + 1)
+            })
+            .is_err()
+        {
+            return Err(RpcError::StateProofBusy {
+                max: MAX_CONCURRENT_STATE_PROOFS,
+            }
+            .into());
+        }
+        let _slot = StateProofSlot(Arc::clone(&self.in_flight_state_proofs));
 
         let requested_len = keys.len();
         let (root, el_block_number, proofs) =

--- a/rpc/src/server.rs
+++ b/rpc/src/server.rs
@@ -208,11 +208,7 @@ impl SummitApiServer for SummitRpcServer {
     }
 
     async fn get_finalized_header_digest(&self, epoch: u64) -> RpcResult<FinalizedHeaderDigestRes> {
-        let maybe_header = self
-            .finalizer_mailbox
-            .clone()
-            .get_finalized_header(epoch)
-            .await;
+        let maybe_header = self.state_query.clone().get_finalized_header(epoch).await;
 
         let Some(header) = maybe_header else {
             return Err(RpcError::FinalizedHeaderNotFound.into());

--- a/rpc/tests/integration_test.rs
+++ b/rpc/tests/integration_test.rs
@@ -9,26 +9,9 @@ use summit_rpc::{
     PathSender, start_rpc_server_for_genesis_with_handle, start_rpc_server_pair_with_handle,
     start_rpc_server_with_handle,
 };
-use utils::{
-    MockFinalizerState, create_test_finalized_header, create_test_finalizer_mailbox,
-    create_test_keystore,
-};
+use utils::{MockFinalizerState, create_test_finalizer_mailbox, create_test_keystore};
 
 const TEST_GENESIS_HASH: [u8; 32] = [7u8; 32];
-
-/// Derive the observer child transport key for the keystore's node key, the
-/// same way `--observer <index>` derives the live P2P signer.
-fn derive_observer_node_key(key_store_path: &str, index: u32) -> String {
-    use commonware_cryptography::Signer as _;
-    use summit_types::{KeyPaths, ext_private_key::ExtPrivateKey};
-
-    let node_key = KeyPaths::new(key_store_path.to_string())
-        .read_node_key_from_file()
-        .unwrap();
-    ExtPrivateKey::derive_child_signer(&node_key, b"_SUMMIT", index)
-        .public_key()
-        .to_string()
-}
 
 #[tokio::test]
 async fn test_health_endpoint() {
@@ -61,14 +44,9 @@ async fn test_health_endpoint() {
 }
 
 #[tokio::test]
-async fn test_websocket_upgrades_are_rejected() {
-    // The RPC server is http-only: Summit's API is request/response (no
-    // subscriptions). Disabling websocket upgrades closes the idle-connection
-    // permit-exhaustion vector (jsonrpsee enables websockets with pings off by
-    // default, so idle upgraded connections would hold their max_connections
-    // permit indefinitely). HTTP must still work; websocket connects must fail.
-    use jsonrpsee::ws_client::WsClientBuilder;
-    use summit_rpc::SummitApiClient;
+async fn test_get_state_proof_rejects_too_many_keys() {
+    use jsonrpsee::core::client::Error as ClientError;
+    use summit_rpc::SummitProofApiClient;
 
     let (mailbox, _finalizer_handle) = create_test_finalizer_mailbox(MockFinalizerState::default());
     let temp_dir = create_test_keystore().unwrap();
@@ -86,20 +64,52 @@ async fn test_websocket_upgrades_are_rejected() {
     .await
     .unwrap();
 
-    // HTTP still works.
-    let http = HttpClientBuilder::default()
-        .build(format!("http://{addr}"))
-        .unwrap();
-    assert_eq!(http.health().await.unwrap(), "Ok");
+    let url = format!("http://{}", addr);
+    let client = HttpClientBuilder::default().build(&url).unwrap();
 
-    // Websocket upgrade is refused, so idle WS connections cannot be opened.
-    let ws = WsClientBuilder::default()
-        .build(format!("ws://{addr}"))
-        .await;
-    assert!(
-        ws.is_err(),
-        "websocket upgrade must be rejected when the server is http-only"
-    );
+    let keys = vec!["epoch".to_string(); 129];
+    let err = client.get_state_proof(keys).await.unwrap_err();
+
+    match err {
+        ClientError::Call(obj) => assert_eq!(obj.code(), 3005),
+        other => panic!("expected 3005 StateProofKeyLimit, got {other:?}"),
+    }
+
+    handle.stop().unwrap();
+}
+
+#[tokio::test]
+async fn test_get_state_proof_rejects_excessive_cost() {
+    use jsonrpsee::core::client::Error as ClientError;
+    use summit_rpc::SummitProofApiClient;
+
+    let (mailbox, _finalizer_handle) = create_test_finalizer_mailbox(MockFinalizerState::default());
+    let temp_dir = create_test_keystore().unwrap();
+    let key_store_path = temp_dir.path().to_str().unwrap().to_string();
+
+    let (handle, addr) = start_rpc_server_with_handle(
+        mailbox,
+        key_store_path,
+        TEST_GENESIS_HASH,
+        b"_SUMMIT".to_vec(),
+        0,
+        #[cfg(feature = "permissioned")]
+        Arc::new(AtomicBool::new(false)),
+    )
+    .await
+    .unwrap();
+
+    let url = format!("http://{}", addr);
+    let client = HttpClientBuilder::default().build(&url).unwrap();
+
+    let validator_key = format!("validator_field:0x{}:balance", "01".repeat(32));
+    let keys = vec![validator_key; 65];
+    let err = client.get_state_proof(keys).await.unwrap_err();
+
+    match err {
+        ClientError::Call(obj) => assert_eq!(obj.code(), 3006),
+        other => panic!("expected 3006 StateProofCostLimit, got {other:?}"),
+    }
 
     handle.stop().unwrap();
 }
@@ -168,43 +178,6 @@ async fn test_get_latest_epoch() {
     let response = client.get_latest_epoch().await;
     assert!(response.is_ok());
     assert_eq!(response.unwrap(), 10);
-
-    handle.stop().unwrap();
-}
-
-#[tokio::test]
-async fn test_get_finalized_header_digest() {
-    use summit_rpc::SummitApiClient;
-
-    let epoch = 3;
-    let finalized_header = create_test_finalized_header(epoch);
-    let expected_digest = finalized_header.header().get_digest().0;
-    let state = MockFinalizerState {
-        finalized_headers: [(epoch, Some(finalized_header))].into(),
-        ..Default::default()
-    };
-    let (mailbox, _finalizer_handle) = create_test_finalizer_mailbox(state);
-    let temp_dir = create_test_keystore().unwrap();
-    let key_store_path = temp_dir.path().to_str().unwrap().to_string();
-
-    let (handle, addr) = start_rpc_server_with_handle(
-        mailbox,
-        key_store_path,
-        TEST_GENESIS_HASH,
-        b"_SUMMIT".to_vec(),
-        0,
-        #[cfg(feature = "permissioned")]
-        Arc::new(AtomicBool::new(false)),
-    )
-    .await
-    .unwrap();
-
-    let url = format!("http://{}", addr);
-    let client = HttpClientBuilder::default().build(&url).unwrap();
-
-    let response = client.get_finalized_header_digest(epoch).await.unwrap();
-    assert_eq!(response.epoch, epoch);
-    assert_eq!(response.digest, expected_digest);
 
     handle.stop().unwrap();
 }
@@ -307,10 +280,6 @@ activity_timeout_views = 256
 skip_timeout_views = 32
 max_message_size_bytes = 104857600
 namespace = "_SUMMIT"
-validator_minimum_stake = 32000000000
-validator_maximum_stake = 32000000000
-blocks_per_epoch = 10000
-allowed_timestamp_future_ms = 10000
 
 [[validators]]
 node_public_key = "1be3cb06d7cc347602421fb73838534e4b54934e28959de98906d120d0799ef2"
@@ -340,55 +309,6 @@ withdrawal_credentials = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
     );
 
     handle.stop().unwrap();
-}
-
-/// send_genesis must validate before installing: malformed or empty content is
-/// rejected, the target path is left untouched (no partial/garbage file that
-/// startup would treat as provisioned), and no temp file is left behind.
-#[tokio::test]
-async fn test_send_genesis_rejects_invalid_content() {
-    use summit_rpc::SummitGenesisApiClient;
-
-    for bad_content in [
-        "",
-        "this is not valid toml",
-        "eth_genesis_hash = \"0xdead\"\n",
-    ] {
-        let temp_dir = create_test_keystore().unwrap();
-        let key_store_path = temp_dir.path().to_str().unwrap().to_string();
-
-        let genesis_dir = tempfile::tempdir().unwrap();
-        let genesis_path = genesis_dir.path().join("genesis.toml");
-        let genesis_path_str = genesis_path.to_str().unwrap().to_string();
-
-        let path_sender = PathSender::new(genesis_path_str, None);
-        let (handle, addr) =
-            start_rpc_server_for_genesis_with_handle(path_sender, key_store_path, 0)
-                .await
-                .unwrap();
-
-        let url = format!("http://{}", addr);
-        let client = HttpClientBuilder::default().build(&url).unwrap();
-
-        let response = client.send_genesis(bad_content.to_string()).await;
-        assert!(
-            response.is_err(),
-            "sendGenesis should reject invalid content: {bad_content:?}"
-        );
-
-        // The target path must not exist — nothing partial/garbage installed.
-        assert!(
-            !genesis_path.exists(),
-            "target genesis path must not be created on invalid content: {bad_content:?}"
-        );
-        // No staging temp file left behind.
-        assert!(
-            !genesis_dir.path().join("genesis.toml.tmp").exists(),
-            "temp genesis file must be cleaned up on invalid content: {bad_content:?}"
-        );
-
-        handle.stop().unwrap();
-    }
 }
 
 /// The genesis provisioning RPC installs the chain's authoritative identity
@@ -619,7 +539,6 @@ async fn test_get_deposit_signature_not_on_public_listener() {
         b"_SUMMIT".to_vec(),
         0,
         0,
-        None,
         #[cfg(feature = "permissioned")]
         Arc::new(AtomicBool::new(false)),
     )
@@ -668,115 +587,6 @@ async fn test_get_deposit_signature_not_on_public_listener() {
         handles.admin_addr.ip().is_loopback(),
         "admin listener must be bound to loopback; bound to {}",
         handles.admin_addr.ip()
-    );
-
-    handles.public_handle.stop().unwrap();
-    handles.admin_handle.stop().unwrap();
-}
-
-/// An observer node's live P2P identity is a child key derived from the
-/// master node key; signing a deposit would bind the master validator
-/// identity from a process that doesn't represent it. `getDepositSignature`
-/// must therefore be rejected in observer mode, even on the admin listener.
-#[tokio::test]
-async fn test_get_deposit_signature_disabled_in_observer_mode() {
-    use jsonrpsee::core::ClientError;
-    use summit_rpc::SummitAdminApiClient;
-
-    let (mailbox, _finalizer_handle) = create_test_finalizer_mailbox(MockFinalizerState::default());
-    let temp_dir = create_test_keystore().unwrap();
-    let key_store_path = temp_dir.path().to_str().unwrap().to_string();
-    let observer_node_key = derive_observer_node_key(&key_store_path, 0);
-
-    let handles = start_rpc_server_pair_with_handle(
-        mailbox,
-        key_store_path,
-        TEST_GENESIS_HASH,
-        b"_SUMMIT".to_vec(),
-        0,
-        0,
-        Some(observer_node_key),
-        #[cfg(feature = "permissioned")]
-        Arc::new(AtomicBool::new(false)),
-    )
-    .await
-    .unwrap();
-
-    let admin_url = format!("http://{}", handles.admin_addr);
-    let admin_client = HttpClientBuilder::default().build(&admin_url).unwrap();
-    let address = format!("0x{}", "a".repeat(40));
-    let resp =
-        SummitAdminApiClient::get_deposit_signature(&admin_client, 32_000_000_000, address).await;
-
-    match resp {
-        Err(ClientError::Call(err)) => {
-            assert_eq!(
-                err.code(),
-                4003,
-                "expected observer-mode rejection (4003), got {:?}",
-                err
-            );
-        }
-        other => panic!(
-            "observer node must not serve getDepositSignature; got {:?}",
-            other
-        ),
-    }
-
-    handles.public_handle.stop().unwrap();
-    handles.admin_handle.stop().unwrap();
-}
-
-/// In observer mode `getPublicKeys` must report the derived child key — the
-/// node's live P2P transport identity — rather than the master keystore
-/// identity, and must leave the consensus key empty so the response can't be
-/// read as speaking for the validator's consensus identity.
-#[tokio::test]
-async fn test_get_public_keys_reports_observer_key_in_observer_mode() {
-    use summit_rpc::SummitApiClient;
-
-    let (mailbox, _finalizer_handle) = create_test_finalizer_mailbox(MockFinalizerState::default());
-    let temp_dir = create_test_keystore().unwrap();
-    let key_store_path = temp_dir.path().to_str().unwrap().to_string();
-    let observer_node_key = derive_observer_node_key(&key_store_path, 3);
-    let master_node_key = {
-        use summit_types::KeyPaths;
-        KeyPaths::new(key_store_path.clone())
-            .node_public_key()
-            .unwrap()
-    };
-
-    let handles = start_rpc_server_pair_with_handle(
-        mailbox,
-        key_store_path,
-        TEST_GENESIS_HASH,
-        b"_SUMMIT".to_vec(),
-        0,
-        0,
-        Some(observer_node_key.clone()),
-        #[cfg(feature = "permissioned")]
-        Arc::new(AtomicBool::new(false)),
-    )
-    .await
-    .unwrap();
-
-    let public_url = format!("http://{}", handles.public_addr);
-    let public_client = HttpClientBuilder::default().build(&public_url).unwrap();
-    let keys = SummitApiClient::get_public_keys(&public_client)
-        .await
-        .expect("observer node should still serve getPublicKeys");
-    assert_eq!(
-        keys.node, observer_node_key,
-        "observer should report its derived transport key"
-    );
-    assert_ne!(
-        keys.node, master_node_key,
-        "observer must not report the master node key"
-    );
-    assert!(
-        keys.consensus.is_empty(),
-        "observer must not report a consensus key; got {}",
-        keys.consensus
     );
 
     handles.public_handle.stop().unwrap();

--- a/rpc/tests/integration_test.rs
+++ b/rpc/tests/integration_test.rs
@@ -195,6 +195,118 @@ async fn test_get_state_proof_concurrency_cap_rejects_excess() {
     handle.stop().unwrap();
 }
 
+// The concurrency permit must be released when the proof task finishes, not
+// when the RPC handler future is dropped. Otherwise a caller could connect,
+// wait for the proof task to be spawned, disconnect to free the slot while the
+// detached proof work keeps running, and repeat to pile up real work under a
+// slot count that reads as idle. This drives the handler future directly,
+// cancels it after the proof task is spawned, and asserts the slot stays held
+// until the gated proof task completes.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_get_state_proof_permit_outlives_cancelled_request() {
+    use std::sync::atomic::Ordering;
+    use std::time::Duration;
+    use summit_rpc::{MAX_CONCURRENT_STATE_PROOFS, SummitProofApiServer, SummitRpcServer};
+
+    // Gated mock holds every proof task open, including the permit handed to it,
+    // until we release.
+    let (mailbox, received, release_tx, _mock) = create_gated_proof_mailbox();
+    let temp_dir = create_test_keystore().unwrap();
+    let key_store_path = temp_dir.path().to_str().unwrap().to_string();
+
+    let server = SummitRpcServer::new(
+        key_store_path,
+        mailbox,
+        TEST_GENESIS_HASH,
+        b"_SUMMIT",
+        #[cfg(feature = "permissioned")]
+        Arc::new(AtomicBool::new(false)),
+    );
+
+    let cap = MAX_CONCURRENT_STATE_PROOFS;
+
+    // Keep cap - 1 proof requests in flight, held open by the gated mock.
+    let mut held = Vec::new();
+    for _ in 0..(cap - 1) {
+        let server = server.clone();
+        held.push(tokio::spawn(async move {
+            let _ = server.get_state_proof(vec!["epoch".to_string()]).await;
+        }));
+    }
+
+    // Start the cap-th request; it acquires the last slot and hands its permit
+    // to the (gated) proof task.
+    let cancel = {
+        let server = server.clone();
+        tokio::spawn(async move {
+            let _ = server.get_state_proof(vec!["epoch".to_string()]).await;
+        })
+    };
+
+    // Wait until every request has reached the mock, so all cap slots are
+    // acquired and all permits are now owned by the mock's detached tasks.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    while received.load(Ordering::SeqCst) < cap {
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "proof tasks were never spawned"
+        );
+        tokio::time::sleep(Duration::from_millis(2)).await;
+    }
+
+    // Cancel the cap-th request's handler future (the client-disconnect path).
+    cancel.abort();
+    let _ = cancel.await;
+
+    // The slot must still be held: it belongs to the cancelled request's proof
+    // task, which is still gated. A fresh request is rejected as busy and
+    // returns immediately. If cancellation had leaked the slot back, the fresh
+    // request would instead be accepted and block on the gated mock until the
+    // timeout fires.
+    let fresh = tokio::time::timeout(
+        Duration::from_secs(2),
+        server.get_state_proof(vec!["epoch".to_string()]),
+    )
+    .await;
+    match fresh {
+        Ok(Err(obj)) => assert_eq!(
+            obj.code(),
+            3007,
+            "cancelled request must keep holding its slot until the proof task completes"
+        ),
+        Ok(Ok(_)) => {
+            panic!("fresh request was accepted: a cancelled request freed its slot early")
+        }
+        Err(_) => panic!(
+            "fresh request blocked on the gated mock: the cancelled request's slot was freed while its proof task is still running"
+        ),
+    }
+
+    // Release every gated task; permits drop as the tasks complete, freeing
+    // slots.
+    let _ = release_tx.send(());
+    for h in held {
+        let _ = h.await;
+    }
+
+    // A fresh request now succeeds, proving the permits were released when the
+    // proof tasks finished rather than lost.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        match server.get_state_proof(vec!["epoch".to_string()]).await {
+            Ok(_) => break,
+            Err(obj) => {
+                assert_eq!(obj.code(), 3007, "unexpected error while draining slots");
+                assert!(
+                    tokio::time::Instant::now() < deadline,
+                    "slots were never freed after the proof tasks completed"
+                );
+                tokio::time::sleep(Duration::from_millis(2)).await;
+            }
+        }
+    }
+}
+
 #[tokio::test]
 async fn test_get_latest_height() {
     use summit_rpc::SummitApiClient;

--- a/rpc/tests/integration_test.rs
+++ b/rpc/tests/integration_test.rs
@@ -9,7 +9,10 @@ use summit_rpc::{
     PathSender, start_rpc_server_for_genesis_with_handle, start_rpc_server_pair_with_handle,
     start_rpc_server_with_handle,
 };
-use utils::{MockFinalizerState, create_test_finalizer_mailbox, create_test_keystore};
+use utils::{
+    MockFinalizerState, create_gated_proof_mailbox, create_test_finalizer_mailbox,
+    create_test_keystore,
+};
 
 const TEST_GENESIS_HASH: [u8; 32] = [7u8; 32];
 
@@ -110,6 +113,84 @@ async fn test_get_state_proof_rejects_excessive_cost() {
         ClientError::Call(obj) => assert_eq!(obj.code(), 3006),
         other => panic!("expected 3006 StateProofCostLimit, got {other:?}"),
     }
+
+    handle.stop().unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_get_state_proof_concurrency_cap_rejects_excess() {
+    use futures::StreamExt as _;
+    use jsonrpsee::core::client::Error as ClientError;
+    use summit_rpc::{MAX_CONCURRENT_STATE_PROOFS, SummitProofApiClient};
+
+    // Gated mock: holds every proof generation open until we release, so we can
+    // pin `cap` requests in flight simultaneously and observe the cap engaging.
+    let (mailbox, _received, release_tx, _mock) = create_gated_proof_mailbox();
+    let temp_dir = create_test_keystore().unwrap();
+    let key_store_path = temp_dir.path().to_str().unwrap().to_string();
+
+    let (handle, addr) = start_rpc_server_with_handle(
+        mailbox,
+        key_store_path,
+        TEST_GENESIS_HASH,
+        b"_SUMMIT".to_vec(),
+        0,
+        #[cfg(feature = "permissioned")]
+        Arc::new(AtomicBool::new(false)),
+    )
+    .await
+    .unwrap();
+
+    let url = format!("http://{}", addr);
+    let cap = MAX_CONCURRENT_STATE_PROOFS;
+    let extra = 5;
+
+    // Fire cap + extra concurrent proof requests (one cheap scalar key each, well
+    // within the per-request limits). The gated mock never responds until we
+    // release, so the first `cap` hold their concurrency slots and the remaining
+    // `extra` must be rejected with the busy error (3007). No slot is freed before
+    // release, so the split is deterministic.
+    let (tx, mut rx) = futures::channel::mpsc::unbounded();
+    for _ in 0..(cap + extra) {
+        let client = HttpClientBuilder::default().build(&url).unwrap();
+        let tx = tx.clone();
+        tokio::spawn(async move {
+            let res = client.get_state_proof(vec!["epoch".to_string()]).await;
+            let _ = tx.unbounded_send(res);
+        });
+    }
+    drop(tx);
+
+    let mut busy = 0usize;
+    let mut accepted = 0usize;
+    let mut release_tx = Some(release_tx);
+    while let Some(res) = rx.next().await {
+        match res {
+            Ok(_) => accepted += 1,
+            Err(ClientError::Call(obj)) => {
+                assert_eq!(
+                    obj.code(),
+                    3007,
+                    "over-cap request must be rejected as busy"
+                );
+                busy += 1;
+            }
+            Err(other) => panic!("unexpected client error: {other:?}"),
+        }
+        // Once every over-cap request has been rejected, the `cap` accepted ones
+        // are confirmed holding their slots in flight; release them to complete.
+        if busy == extra {
+            if let Some(tx) = release_tx.take() {
+                let _ = tx.send(());
+            }
+        }
+    }
+
+    assert_eq!(busy, extra, "exactly the over-cap requests are rejected");
+    assert_eq!(
+        accepted, cap,
+        "exactly the cap is accepted concurrently before release"
+    );
 
     handle.stop().unwrap();
 }

--- a/rpc/tests/integration_test.rs
+++ b/rpc/tests/integration_test.rs
@@ -10,11 +10,25 @@ use summit_rpc::{
     start_rpc_server_with_handle,
 };
 use utils::{
-    MockFinalizerState, create_gated_proof_mailbox, create_test_finalizer_mailbox,
-    create_test_keystore,
+    MockFinalizerState, create_gated_proof_mailbox, create_test_finalized_header,
+    create_test_finalizer_mailbox, create_test_keystore,
 };
 
 const TEST_GENESIS_HASH: [u8; 32] = [7u8; 32];
+
+/// Derives the observer child public key (hex) the way the node does in
+/// observer mode, so tests can assert the RPC reports it as the live identity.
+fn derive_observer_node_key(key_store_path: &str, index: u32) -> String {
+    use commonware_cryptography::Signer as _;
+    use summit_types::{KeyPaths, ext_private_key::ExtPrivateKey};
+
+    let node_key = KeyPaths::new(key_store_path.to_string())
+        .read_node_key_from_file()
+        .unwrap();
+    ExtPrivateKey::derive_child_signer(&node_key, b"_SUMMIT", index)
+        .public_key()
+        .to_string()
+}
 
 #[tokio::test]
 async fn test_health_endpoint() {
@@ -219,6 +233,7 @@ async fn test_get_state_proof_permit_outlives_cancelled_request() {
         mailbox,
         TEST_GENESIS_HASH,
         b"_SUMMIT",
+        None,
         #[cfg(feature = "permissioned")]
         Arc::new(AtomicBool::new(false)),
     );
@@ -473,6 +488,10 @@ activity_timeout_views = 256
 skip_timeout_views = 32
 max_message_size_bytes = 104857600
 namespace = "_SUMMIT"
+validator_minimum_stake = 32000000000
+validator_maximum_stake = 32000000000
+blocks_per_epoch = 10000
+allowed_timestamp_future_ms = 10000
 
 [[validators]]
 node_public_key = "1be3cb06d7cc347602421fb73838534e4b54934e28959de98906d120d0799ef2"
@@ -732,6 +751,7 @@ async fn test_get_deposit_signature_not_on_public_listener() {
         b"_SUMMIT".to_vec(),
         0,
         0,
+        None,
         #[cfg(feature = "permissioned")]
         Arc::new(AtomicBool::new(false)),
     )
@@ -780,6 +800,245 @@ async fn test_get_deposit_signature_not_on_public_listener() {
         handles.admin_addr.ip().is_loopback(),
         "admin listener must be bound to loopback; bound to {}",
         handles.admin_addr.ip()
+    );
+
+    handles.public_handle.stop().unwrap();
+    handles.admin_handle.stop().unwrap();
+}
+
+#[tokio::test]
+async fn test_websocket_upgrades_are_rejected() {
+    // The RPC server is http-only: Summit's API is request/response (no
+    // subscriptions). Disabling websocket upgrades closes the idle-connection
+    // permit-exhaustion vector (jsonrpsee enables websockets with pings off by
+    // default, so idle upgraded connections would hold their max_connections
+    // permit indefinitely). HTTP must still work; websocket connects must fail.
+    use jsonrpsee::ws_client::WsClientBuilder;
+    use summit_rpc::SummitApiClient;
+
+    let (mailbox, _finalizer_handle) = create_test_finalizer_mailbox(MockFinalizerState::default());
+    let temp_dir = create_test_keystore().unwrap();
+    let key_store_path = temp_dir.path().to_str().unwrap().to_string();
+
+    let (handle, addr) = start_rpc_server_with_handle(
+        mailbox,
+        key_store_path,
+        TEST_GENESIS_HASH,
+        b"_SUMMIT".to_vec(),
+        0,
+        #[cfg(feature = "permissioned")]
+        Arc::new(AtomicBool::new(false)),
+    )
+    .await
+    .unwrap();
+
+    // HTTP still works.
+    let http = HttpClientBuilder::default()
+        .build(format!("http://{addr}"))
+        .unwrap();
+    assert_eq!(http.health().await.unwrap(), "Ok");
+
+    // Websocket upgrade is refused, so idle WS connections cannot be opened.
+    let ws = WsClientBuilder::default()
+        .build(format!("ws://{addr}"))
+        .await;
+    assert!(
+        ws.is_err(),
+        "websocket upgrade must be rejected when the server is http-only"
+    );
+
+    handle.stop().unwrap();
+}
+
+#[tokio::test]
+async fn test_get_finalized_header_digest() {
+    use summit_rpc::SummitApiClient;
+
+    let epoch = 3;
+    let finalized_header = create_test_finalized_header(epoch);
+    let expected_digest = finalized_header.header().get_digest().0;
+    let state = MockFinalizerState {
+        finalized_headers: [(epoch, Some(finalized_header))].into(),
+        ..Default::default()
+    };
+    let (mailbox, _finalizer_handle) = create_test_finalizer_mailbox(state);
+    let temp_dir = create_test_keystore().unwrap();
+    let key_store_path = temp_dir.path().to_str().unwrap().to_string();
+
+    let (handle, addr) = start_rpc_server_with_handle(
+        mailbox,
+        key_store_path,
+        TEST_GENESIS_HASH,
+        b"_SUMMIT".to_vec(),
+        0,
+        #[cfg(feature = "permissioned")]
+        Arc::new(AtomicBool::new(false)),
+    )
+    .await
+    .unwrap();
+
+    let url = format!("http://{}", addr);
+    let client = HttpClientBuilder::default().build(&url).unwrap();
+
+    let response = client.get_finalized_header_digest(epoch).await.unwrap();
+    assert_eq!(response.epoch, epoch);
+    assert_eq!(response.digest, expected_digest);
+
+    handle.stop().unwrap();
+}
+
+/// send_genesis must validate before installing: malformed or empty content is
+/// rejected, the target path is left untouched (no partial/garbage file that
+/// startup would treat as provisioned), and no temp file is left behind.
+#[tokio::test]
+async fn test_send_genesis_rejects_invalid_content() {
+    use summit_rpc::SummitGenesisApiClient;
+
+    for bad_content in [
+        "",
+        "this is not valid toml",
+        "eth_genesis_hash = \"0xdead\"\n",
+    ] {
+        let temp_dir = create_test_keystore().unwrap();
+        let key_store_path = temp_dir.path().to_str().unwrap().to_string();
+
+        let genesis_dir = tempfile::tempdir().unwrap();
+        let genesis_path = genesis_dir.path().join("genesis.toml");
+        let genesis_path_str = genesis_path.to_str().unwrap().to_string();
+
+        let path_sender = PathSender::new(genesis_path_str, None);
+        let (handle, addr) =
+            start_rpc_server_for_genesis_with_handle(path_sender, key_store_path, 0)
+                .await
+                .unwrap();
+
+        let url = format!("http://{}", addr);
+        let client = HttpClientBuilder::default().build(&url).unwrap();
+
+        let response = client.send_genesis(bad_content.to_string()).await;
+        assert!(
+            response.is_err(),
+            "sendGenesis should reject invalid content: {bad_content:?}"
+        );
+
+        // The target path must not exist — nothing partial/garbage installed.
+        assert!(
+            !genesis_path.exists(),
+            "target genesis path must not be created on invalid content: {bad_content:?}"
+        );
+        // No staging temp file left behind.
+        assert!(
+            !genesis_dir.path().join("genesis.toml.tmp").exists(),
+            "temp genesis file must be cleaned up on invalid content: {bad_content:?}"
+        );
+
+        handle.stop().unwrap();
+    }
+}
+
+/// In observer mode `getDepositSignature` must be rejected even on the admin
+/// listener: the observer runs a derived child key, not the master node key,
+/// so signing a deposit would bind the master validator identity from a
+/// process that doesn't represent it.
+#[tokio::test]
+async fn test_get_deposit_signature_disabled_in_observer_mode() {
+    use jsonrpsee::core::ClientError;
+    use summit_rpc::SummitAdminApiClient;
+
+    let (mailbox, _finalizer_handle) = create_test_finalizer_mailbox(MockFinalizerState::default());
+    let temp_dir = create_test_keystore().unwrap();
+    let key_store_path = temp_dir.path().to_str().unwrap().to_string();
+    let observer_node_key = derive_observer_node_key(&key_store_path, 0);
+
+    let handles = start_rpc_server_pair_with_handle(
+        mailbox,
+        key_store_path,
+        TEST_GENESIS_HASH,
+        b"_SUMMIT".to_vec(),
+        0,
+        0,
+        Some(observer_node_key),
+        #[cfg(feature = "permissioned")]
+        Arc::new(AtomicBool::new(false)),
+    )
+    .await
+    .unwrap();
+
+    let admin_url = format!("http://{}", handles.admin_addr);
+    let admin_client = HttpClientBuilder::default().build(&admin_url).unwrap();
+    let address = format!("0x{}", "a".repeat(40));
+    let resp =
+        SummitAdminApiClient::get_deposit_signature(&admin_client, 32_000_000_000, address).await;
+
+    match resp {
+        Err(ClientError::Call(err)) => {
+            assert_eq!(
+                err.code(),
+                4003,
+                "expected observer-mode rejection (4003), got {:?}",
+                err
+            );
+        }
+        other => panic!(
+            "observer node must not serve getDepositSignature; got {:?}",
+            other
+        ),
+    }
+
+    handles.public_handle.stop().unwrap();
+    handles.admin_handle.stop().unwrap();
+}
+
+/// In observer mode `getPublicKeys` must report the derived child key — the
+/// node's live P2P transport identity — rather than the master keystore
+/// identity, and must leave the consensus key empty so the response can't be
+/// read as speaking for the validator's consensus identity.
+#[tokio::test]
+async fn test_get_public_keys_reports_observer_key_in_observer_mode() {
+    use summit_rpc::SummitApiClient;
+
+    let (mailbox, _finalizer_handle) = create_test_finalizer_mailbox(MockFinalizerState::default());
+    let temp_dir = create_test_keystore().unwrap();
+    let key_store_path = temp_dir.path().to_str().unwrap().to_string();
+    let observer_node_key = derive_observer_node_key(&key_store_path, 3);
+    let master_node_key = {
+        use summit_types::KeyPaths;
+        KeyPaths::new(key_store_path.clone())
+            .node_public_key()
+            .unwrap()
+    };
+
+    let handles = start_rpc_server_pair_with_handle(
+        mailbox,
+        key_store_path,
+        TEST_GENESIS_HASH,
+        b"_SUMMIT".to_vec(),
+        0,
+        0,
+        Some(observer_node_key.clone()),
+        #[cfg(feature = "permissioned")]
+        Arc::new(AtomicBool::new(false)),
+    )
+    .await
+    .unwrap();
+
+    let public_url = format!("http://{}", handles.public_addr);
+    let public_client = HttpClientBuilder::default().build(&public_url).unwrap();
+    let keys = SummitApiClient::get_public_keys(&public_client)
+        .await
+        .expect("observer node should still serve getPublicKeys");
+    assert_eq!(
+        keys.node, observer_node_key,
+        "observer should report its derived transport key"
+    );
+    assert_ne!(
+        keys.node, master_node_key,
+        "observer must not report the master node key"
+    );
+    assert!(
+        keys.consensus.is_empty(),
+        "observer must not report a consensus key; got {}",
+        keys.consensus
     );
 
     handles.public_handle.stop().unwrap();

--- a/rpc/tests/utils.rs
+++ b/rpc/tests/utils.rs
@@ -1,24 +1,22 @@
 use alloy_primitives::Address;
-use commonware_codec::{DecodeExt as _, Encode as _};
+use commonware_codec::Encode as _;
 use commonware_cryptography::{bls12381, ed25519};
 use commonware_math::algebra::Random;
-use futures::{StreamExt, channel::mpsc};
+use futures::StreamExt;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
 use std::collections::HashMap;
 use std::fs;
-use summit_finalizer::{FinalizerMailbox, FinalizerMessage};
 use summit_types::account::ValidatorAccount;
 use summit_types::{
     Block,
-    consensus_state_query::{ConsensusStateRequest, ConsensusStateResponse},
+    consensus_state_query::{ConsensusStateQuery, ConsensusStateRequest, ConsensusStateResponse},
     scheme::MultisigScheme,
 };
 use tokio::task::JoinHandle;
 
 // Use the default Block type parameters and the MultisigScheme with ed25519 + MinPk
 pub type TestScheme = MultisigScheme;
-pub type TestBlock = Block;
 
 /// Mock finalizer state that can be customized per test
 #[derive(Clone, Debug)]
@@ -27,7 +25,6 @@ pub struct MockFinalizerState {
     pub latest_epoch: u64,
     pub checkpoints: HashMap<u64, Option<summit_types::checkpoint::Checkpoint>>,
     pub latest_checkpoint: Option<(Option<summit_types::checkpoint::Checkpoint>, u64)>,
-    pub finalized_headers: HashMap<u64, Option<summit_types::FinalizedHeader<TestScheme>>>,
     pub validator_balances: HashMap<summit_types::PublicKey, Option<u64>>,
     pub validator_accounts: HashMap<summit_types::PublicKey, Option<ValidatorAccount>>,
     pub minimum_stake: u64,
@@ -41,7 +38,6 @@ impl Default for MockFinalizerState {
             latest_epoch: 0,
             checkpoints: HashMap::new(),
             latest_checkpoint: Some((None, 0)),
-            finalized_headers: HashMap::new(),
             validator_balances: HashMap::new(),
             validator_accounts: HashMap::new(),
             minimum_stake: 32_000_000_000, // 32 ETH in gwei
@@ -53,174 +49,111 @@ impl Default for MockFinalizerState {
 /// Creates a mock finalizer mailbox that responds to queries with test data
 pub fn create_test_finalizer_mailbox(
     state: MockFinalizerState,
-) -> (FinalizerMailbox<TestScheme, TestBlock>, JoinHandle<()>) {
-    let (tx, mut rx) = mpsc::channel::<FinalizerMessage<TestScheme, TestBlock>>(100);
+) -> (ConsensusStateQuery<TestScheme>, JoinHandle<()>) {
+    let (query, mut rx) = ConsensusStateQuery::new(100);
 
     let handle = tokio::spawn(async move {
-        while let Some(msg) = rx.next().await {
-            match msg {
-                FinalizerMessage::QueryState { request, response } => match request {
-                    ConsensusStateRequest::GetLatestHeight => {
-                        let _ = response
-                            .send(ConsensusStateResponse::LatestHeight(state.latest_height));
-                    }
-                    ConsensusStateRequest::GetLatestEpoch => {
-                        let _ =
-                            response.send(ConsensusStateResponse::LatestEpoch(state.latest_epoch));
-                    }
-                    ConsensusStateRequest::GetCheckpoint(epoch) => {
-                        let checkpoint = state
-                            .checkpoints
-                            .get(&epoch)
-                            .cloned()
-                            .flatten()
-                            .and_then(|checkpoint| Some((checkpoint, Block::genesis([0; 32]))));
-                        let _ = response.send(ConsensusStateResponse::Checkpoint(checkpoint));
-                    }
-                    ConsensusStateRequest::GetLatestCheckpoint => {
-                        let (latest_checkpoint, epoch) =
-                            state.latest_checkpoint.clone().unwrap_or((None, 0));
-
-                        let latest_checkpoint = latest_checkpoint
-                            .map(|checkpoint| (checkpoint, Block::genesis([0; 32])));
-                        let _ = response.send(ConsensusStateResponse::LatestCheckpoint((
-                            latest_checkpoint,
-                            epoch,
-                        )));
-                    }
-                    ConsensusStateRequest::GetValidatorBalance(public_key) => {
-                        let balance = state.validator_balances.get(&public_key).cloned().flatten();
-                        let _ = response.send(ConsensusStateResponse::ValidatorBalance(balance));
-                    }
-                    ConsensusStateRequest::GetValidatorAccount(public_key) => {
-                        let account = state.validator_accounts.get(&public_key).cloned().flatten();
-                        let _ = response.send(ConsensusStateResponse::ValidatorAccount(account));
-                    }
-                    ConsensusStateRequest::GetFinalizedHeader(epoch) => {
-                        let header = state.finalized_headers.get(&epoch).cloned().flatten();
-                        let _ = response.send(ConsensusStateResponse::FinalizedHeader(header));
-                    }
-                    ConsensusStateRequest::GetMinimumStake => {
-                        let _ = response
-                            .send(ConsensusStateResponse::MinimumStake(state.minimum_stake));
-                    }
-                    ConsensusStateRequest::GetMaximumStake => {
-                        let _ = response
-                            .send(ConsensusStateResponse::MaximumStake(state.maximum_stake));
-                    }
-                    ConsensusStateRequest::GetStateRoot => {
-                        let _ = response.send(ConsensusStateResponse::StateRoot {
-                            root: [0; 32],
-                            el_block_number: 0,
-                        });
-                    }
-                    ConsensusStateRequest::GetDeposit(_) => {
-                        let _ = response.send(ConsensusStateResponse::Deposit(None));
-                    }
-                    ConsensusStateRequest::GetDepositCount => {
-                        let _ = response.send(ConsensusStateResponse::DepositCount(0));
-                    }
-                    ConsensusStateRequest::GetWithdrawal(_) => {
-                        let _ = response.send(ConsensusStateResponse::Withdrawal(None));
-                    }
-                    ConsensusStateRequest::GenerateStateProof(_keys) => {
-                        let _ = response.send(ConsensusStateResponse::StateProof {
-                            root: [0; 32],
-                            el_block_number: 0,
-                            proofs: vec![],
-                        });
-                    }
-                    ConsensusStateRequest::GetEpochLength => {
-                        let _ = response.send(ConsensusStateResponse::EpochLength(10));
-                    }
-                    ConsensusStateRequest::GetAllowedTimestampFuture => {
-                        let _ =
-                            response.send(ConsensusStateResponse::AllowedTimestampFuture(10_000));
-                    }
-                    ConsensusStateRequest::GetTreasuryAddress => {
-                        let _ =
-                            response.send(ConsensusStateResponse::TreasuryAddress(Address::ZERO));
-                    }
-                    ConsensusStateRequest::GetMaxDepositsPerEpoch => {
-                        let _ = response.send(ConsensusStateResponse::MaxDepositsPerEpoch(3));
-                    }
-                    ConsensusStateRequest::GetMaxWithdrawalsPerEpoch => {
-                        let _ = response.send(ConsensusStateResponse::MaxWithdrawalsPerEpoch(16));
-                    }
-                    ConsensusStateRequest::GetObserversPerValidator => {
-                        let _ = response.send(ConsensusStateResponse::ObserversPerValidator(0));
-                    }
-                    ConsensusStateRequest::GetMinimumValidatorCount => {
-                        let _ = response.send(ConsensusStateResponse::MinimumValidatorCount(3));
-                    }
-                    ConsensusStateRequest::GetEpochBounds(epoch) => {
-                        let first = epoch * 10;
-                        let last = first + 9;
-                        let _ =
-                            response.send(ConsensusStateResponse::EpochBounds(Some((first, last))));
-                    }
-                },
-                _ => {}
+        while let Some((request, response)) = rx.next().await {
+            match request {
+                ConsensusStateRequest::GetLatestHeight => {
+                    let _ =
+                        response.send(ConsensusStateResponse::LatestHeight(state.latest_height));
+                }
+                ConsensusStateRequest::GetLatestEpoch => {
+                    let _ = response.send(ConsensusStateResponse::LatestEpoch(state.latest_epoch));
+                }
+                ConsensusStateRequest::GetCheckpoint(epoch) => {
+                    let checkpoint = state
+                        .checkpoints
+                        .get(&epoch)
+                        .cloned()
+                        .flatten()
+                        .and_then(|checkpoint| Some((checkpoint, Block::genesis([0; 32]))));
+                    let _ = response.send(ConsensusStateResponse::Checkpoint(checkpoint));
+                }
+                ConsensusStateRequest::GetLatestCheckpoint => {
+                    let (latest_checkpoint, epoch) =
+                        state.latest_checkpoint.clone().unwrap_or((None, 0));
+                    let latest_checkpoint =
+                        latest_checkpoint.map(|checkpoint| (checkpoint, Block::genesis([0; 32])));
+                    let _ = response.send(ConsensusStateResponse::LatestCheckpoint((
+                        latest_checkpoint,
+                        epoch,
+                    )));
+                }
+                ConsensusStateRequest::GetValidatorBalance(public_key) => {
+                    let balance = state.validator_balances.get(&public_key).cloned().flatten();
+                    let _ = response.send(ConsensusStateResponse::ValidatorBalance(balance));
+                }
+                ConsensusStateRequest::GetValidatorAccount(public_key) => {
+                    let account = state.validator_accounts.get(&public_key).cloned().flatten();
+                    let _ = response.send(ConsensusStateResponse::ValidatorAccount(account));
+                }
+                ConsensusStateRequest::GetFinalizedHeader(_) => unimplemented!(),
+                ConsensusStateRequest::GetMinimumStake => {
+                    let _ =
+                        response.send(ConsensusStateResponse::MinimumStake(state.minimum_stake));
+                }
+                ConsensusStateRequest::GetMaximumStake => {
+                    let _ =
+                        response.send(ConsensusStateResponse::MaximumStake(state.maximum_stake));
+                }
+                ConsensusStateRequest::GetStateRoot => {
+                    let _ = response.send(ConsensusStateResponse::StateRoot {
+                        root: [0; 32],
+                        el_block_number: 0,
+                    });
+                }
+                ConsensusStateRequest::GetDeposit(_) => {
+                    let _ = response.send(ConsensusStateResponse::Deposit(None));
+                }
+                ConsensusStateRequest::GetDepositCount => {
+                    let _ = response.send(ConsensusStateResponse::DepositCount(0));
+                }
+                ConsensusStateRequest::GetWithdrawal(_) => {
+                    let _ = response.send(ConsensusStateResponse::Withdrawal(None));
+                }
+                ConsensusStateRequest::GenerateStateProof(keys) => {
+                    // Honor the one-result-per-requested-key contract (#260/#267):
+                    // return a positional slot per key so the server's length guard
+                    // and keyed-alignment logic are exercised faithfully.
+                    let _ = response.send(ConsensusStateResponse::StateProof {
+                        root: [0; 32],
+                        el_block_number: 0,
+                        proofs: keys.iter().map(|_| None).collect(),
+                    });
+                }
+                ConsensusStateRequest::GetEpochLength => {
+                    let _ = response.send(ConsensusStateResponse::EpochLength(10));
+                }
+                ConsensusStateRequest::GetAllowedTimestampFuture => {
+                    let _ = response.send(ConsensusStateResponse::AllowedTimestampFuture(10_000));
+                }
+                ConsensusStateRequest::GetTreasuryAddress => {
+                    let _ = response.send(ConsensusStateResponse::TreasuryAddress(Address::ZERO));
+                }
+                ConsensusStateRequest::GetMaxDepositsPerEpoch => {
+                    let _ = response.send(ConsensusStateResponse::MaxDepositsPerEpoch(3));
+                }
+                ConsensusStateRequest::GetMaxWithdrawalsPerEpoch => {
+                    let _ = response.send(ConsensusStateResponse::MaxWithdrawalsPerEpoch(16));
+                }
+                ConsensusStateRequest::GetObserversPerValidator => {
+                    let _ = response.send(ConsensusStateResponse::ObserversPerValidator(0));
+                }
+                ConsensusStateRequest::GetMinimumValidatorCount => {
+                    let _ = response.send(ConsensusStateResponse::MinimumValidatorCount(3));
+                }
+                ConsensusStateRequest::GetEpochBounds(epoch) => {
+                    let first = epoch * 10;
+                    let last = first + 9;
+                    let _ = response.send(ConsensusStateResponse::EpochBounds(Some((first, last))));
+                }
             }
         }
     });
 
-    (FinalizerMailbox::new(tx), handle)
-}
-
-pub fn create_test_finalized_header(epoch: u64) -> summit_types::FinalizedHeader<TestScheme> {
-    use commonware_consensus::simplex::types::{Finalization, Proposal};
-    use commonware_consensus::types::{Epoch, Round, View};
-    use commonware_cryptography::bls12381::{
-        certificate::multisig::Certificate as BlsCertificate,
-        primitives::{
-            group::Private,
-            ops::{aggregate::Signature, sign_message},
-            variant::MinPk,
-        },
-    };
-    use commonware_utils::Participant;
-
-    let header = summit_types::Header::new(
-        [1u8; 32].into(),
-        epoch * 10 + 9,
-        1234567890 + epoch,
-        epoch,
-        1,
-        [2u8; 32].into(),
-        [3u8; 32].into(),
-        [4u8; 32].into(),
-        [5u8; 32].into(),
-        Vec::new(),
-        Vec::new(),
-        [0u8; 32],
-    );
-
-    let proposal = Proposal {
-        round: Round::new(Epoch::new(header.epoch()), View::new(header.view())),
-        parent: View::new(header.height()),
-        payload: header.get_digest(),
-    };
-
-    let mut rng = StdRng::seed_from_u64(42);
-    let private = Private::random(&mut rng);
-    let g2_signature = sign_message::<MinPk>(&private, b"", b"test message");
-    let encoded = g2_signature.encode();
-    let signature = Signature::<MinPk>::decode(encoded).expect("valid signature");
-
-    let finalized = Finalization {
-        proposal,
-        certificate: BlsCertificate::<MinPk> {
-            signers: commonware_cryptography::certificate::Signers::from(
-                3,
-                [0, 1, 2].map(Participant::new),
-            ),
-            signature: signature.into(),
-        },
-    };
-
-    summit_types::FinalizedHeader::new(header, finalized, 3)
-        .expect("test finalized header should be payload-bound")
+    (query, handle)
 }
 
 /// Creates a temporary key store directory with test keys

--- a/rpc/tests/utils.rs
+++ b/rpc/tests/utils.rs
@@ -115,7 +115,7 @@ pub fn create_test_finalizer_mailbox(
                 ConsensusStateRequest::GetWithdrawal(_) => {
                     let _ = response.send(ConsensusStateResponse::Withdrawal(None));
                 }
-                ConsensusStateRequest::GenerateStateProof(keys) => {
+                ConsensusStateRequest::GenerateStateProof(keys, _permit) => {
                     // Honor the one-result-per-requested-key contract (#260/#267):
                     // return a positional slot per key so the server's length guard
                     // and keyed-alignment logic are exercised faithfully.
@@ -182,10 +182,15 @@ pub fn create_gated_proof_mailbox() -> (
     let handle = tokio::spawn(async move {
         while let Some((request, response)) = rx.next().await {
             match request {
-                ConsensusStateRequest::GenerateStateProof(keys) => {
+                ConsensusStateRequest::GenerateStateProof(keys, permit) => {
                     let received = received_task.clone();
                     let release = release.clone();
                     tokio::spawn(async move {
+                        // Hold the concurrency permit inside this spawned task,
+                        // exactly as the finalizer does, so it is dropped only
+                        // when the (gated) proof work completes. Capturing it
+                        // here is what models the real permit lifetime.
+                        let _permit = permit;
                         received.fetch_add(1, Ordering::SeqCst);
                         let _ = release.await;
                         let _ = response.send(ConsensusStateResponse::StateProof {

--- a/rpc/tests/utils.rs
+++ b/rpc/tests/utils.rs
@@ -2,11 +2,13 @@ use alloy_primitives::Address;
 use commonware_codec::Encode as _;
 use commonware_cryptography::{bls12381, ed25519};
 use commonware_math::algebra::Random;
-use futures::StreamExt;
+use futures::{FutureExt as _, StreamExt, channel::oneshot};
 use rand::SeedableRng;
 use rand::rngs::StdRng;
 use std::collections::HashMap;
 use std::fs;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use summit_types::account::ValidatorAccount;
 use summit_types::{
     Block,
@@ -154,6 +156,51 @@ pub fn create_test_finalizer_mailbox(
     });
 
     (query, handle)
+}
+
+/// A mock state-query mailbox whose `GenerateStateProof` responses are gated:
+/// every received proof request increments `received` and then blocks until the
+/// returned one-shot release trigger fires, letting a test hold many proof
+/// generations in flight at once. Each request is handled in its own spawned
+/// task (mirroring the finalizer's off-loop proof spawn) so the mock keeps
+/// accepting requests while earlier ones are held open.
+///
+/// Returns the query handle, an in-flight-received counter, and the release
+/// trigger (drop or send `()` to let all held requests complete).
+pub fn create_gated_proof_mailbox() -> (
+    ConsensusStateQuery<TestScheme>,
+    Arc<AtomicUsize>,
+    oneshot::Sender<()>,
+    JoinHandle<()>,
+) {
+    let (query, mut rx) = ConsensusStateQuery::new(1024);
+    let received = Arc::new(AtomicUsize::new(0));
+    let (release_tx, release_rx) = oneshot::channel::<()>();
+    let release = release_rx.shared();
+    let received_task = received.clone();
+
+    let handle = tokio::spawn(async move {
+        while let Some((request, response)) = rx.next().await {
+            match request {
+                ConsensusStateRequest::GenerateStateProof(keys) => {
+                    let received = received_task.clone();
+                    let release = release.clone();
+                    tokio::spawn(async move {
+                        received.fetch_add(1, Ordering::SeqCst);
+                        let _ = release.await;
+                        let _ = response.send(ConsensusStateResponse::StateProof {
+                            root: [0; 32],
+                            el_block_number: 0,
+                            proofs: keys.iter().map(|_| None).collect(),
+                        });
+                    });
+                }
+                _ => unreachable!("gated mock only serves GenerateStateProof"),
+            }
+        }
+    });
+
+    (query, received, release_tx, handle)
 }
 
 /// Creates a temporary key store directory with test keys

--- a/rpc/tests/utils.rs
+++ b/rpc/tests/utils.rs
@@ -1,5 +1,5 @@
 use alloy_primitives::Address;
-use commonware_codec::Encode as _;
+use commonware_codec::{DecodeExt as _, Encode as _};
 use commonware_cryptography::{bls12381, ed25519};
 use commonware_math::algebra::Random;
 use futures::{FutureExt as _, StreamExt, channel::oneshot};
@@ -27,6 +27,7 @@ pub struct MockFinalizerState {
     pub latest_epoch: u64,
     pub checkpoints: HashMap<u64, Option<summit_types::checkpoint::Checkpoint>>,
     pub latest_checkpoint: Option<(Option<summit_types::checkpoint::Checkpoint>, u64)>,
+    pub finalized_headers: HashMap<u64, Option<summit_types::FinalizedHeader<TestScheme>>>,
     pub validator_balances: HashMap<summit_types::PublicKey, Option<u64>>,
     pub validator_accounts: HashMap<summit_types::PublicKey, Option<ValidatorAccount>>,
     pub minimum_stake: u64,
@@ -40,6 +41,7 @@ impl Default for MockFinalizerState {
             latest_epoch: 0,
             checkpoints: HashMap::new(),
             latest_checkpoint: Some((None, 0)),
+            finalized_headers: HashMap::new(),
             validator_balances: HashMap::new(),
             validator_accounts: HashMap::new(),
             minimum_stake: 32_000_000_000, // 32 ETH in gwei
@@ -91,7 +93,10 @@ pub fn create_test_finalizer_mailbox(
                     let account = state.validator_accounts.get(&public_key).cloned().flatten();
                     let _ = response.send(ConsensusStateResponse::ValidatorAccount(account));
                 }
-                ConsensusStateRequest::GetFinalizedHeader(_) => unimplemented!(),
+                ConsensusStateRequest::GetFinalizedHeader(epoch) => {
+                    let header = state.finalized_headers.get(&epoch).cloned().flatten();
+                    let _ = response.send(ConsensusStateResponse::FinalizedHeader(header));
+                }
                 ConsensusStateRequest::GetMinimumStake => {
                     let _ =
                         response.send(ConsensusStateResponse::MinimumStake(state.minimum_stake));
@@ -226,4 +231,61 @@ pub fn create_test_keystore() -> anyhow::Result<tempfile::TempDir> {
     fs::write(consensus_key_path, encoded_consensus_key)?;
 
     Ok(temp_dir)
+}
+
+/// Builds a payload-bound `FinalizedHeader` for the given epoch so tests can
+/// exercise finalized-header query paths without a live consensus run.
+pub fn create_test_finalized_header(epoch: u64) -> summit_types::FinalizedHeader<TestScheme> {
+    use commonware_consensus::simplex::types::{Finalization, Proposal};
+    use commonware_consensus::types::{Epoch, Round, View};
+    use commonware_cryptography::bls12381::{
+        certificate::multisig::Certificate as BlsCertificate,
+        primitives::{
+            group::Private,
+            ops::{aggregate::Signature, sign_message},
+            variant::MinPk,
+        },
+    };
+    use commonware_utils::Participant;
+
+    let header = summit_types::Header::new(
+        [1u8; 32].into(),
+        epoch * 10 + 9,
+        1234567890 + epoch,
+        epoch,
+        1,
+        [2u8; 32].into(),
+        [3u8; 32].into(),
+        [4u8; 32].into(),
+        [5u8; 32].into(),
+        Vec::new(),
+        Vec::new(),
+        [0u8; 32],
+    );
+
+    let proposal = Proposal {
+        round: Round::new(Epoch::new(header.epoch()), View::new(header.view())),
+        parent: View::new(header.height()),
+        payload: header.get_digest(),
+    };
+
+    let mut rng = StdRng::seed_from_u64(42);
+    let private = Private::random(&mut rng);
+    let g2_signature = sign_message::<MinPk>(&private, b"", b"test message");
+    let encoded = g2_signature.encode();
+    let signature = Signature::<MinPk>::decode(encoded).expect("valid signature");
+
+    let finalized = Finalization {
+        proposal,
+        certificate: BlsCertificate::<MinPk> {
+            signers: commonware_cryptography::certificate::Signers::from(
+                3,
+                [0, 1, 2].map(Participant::new),
+            ),
+            signature: signature.into(),
+        },
+    };
+
+    summit_types::FinalizedHeader::new(header, finalized, 3)
+        .expect("test finalized header should be payload-bound")
 }

--- a/types/src/checkpoint.rs
+++ b/types/src/checkpoint.rs
@@ -536,6 +536,7 @@ mod tests {
     use ssz::{Decode, Encode};
     use std::collections::{BTreeMap, VecDeque};
     use std::num::NonZeroU64;
+    use std::sync::Arc;
 
     fn parse_public_key(public_key: &str) -> ed25519::PublicKey {
         ed25519::PublicKey::decode(
@@ -577,9 +578,9 @@ mod tests {
             pending_active_validator_exits: 0,
             epocher: DynamicEpocher::new(NonZeroU64::new(10).unwrap()),
             ssz_tree: SszStateTree::default(),
-            proof_tree: SszStateTree::default(),
+            proof_tree: Arc::new(SszStateTree::default()),
             state_root: [0u8; 32],
-            proof_validator_keys: Vec::new(),
+            proof_validator_keys: Arc::new(Vec::new()),
 
             proof_el_block_number: 0,
             captured_bytes: None,
@@ -709,9 +710,9 @@ mod tests {
             pending_active_validator_exits: 0,
             epocher: DynamicEpocher::new(NonZeroU64::new(10).unwrap()),
             ssz_tree: SszStateTree::default(),
-            proof_tree: SszStateTree::default(),
+            proof_tree: Arc::new(SszStateTree::default()),
             state_root: [0u8; 32],
-            proof_validator_keys: Vec::new(),
+            proof_validator_keys: Arc::new(Vec::new()),
 
             proof_el_block_number: 0,
             captured_bytes: None,
@@ -765,9 +766,9 @@ mod tests {
             pending_active_validator_exits: 0,
             epocher: DynamicEpocher::new(NonZeroU64::new(10).unwrap()),
             ssz_tree: SszStateTree::default(),
-            proof_tree: SszStateTree::default(),
+            proof_tree: Arc::new(SszStateTree::default()),
             state_root: [0u8; 32],
-            proof_validator_keys: Vec::new(),
+            proof_validator_keys: Arc::new(Vec::new()),
 
             proof_el_block_number: 0,
             captured_bytes: None,
@@ -904,9 +905,9 @@ mod tests {
             pending_active_validator_exits: 0,
             epocher: DynamicEpocher::new(NonZeroU64::new(10).unwrap()),
             ssz_tree: SszStateTree::default(),
-            proof_tree: SszStateTree::default(),
+            proof_tree: Arc::new(SszStateTree::default()),
             state_root: [0u8; 32],
-            proof_validator_keys: Vec::new(),
+            proof_validator_keys: Arc::new(Vec::new()),
 
             proof_el_block_number: 0,
             captured_bytes: None,
@@ -965,9 +966,9 @@ mod tests {
             pending_active_validator_exits: 0,
             epocher: DynamicEpocher::new(NonZeroU64::new(10).unwrap()),
             ssz_tree: SszStateTree::default(),
-            proof_tree: SszStateTree::default(),
+            proof_tree: Arc::new(SszStateTree::default()),
             state_root: [0u8; 32],
-            proof_validator_keys: Vec::new(),
+            proof_validator_keys: Arc::new(Vec::new()),
 
             proof_el_block_number: 0,
             captured_bytes: None,
@@ -1031,9 +1032,9 @@ mod tests {
             pending_active_validator_exits: 0,
             epocher: DynamicEpocher::new(NonZeroU64::new(10).unwrap()),
             ssz_tree: SszStateTree::default(),
-            proof_tree: SszStateTree::default(),
+            proof_tree: Arc::new(SszStateTree::default()),
             state_root: [0u8; 32],
-            proof_validator_keys: Vec::new(),
+            proof_validator_keys: Arc::new(Vec::new()),
 
             proof_el_block_number: 0,
             captured_bytes: None,
@@ -1093,9 +1094,9 @@ mod tests {
             pending_active_validator_exits: 0,
             epocher: DynamicEpocher::new(NonZeroU64::new(10).unwrap()),
             ssz_tree: SszStateTree::default(),
-            proof_tree: SszStateTree::default(),
+            proof_tree: Arc::new(SszStateTree::default()),
             state_root: [0u8; 32],
-            proof_validator_keys: Vec::new(),
+            proof_validator_keys: Arc::new(Vec::new()),
 
             proof_el_block_number: 0,
             captured_bytes: None,
@@ -1252,9 +1253,9 @@ mod tests {
             pending_active_validator_exits: 0,
             epocher: DynamicEpocher::new(NonZeroU64::new(10).unwrap()),
             ssz_tree: SszStateTree::default(),
-            proof_tree: SszStateTree::default(),
+            proof_tree: Arc::new(SszStateTree::default()),
             state_root: [0u8; 32],
-            proof_validator_keys: Vec::new(),
+            proof_validator_keys: Arc::new(Vec::new()),
 
             proof_el_block_number: 0,
             captured_bytes: None,

--- a/types/src/consensus_state.rs
+++ b/types/src/consensus_state.rs
@@ -1404,7 +1404,8 @@ impl Read for ConsensusState {
             let inner = ConsensusState::decode(bytes.as_slice())?;
             state.proof_tree = inner.proof_tree.clone();
             state.state_root = state.proof_tree.root();
-            state.proof_validator_keys = inner.validator_accounts.keys().copied().collect();
+            state.proof_validator_keys =
+                Arc::new(inner.validator_accounts.keys().copied().collect());
         }
 
         Ok(state)

--- a/types/src/consensus_state.rs
+++ b/types/src/consensus_state.rs
@@ -18,6 +18,7 @@ use commonware_cryptography::{bls12381, sha256};
 use metrics::histogram;
 use std::collections::{BTreeMap, VecDeque};
 use std::num::NonZeroU64;
+use std::sync::Arc;
 
 const INVALID_STAKE_INTERVAL: &str =
     "validator_minimum_stake must be less than or equal to validator_maximum_stake";
@@ -66,11 +67,11 @@ pub struct ConsensusState {
     /// Frozen snapshot of `ssz_tree` at `capture_state_root()` time.
     /// Proofs are generated from this tree so they verify against the on-chain root.
     /// Not serialized — rebuilt alongside `ssz_tree`.
-    pub(crate) proof_tree: SszStateTree,
+    pub(crate) proof_tree: Arc<SszStateTree>,
 
     /// Frozen snapshot of validator pubkeys (sorted) at `capture_state_root()` time.
     /// Needed for positional index lookups when generating validator proofs.
-    pub(crate) proof_validator_keys: Vec<[u8; 32]>,
+    pub(crate) proof_validator_keys: Arc<Vec<[u8; 32]>>,
 
     // Withdrawal proof lookup is handled by the pubkey index stored in SszStateTree itself.
     // The frozen proof_tree contains the withdrawal_pubkey_index from capture time.
@@ -129,8 +130,8 @@ impl Default for ConsensusState {
             pending_active_validator_exits: 0,
             epocher: DynamicEpocher::new(NonZeroU64::new(1).unwrap()),
             ssz_tree: SszStateTree::default(),
-            proof_tree: SszStateTree::default(),
-            proof_validator_keys: Vec::new(),
+            proof_tree: Arc::new(SszStateTree::default()),
+            proof_validator_keys: Arc::new(Vec::new()),
             captured_bytes: None,
 
             state_root: [0u8; 32],
@@ -230,8 +231,8 @@ impl ConsensusState {
             pending_active_validator_exits: 0,
             epocher: DynamicEpocher::new(epoch_length),
             ssz_tree: SszStateTree::default(),
-            proof_tree: SszStateTree::default(),
-            proof_validator_keys: Vec::new(),
+            proof_tree: Arc::new(SszStateTree::default()),
+            proof_validator_keys: Arc::new(Vec::new()),
             captured_bytes: None,
 
             state_root: [0u8; 32],
@@ -682,8 +683,8 @@ impl ConsensusState {
             .set_dynamic_epoch_schedule(&self.epocher.encode());
 
         self.state_root = self.ssz_tree.root();
-        self.proof_tree = self.ssz_tree.clone();
-        self.proof_validator_keys = self.validator_accounts.keys().copied().collect();
+        self.proof_tree = Arc::new(self.ssz_tree.clone());
+        self.proof_validator_keys = Arc::new(self.validator_accounts.keys().copied().collect());
         self.proof_el_block_number = el_block_number;
 
         // Snapshot the entire state so a restart can rebuild `proof_tree`
@@ -702,13 +703,23 @@ impl ConsensusState {
     /// Returns the frozen tree snapshot for proof generation.
     /// Proofs from this tree verify against the on-chain `parent_beacon_block_root`.
     pub fn proof_tree(&self) -> &SszStateTree {
-        &self.proof_tree
+        self.proof_tree.as_ref()
+    }
+
+    /// Returns a shareable frozen proof tree snapshot.
+    pub fn proof_tree_snapshot(&self) -> Arc<SszStateTree> {
+        Arc::clone(&self.proof_tree)
     }
 
     /// Returns the frozen validator pubkeys (sorted) for proof generation.
     /// Needed for positional index lookups when generating validator proofs.
     pub fn proof_validator_keys(&self) -> &[[u8; 32]] {
-        &self.proof_validator_keys
+        self.proof_validator_keys.as_slice()
+    }
+
+    /// Returns a shareable frozen validator-key snapshot for proof generation.
+    pub fn proof_validator_keys_snapshot(&self) -> Arc<Vec<[u8; 32]>> {
+        Arc::clone(&self.proof_validator_keys)
     }
 
     /// Returns the EL block number at the time the proof tree was captured.
@@ -1078,8 +1089,8 @@ impl ConsensusState {
         // these from the capture time snapshot afterwards, so this is only the
         // baseline for construction, bulk reset, and capture less restarts.
         self.state_root = self.ssz_tree.root();
-        self.proof_tree = self.ssz_tree.clone();
-        self.proof_validator_keys = self.validator_accounts.keys().copied().collect();
+        self.proof_tree = Arc::new(self.ssz_tree.clone());
+        self.proof_validator_keys = Arc::new(self.validator_accounts.keys().copied().collect());
 
         #[cfg(feature = "prom")]
         histogram!("ssz_rebuild_tree_micros").record(start.elapsed().as_micros() as f64);
@@ -1372,8 +1383,8 @@ impl Read for ConsensusState {
             pending_active_validator_exits,
             epocher,
             ssz_tree: SszStateTree::default(),
-            proof_tree: SszStateTree::default(),
-            proof_validator_keys: Vec::new(),
+            proof_tree: Arc::new(SszStateTree::default()),
+            proof_validator_keys: Arc::new(Vec::new()),
             captured_bytes: captured_bytes.clone(),
 
             state_root: [0u8; 32],

--- a/types/src/consensus_state_query.rs
+++ b/types/src/consensus_state_query.rs
@@ -416,9 +416,6 @@ impl<S: Scheme> ConsensusStateQuery<S> {
     /// `permit` is an opaque concurrency guard (boxed by the RPC layer) that
     /// travels with the request so the finalizer can drop it when the spawned
     /// proof task finishes, instead of when this future is dropped.
-    /// Permit is an opaque concurrency guard (boxed by the rpc layer) that
-    /// travels with the request so the finalizer can drop it when the spawned
-    /// proof task finishes, instead of when this future is dropped.
     pub async fn generate_state_proof(
         &self,
         keys: Vec<SszStateKey>,

--- a/types/src/consensus_state_query.rs
+++ b/types/src/consensus_state_query.rs
@@ -33,7 +33,14 @@ pub enum ConsensusStateRequest {
     GetDepositCount,
     GetWithdrawal([u8; 32]),
     GetStateRoot,
-    GenerateStateProof(Vec<SszStateKey>),
+    /// Generate positional proofs for the requested keys against the frozen
+    /// proof snapshot. The second field is an opaque concurrency permit owned
+    /// by the caller (the rpc layer's in-flight-proof slot guard, boxed so this
+    /// crate stays free of any rpc dependency). The finalizer moves it into the
+    /// spawned, detached proof task and drops it only once proof generation
+    /// finishes, so the permit's lifetime tracks real work rather than the
+    /// caller's rpc future. None for internal callers that do not rate-limit.
+    GenerateStateProof(Vec<SszStateKey>, Option<Box<dyn Send + 'static>>),
 }
 
 pub enum ConsensusStateResponse<S: Scheme> {
@@ -406,12 +413,19 @@ impl<S: Scheme> ConsensusStateQuery<S> {
         (root, el_block_number)
     }
 
+    /// `permit` is an opaque concurrency guard (boxed by the RPC layer) that
+    /// travels with the request so the finalizer can drop it when the spawned
+    /// proof task finishes, instead of when this future is dropped.
+    /// Permit is an opaque concurrency guard (boxed by the rpc layer) that
+    /// travels with the request so the finalizer can drop it when the spawned
+    /// proof task finishes, instead of when this future is dropped.
     pub async fn generate_state_proof(
         &self,
         keys: Vec<SszStateKey>,
+        permit: Box<dyn Send + 'static>,
     ) -> ([u8; 32], u64, Vec<Option<SszProof>>) {
         let (tx, rx) = oneshot::channel();
-        let req = ConsensusStateRequest::GenerateStateProof(keys);
+        let req = ConsensusStateRequest::GenerateStateProof(keys, Some(permit));
         let _ = self.sender.clone().send((req, tx)).await;
 
         let res = rx

--- a/types/src/consensus_state_query.rs
+++ b/types/src/consensus_state_query.rs
@@ -176,6 +176,20 @@ impl<S: Scheme> ConsensusStateQuery<S> {
         balance
     }
 
+    pub async fn get_validator_account(&self, public_key: PublicKey) -> Option<ValidatorAccount> {
+        let (tx, rx) = oneshot::channel();
+        let req = ConsensusStateRequest::GetValidatorAccount(public_key);
+        let _ = self.sender.clone().send((req, tx)).await;
+
+        let res = rx
+            .await
+            .expect("consensus state query response sender dropped");
+        let ConsensusStateResponse::ValidatorAccount(account) = res else {
+            unreachable!("request and response variants must match");
+        };
+        account
+    }
+
     pub async fn get_finalized_header(&self, epoch: u64) -> Option<FinalizedHeader<S>> {
         let (tx, rx) = oneshot::channel();
         let req = ConsensusStateRequest::GetFinalizedHeader(epoch);
@@ -330,5 +344,87 @@ impl<S: Scheme> ConsensusStateQuery<S> {
             unreachable!("request and response variants must match");
         };
         bounds
+    }
+
+    pub async fn get_deposit(&self, index: usize) -> Option<DepositRequest> {
+        let (tx, rx) = oneshot::channel();
+        let req = ConsensusStateRequest::GetDeposit(index);
+        let _ = self.sender.clone().send((req, tx)).await;
+
+        let res = rx
+            .await
+            .expect("consensus state query response sender dropped");
+        let ConsensusStateResponse::Deposit(deposit) = res else {
+            unreachable!("request and response variants must match");
+        };
+        deposit
+    }
+
+    pub async fn get_deposit_count(&self) -> usize {
+        let (tx, rx) = oneshot::channel();
+        let req = ConsensusStateRequest::GetDepositCount;
+        let _ = self.sender.clone().send((req, tx)).await;
+
+        let res = rx
+            .await
+            .expect("consensus state query response sender dropped");
+        let ConsensusStateResponse::DepositCount(count) = res else {
+            unreachable!("request and response variants must match");
+        };
+        count
+    }
+
+    pub async fn get_withdrawal(&self, pubkey: [u8; 32]) -> Option<PendingWithdrawal> {
+        let (tx, rx) = oneshot::channel();
+        let req = ConsensusStateRequest::GetWithdrawal(pubkey);
+        let _ = self.sender.clone().send((req, tx)).await;
+
+        let res = rx
+            .await
+            .expect("consensus state query response sender dropped");
+        let ConsensusStateResponse::Withdrawal(withdrawal) = res else {
+            unreachable!("request and response variants must match");
+        };
+        withdrawal
+    }
+
+    pub async fn get_state_root(&self) -> ([u8; 32], u64) {
+        let (tx, rx) = oneshot::channel();
+        let req = ConsensusStateRequest::GetStateRoot;
+        let _ = self.sender.clone().send((req, tx)).await;
+
+        let res = rx
+            .await
+            .expect("consensus state query response sender dropped");
+        let ConsensusStateResponse::StateRoot {
+            root,
+            el_block_number,
+        } = res
+        else {
+            unreachable!("request and response variants must match");
+        };
+        (root, el_block_number)
+    }
+
+    pub async fn generate_state_proof(
+        &self,
+        keys: Vec<SszStateKey>,
+    ) -> ([u8; 32], u64, Vec<Option<SszProof>>) {
+        let (tx, rx) = oneshot::channel();
+        let req = ConsensusStateRequest::GenerateStateProof(keys);
+        let _ = self.sender.clone().send((req, tx)).await;
+
+        let res = rx
+            .await
+            .expect("consensus state query response sender dropped");
+        let ConsensusStateResponse::StateProof {
+            root,
+            el_block_number,
+            proofs,
+        } = res
+        else {
+            unreachable!("request and response variants must match");
+        };
+        (root, el_block_number, proofs)
     }
 }


### PR DESCRIPTION
Addresses: https://github.com/SeismicSystems/summit/issues/225

  Changes:
  - Add a dedicated finalizer state-query mailbox for RPC state queries.
  - Prioritize the main finalizer mailbox with `select_biased!`, leaving query work last.
  - Move `GenerateStateProof` proof generation off the finalizer actor loop by snapshotting frozen proof data and spawning proof work on a blocking/shared task.
  - Store frozen proof tree and validator keys behind `Arc` so proof requests clone cheap handles.
  - Add `getStateProof` request limits: max 128 keys, max computed cost 512, with RPC errors 3005/3006.
  - Update RPC wiring and tests to use the query mailbox.
  - Add tests for oversized proof key batches and excessive proof cost.
  - Update finalizer tests for the new constructor return value.