### PR TITLE
fix: persist cleaned epoch transition state before ack

### DIFF
--- a/finalizer/src/actor.rs
+++ b/finalizer/src/actor.rs
@@ -916,15 +916,9 @@ impl<
         }
 
         let new_height = block.height();
+        let current_epoch = self.canonical_state.get_epoch();
         self.height_notify_finalized_up_to(new_height, block_digest);
-        ack_tx.acknowledge();
-        info!(
-            new_height,
-            epoch = self.canonical_state.get_epoch(),
-            "executed block"
-        );
 
-        let new_height = block.height();
         let mut epoch_change = false; // Store finalizes checkpoint to database
         if is_last_block_of_epoch(self.canonical_state.get_epocher(), new_height) {
             // The syncer will always send the last block of an epoch together with
@@ -1040,6 +1034,13 @@ impl<
                 .set_epoch_genesis_hash(block.digest().0);
             self.canonical_state.reset_pending_active_validator_exits();
 
+            // Clear transition deltas before persisting the next-epoch consensus state.
+            self.canonical_state
+                .remove_added_validators_for_epoch(next_epoch);
+            if self.canonical_state.has_removed_validators() {
+                self.canonical_state.clear_removed_validators();
+            }
+
             let active_count = self.canonical_state.get_active_validators().len();
             let joining_count = self
                 .canonical_state
@@ -1078,14 +1079,6 @@ impl<
                 let db_operations_duration = db_operations_start.elapsed().as_millis() as f64;
                 histogram!("database_operations_duration_millis").record(db_operations_duration);
                 counter!("finalizer_epochs_completed_total").increment(1);
-            }
-
-            // Clear the added and removed validators
-            let current_epoch = self.canonical_state.get_epoch();
-            self.canonical_state
-                .remove_added_validators_for_epoch(current_epoch);
-            if self.canonical_state.has_removed_validators() {
-                self.canonical_state.clear_removed_validators();
             }
 
             // Create the peer sets for the next epoch's P2P network.
@@ -1148,6 +1141,9 @@ impl<
                 .await;
             epoch_change = true;
         }
+
+        ack_tx.acknowledge();
+        info!(new_height, epoch = current_epoch, "executed block");
 
         if epoch_change {
             // Shut down the Simplex engine for the old epoch

--- a/finalizer/src/actor.rs
+++ b/finalizer/src/actor.rs
@@ -1081,6 +1081,8 @@ impl<
                 counter!("finalizer_epochs_completed_total").increment(1);
             }
 
+            ack_tx.acknowledge();
+
             // Create the peer sets for the next epoch's P2P network.
             //
             // Only active validators go into the PRIMARY set: the backfill
@@ -1140,9 +1142,13 @@ impl<
                 }))
                 .await;
             epoch_change = true;
+        } else {
+            // Every block needs to be ack'ed.
+            // On the last block of an epoch we send the ack before updating the oracle and
+            // reporting to the orchestrator, because those calls might be blocking.
+            ack_tx.acknowledge();
         }
 
-        ack_tx.acknowledge();
         info!(new_height, epoch = current_epoch, "executed block");
 
         if epoch_change {

--- a/finalizer/src/tests/mocks.rs
+++ b/finalizer/src/tests/mocks.rs
@@ -15,10 +15,10 @@ use commonware_math::algebra::Random;
 use commonware_parallel::Sequential;
 use commonware_utils::ordered::{BiMap, Map};
 use std::collections::VecDeque;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use summit_types::network_oracle::NetworkOracle;
-use summit_types::{Block, Digest, EngineClient, PublicKey};
+use summit_types::{Block, Digest, EngineClient, EngineClientError, PublicKey};
 
 pub type MultisigScheme = bls12381_multisig::Scheme<ed25519::PublicKey, MinPk>;
 
@@ -88,6 +88,7 @@ pub struct MockEngineClient {
     check_payload_overrides: Arc<Mutex<VecDeque<PayloadStatus>>>,
     commit_hash_overrides: Arc<Mutex<VecDeque<ForkchoiceUpdated>>>,
     check_payload_calls: Arc<AtomicU64>,
+    commit_hash_fails: Arc<AtomicBool>,
 }
 
 impl MockEngineClient {
@@ -96,7 +97,16 @@ impl MockEngineClient {
             check_payload_overrides: Arc::new(Mutex::new(VecDeque::new())),
             commit_hash_overrides: Arc::new(Mutex::new(VecDeque::new())),
             check_payload_calls: Arc::new(AtomicU64::new(0)),
+            commit_hash_fails: Arc::new(AtomicBool::new(false)),
         }
+    }
+
+    /// Make every subsequent `commit_hash` call return a non-retryable error,
+    /// simulating a failed forkchoice commit. Used to drive the finalizer's
+    /// fatal-shutdown path at an epoch boundary.
+    #[allow(unused)]
+    pub fn fail_commit_hash(&self) {
+        self.commit_hash_fails.store(true, Ordering::SeqCst);
     }
 
     /// Number of times `check_payload` has been invoked. Used to detect whether a
@@ -205,6 +215,9 @@ impl EngineClient for MockEngineClient {
         &mut self,
         _fork_choice_state: ForkchoiceState,
     ) -> Result<ForkchoiceUpdated, summit_types::EngineClientError> {
+        if self.commit_hash_fails.load(Ordering::SeqCst) {
+            return Err(EngineClientError::custom("injected commit_hash failure"));
+        }
         if let Some(override_response) = self.commit_hash_overrides.lock().unwrap().pop_front() {
             return Ok(override_response);
         }

--- a/finalizer/src/tests/validator_lifecycle.rs
+++ b/finalizer/src/tests/validator_lifecycle.rs
@@ -756,6 +756,157 @@ fn epoch_transition_deltas_are_cleared_before_persisted_state_ack() {
     });
 }
 
+/// A commit failure on the last block of an epoch must NOT ack the syncer and
+/// must NOT durably advance the epoch.
+///
+/// The finalizer acks the syncer only after the epoch-boundary consensus state
+/// is persisted (#270/#325). If the EL forkchoice commit fails on the boundary
+/// block, the finalizer returns an error before persisting or acking: the
+/// syncer's `Exact` waiter must resolve `Err` (withheld ack, so the block is
+/// re-delivered later) and the node must trigger a graceful shutdown. A restart
+/// from the same DB must still load the pre-boundary epoch, proving the
+/// transition was not half-committed.
+#[test]
+fn epoch_boundary_commit_failure_withholds_ack_and_shuts_down() {
+    let cfg = deterministic::Config::default().with_seed(59);
+    let executor = Runner::from(cfg);
+    executor.start(|context| async move {
+        let genesis_hash = [0x59u8; 32];
+        let db_prefix = "test_epoch_commit_failure_withholds_ack".to_string();
+        let local_node_key = ed25519::PrivateKey::from_seed(1);
+
+        let initial_state = create_test_initial_state(genesis_hash, NonZeroU64::new(5).unwrap());
+
+        let page_cache = CacheRef::from_pooler(
+            &context,
+            std::num::NonZero::new(4096).unwrap(),
+            NZUsize!(100),
+        );
+        let (orchestrator_tx, _orchestrator_rx) = futures_mpsc::channel(100);
+        let orchestrator_mailbox = summit_orchestrator::Mailbox::new(orchestrator_tx);
+        let cancellation_token = CancellationToken::new();
+
+        // Shared engine client so the test can flip commit_hash to failing only
+        // after the non-boundary blocks have been acked. The clone handed to the
+        // finalizer shares the failure flag.
+        let engine_client = MockEngineClient::new();
+
+        let finalizer_cfg = FinalizerConfig::<MockEngineClient, MockNetworkOracle, MinPk> {
+            mailbox_size: 100,
+            db_prefix: db_prefix.clone(),
+            engine_client: engine_client.clone(),
+            oracle: MockNetworkOracle,
+            protocol_consts: ProtocolConsts {
+                validator_num_warm_up_epochs: 2,
+                validator_withdrawal_num_epochs: 2,
+            },
+            page_cache: page_cache.clone(),
+            genesis_hash,
+            initial_state: initial_state.clone(),
+            protocol_version: 1,
+            node_public_key: local_node_key.public_key(),
+            cancellation_token: cancellation_token.clone(),
+            drain_interval: Duration::from_millis(100),
+            buffered_blocks_warn_threshold: 100,
+            pending_notarized_max: 1000,
+            namespace: Vec::new(),
+            _variant_marker: PhantomData,
+        };
+
+        let (finalizer, _state, mut mailbox) =
+            Finalizer::<_, MockEngineClient, MockNetworkOracle, ed25519::PrivateKey, MinPk>::new(
+                context.with_label("finalizer"),
+                finalizer_cfg,
+            )
+            .await;
+        let handle = finalizer.start(orchestrator_mailbox);
+        context.sleep(Duration::from_millis(50)).await;
+
+        let genesis_block = Block::genesis(genesis_hash);
+        let mut parent_digest = genesis_block.digest();
+
+        // Non-boundary blocks 1..=3 commit cleanly and must be acked.
+        for height in 1..4 {
+            let block =
+                create_test_block_with_epoch(parent_digest, height, height + 1, 59000 + height, 0);
+            parent_digest = block.digest();
+            let (ack, ack_waiter) = Exact::handle();
+            mailbox
+                .report(Update::FinalizedBlock((block, None), ack))
+                .await;
+            ack_waiter.await.expect("non-boundary block must be acked");
+        }
+
+        // Fail the forkchoice commit for the epoch-boundary block.
+        engine_client.fail_commit_hash();
+
+        let schemes = create_test_schemes(4);
+        let quorum = 3;
+        let boundary = create_test_block_with_epoch(parent_digest, 4, 5, 59004, 0);
+        let boundary_digest = boundary.digest();
+        let finalization = make_finalization(boundary_digest, 4, 3, &schemes, quorum);
+        let (ack, ack_waiter) = Exact::handle();
+        mailbox
+            .report(Update::FinalizedBlock((boundary, Some(finalization)), ack))
+            .await;
+
+        // Ack must be WITHHELD: the finalizer errors on the failed commit before
+        // acknowledging, so the Exact waiter resolves Err (sender dropped).
+        assert!(
+            ack_waiter.await.is_err(),
+            "epoch-boundary ack must be withheld when the commit fails"
+        );
+
+        // The finalizer must trigger a graceful shutdown.
+        context.sleep(Duration::from_millis(50)).await;
+        assert!(
+            cancellation_token.is_cancelled(),
+            "finalizer must shut down after a fatal commit failure"
+        );
+
+        drop(mailbox);
+        handle.abort();
+        context.sleep(Duration::from_millis(50)).await;
+
+        // Restart from the same DB: the epoch must NOT have durably advanced.
+        let (restarted, reloaded_state, _mailbox) =
+            Finalizer::<_, MockEngineClient, MockNetworkOracle, ed25519::PrivateKey, MinPk>::new(
+                context.with_label("finalizer_restart"),
+                FinalizerConfig {
+                    mailbox_size: 100,
+                    db_prefix,
+                    engine_client: MockEngineClient::new(),
+                    oracle: MockNetworkOracle,
+                    protocol_consts: ProtocolConsts {
+                        validator_num_warm_up_epochs: 2,
+                        validator_withdrawal_num_epochs: 2,
+                    },
+                    page_cache,
+                    genesis_hash,
+                    initial_state,
+                    protocol_version: 1,
+                    node_public_key: local_node_key.public_key(),
+                    cancellation_token: CancellationToken::new(),
+                    drain_interval: Duration::from_millis(100),
+                    buffered_blocks_warn_threshold: 100,
+                    pending_notarized_max: 1000,
+                    namespace: Vec::new(),
+                    _variant_marker: PhantomData,
+                },
+            )
+            .await;
+        drop(restarted);
+
+        assert_eq!(
+            reloaded_state.get_epoch(),
+            0,
+            "epoch must not durably advance when the boundary commit fails before the ack"
+        );
+
+        context.auditor().state()
+    });
+}
+
 /// An active validator's full exit on the last block of an epoch must
 /// dominate a concurrent `MaximumStake` reduction at the same boundary:
 /// the buffered exit replays on the first block of the next epoch and the

--- a/finalizer/src/tests/validator_lifecycle.rs
+++ b/finalizer/src/tests/validator_lifecycle.rs
@@ -561,6 +561,201 @@ fn test_joining_validator_peer_tier_follows_activation() {
     });
 }
 
+#[test]
+fn epoch_transition_deltas_are_cleared_before_persisted_state_ack() {
+    let cfg = deterministic::Config::default().with_seed(58);
+    let executor = Runner::from(cfg);
+    executor.start(|context| async move {
+        use rand::SeedableRng;
+
+        let genesis_hash = [0x58u8; 32];
+        let db_prefix = "test_epoch_transition_deltas_cleared_before_ack".to_string();
+        let local_node_key = ed25519::PrivateKey::from_seed(1);
+        let removed_node_key = ed25519::PrivateKey::from_seed(0);
+        let removed_node_pubkey = removed_node_key.public_key();
+        let removed_pubkey_bytes: [u8; 32] = removed_node_pubkey.as_ref().try_into().unwrap();
+        let joining_node_key = ed25519::PrivateKey::from_seed(10);
+        let joining_node_pubkey = joining_node_key.public_key();
+        let joining_pubkey_bytes: [u8; 32] = joining_node_pubkey.as_ref().try_into().unwrap();
+
+        let mut rng = rand::rngs::StdRng::seed_from_u64(58);
+        let joining_consensus_key = bls12381::PrivateKey::random(&mut rng);
+        let joining_consensus_pubkey = joining_consensus_key.public_key();
+
+        let mut initial_state =
+            create_test_initial_state(genesis_hash, NonZeroU64::new(5).unwrap());
+        initial_state.push_removed_validator(removed_node_pubkey.clone());
+        initial_state.set_account(
+            joining_pubkey_bytes,
+            ValidatorAccount {
+                consensus_public_key: joining_consensus_pubkey.clone(),
+                withdrawal_credentials: Address::from([10u8; 20]),
+                balance: 32_000_000_000,
+                status: ValidatorStatus::Joining,
+                has_pending_deposit: false,
+                has_pending_withdrawal: false,
+                joining_epoch: 1,
+                last_deposit_index: 0,
+            },
+        );
+        initial_state.add_validator(
+            1,
+            AddedValidator {
+                node_key: joining_node_pubkey.clone(),
+                consensus_key: joining_consensus_pubkey,
+            },
+        );
+
+        let page_cache = CacheRef::from_pooler(
+            &context,
+            std::num::NonZero::new(4096).unwrap(),
+            NZUsize!(100),
+        );
+        let (orchestrator_tx, _orchestrator_rx) = futures_mpsc::channel(100);
+        let orchestrator_mailbox = summit_orchestrator::Mailbox::new(orchestrator_tx);
+        let cancellation_token = CancellationToken::new();
+
+        let finalizer_cfg = FinalizerConfig::<MockEngineClient, MockNetworkOracle, MinPk> {
+            mailbox_size: 100,
+            db_prefix: db_prefix.clone(),
+            engine_client: MockEngineClient::new(),
+            oracle: MockNetworkOracle,
+            protocol_consts: ProtocolConsts {
+                validator_num_warm_up_epochs: 2,
+                validator_withdrawal_num_epochs: 2,
+            },
+            page_cache: page_cache.clone(),
+            genesis_hash,
+            initial_state: initial_state.clone(),
+            protocol_version: 1,
+            node_public_key: local_node_key.public_key(),
+            cancellation_token,
+            drain_interval: Duration::from_millis(100),
+            buffered_blocks_warn_threshold: 100,
+            pending_notarized_max: 1000,
+            namespace: Vec::new(),
+            _variant_marker: PhantomData,
+        };
+
+        let (finalizer, _state, mut mailbox) =
+            Finalizer::<_, MockEngineClient, MockNetworkOracle, ed25519::PrivateKey, MinPk>::new(
+                context.with_label("finalizer"),
+                finalizer_cfg,
+            )
+            .await;
+        let handle = finalizer.start(orchestrator_mailbox);
+        context.sleep(Duration::from_millis(50)).await;
+
+        let genesis_block = Block::genesis(genesis_hash);
+        let mut parent_digest = genesis_block.digest();
+
+        for height in 1..4 {
+            let block =
+                create_test_block_with_epoch(parent_digest, height, height + 1, 58000 + height, 0);
+            parent_digest = block.digest();
+            let (ack, ack_waiter) = Exact::handle();
+            mailbox
+                .report(Update::FinalizedBlock((block, None), ack))
+                .await;
+            ack_waiter.await.expect("non-boundary block must be acked");
+        }
+
+        let schemes = create_test_schemes(4);
+        let quorum = 3;
+        let boundary = create_test_block_with_epoch(parent_digest, 4, 5, 58004, 0);
+        let boundary_digest = boundary.digest();
+        let finalization = make_finalization(boundary_digest, 4, 3, &schemes, quorum);
+        let (ack, ack_waiter) = Exact::handle();
+        mailbox
+            .report(Update::FinalizedBlock((boundary, Some(finalization)), ack))
+            .await;
+        ack_waiter.await.expect("epoch boundary block must be acked");
+
+        drop(mailbox);
+        handle.abort();
+        context.sleep(Duration::from_millis(50)).await;
+
+        let (restarted, reloaded_state, _mailbox) =
+            Finalizer::<_, MockEngineClient, MockNetworkOracle, ed25519::PrivateKey, MinPk>::new(
+                context.with_label("finalizer_restart"),
+                FinalizerConfig {
+                    mailbox_size: 100,
+                    db_prefix,
+                    engine_client: MockEngineClient::new(),
+                    oracle: MockNetworkOracle,
+                    protocol_consts: ProtocolConsts {
+                        validator_num_warm_up_epochs: 2,
+                        validator_withdrawal_num_epochs: 2,
+                    },
+                    page_cache,
+                    genesis_hash,
+                    initial_state,
+                    protocol_version: 1,
+                    node_public_key: local_node_key.public_key(),
+                    cancellation_token: CancellationToken::new(),
+                    drain_interval: Duration::from_millis(100),
+                    buffered_blocks_warn_threshold: 100,
+                    pending_notarized_max: 1000,
+                    namespace: Vec::new(),
+                    _variant_marker: PhantomData,
+                },
+            )
+            .await;
+        drop(restarted);
+
+        assert_eq!(
+            reloaded_state.get_epoch(),
+            1,
+            "restarted finalizer must load the persisted next-epoch state"
+        );
+        assert!(
+            reloaded_state.get_removed_validators().is_empty(),
+            "removed_validators must not persist after the epoch transition is acked"
+        );
+        assert!(
+            reloaded_state.get_added_validators(1).is_none(),
+            "added_validators for the activated epoch must not persist after the transition is acked"
+        );
+        assert_eq!(
+            reloaded_state
+                .get_account(&removed_pubkey_bytes)
+                .expect("removed validator account must exist")
+                .status,
+            ValidatorStatus::Inactive,
+            "removed validator status must be materialized before clearing transition deltas"
+        );
+        assert_eq!(
+            reloaded_state
+                .get_account(&joining_pubkey_bytes)
+                .expect("joining validator account must exist")
+                .status,
+            ValidatorStatus::Active,
+            "joining validator status must be materialized before clearing transition deltas"
+        );
+
+        let active_validators = reloaded_state.get_active_validators();
+        assert_eq!(
+            active_validators.len(),
+            4,
+            "active validator set should replace the removed validator with the joining validator"
+        );
+        assert!(
+            active_validators
+                .iter()
+                .any(|(node_key, _)| node_key == &joining_node_pubkey),
+            "joining validator must be present in the active validator set after restart"
+        );
+        assert!(
+            !active_validators
+                .iter()
+                .any(|(node_key, _)| node_key == &removed_node_pubkey),
+            "removed validator must not be present in the active validator set after restart"
+        );
+
+        context.auditor().state()
+    });
+}
+
 /// An active validator's full exit on the last block of an epoch must
 /// dominate a concurrent `MaximumStake` reduction at the same boundary:
 /// the buffered exit replays on the first block of the next epoch and the

--- a/node/src/tests/execution_requests/deposit_withdrawal_combined.rs
+++ b/node/src/tests/execution_requests/deposit_withdrawal_combined.rs
@@ -95,14 +95,17 @@ fn test_deposit_and_withdrawal_request_single() {
         // the account doesn't exist yet.
         let deposit_block_height = 5;
         let withdrawal_block_height = 11;
-        let stop_height = withdrawal_block_height + DEFAULT_BLOCKS_PER_EPOCH + 1;
+        let withdrawal_epoch =
+            (withdrawal_block_height / DEFAULT_BLOCKS_PER_EPOCH) + VALIDATOR_WITHDRAWAL_NUM_EPOCHS;
+        let withdrawal_height = (withdrawal_epoch + 1) * DEFAULT_BLOCKS_PER_EPOCH - 1;
+        let stop_height = withdrawal_height + 2;
         let mut execution_requests_map = HashMap::new();
         execution_requests_map.insert(deposit_block_height, requests1);
         execution_requests_map.insert(withdrawal_block_height, requests2);
 
         let engine_client_network = MockEngineNetworkBuilder::new(genesis_hash)
             .with_execution_requests(execution_requests_map)
-            .with_stop_at(41) // stop at block 41 because of the epoch+1 hold period on withdrawls
+            .with_stop_at(stop_height) // stop after the epoch+1 hold period on withdrawals
             .build();
         let initial_state = get_initial_state(genesis_hash, &validators, None, None, min_stake);
 
@@ -201,9 +204,6 @@ fn test_deposit_and_withdrawal_request_single() {
 
         let withdrawals = engine_client_network.get_withdrawals();
         assert_eq!(withdrawals.len(), 1);
-        let withdrawal_epoch =
-            (withdrawal_block_height / DEFAULT_BLOCKS_PER_EPOCH) + VALIDATOR_WITHDRAWAL_NUM_EPOCHS;
-        let withdrawal_height = (withdrawal_epoch + 1) * DEFAULT_BLOCKS_PER_EPOCH - 1;
         let withdrawals = withdrawals
             .get(&(withdrawal_height))
             .expect("missing withdrawal");

--- a/node/src/tests/execution_requests/withdrawals.rs
+++ b/node/src/tests/execution_requests/withdrawals.rs
@@ -108,7 +108,7 @@ fn test_grouped_withdrawal_requests_in_single_eip7685_entry() {
         let withdrawal_epoch =
             (withdrawal_block_height / DEFAULT_BLOCKS_PER_EPOCH) + VALIDATOR_WITHDRAWAL_NUM_EPOCHS;
         let withdrawal_height = (withdrawal_epoch + 1) * DEFAULT_BLOCKS_PER_EPOCH - 1;
-        let stop_height = withdrawal_height + 1;
+        let stop_height = withdrawal_height + 2;
 
         let mut execution_requests_map = HashMap::new();
         execution_requests_map.insert(deposit_block_height, requests_deposit_1);
@@ -117,7 +117,7 @@ fn test_grouped_withdrawal_requests_in_single_eip7685_entry() {
 
         let engine_client_network = MockEngineNetworkBuilder::new(genesis_hash)
             .with_execution_requests(execution_requests_map)
-            .with_stop_at(41)
+            .with_stop_at(stop_height)
             .build();
         let initial_state = get_initial_state(genesis_hash, &validators, None, None, min_stake);
 
@@ -190,9 +190,6 @@ fn test_grouped_withdrawal_requests_in_single_eip7685_entry() {
         }
 
         let withdrawals = engine_client_network.get_withdrawals();
-        let withdrawal_epoch =
-            (withdrawal_block_height / DEFAULT_BLOCKS_PER_EPOCH) + VALIDATOR_WITHDRAWAL_NUM_EPOCHS;
-        let withdrawal_height = (withdrawal_epoch + 1) * DEFAULT_BLOCKS_PER_EPOCH - 1;
         let withdrawals = withdrawals
             .get(&withdrawal_height)
             .expect("missing grouped withdrawal entry");
@@ -320,7 +317,10 @@ fn test_partial_withdrawal_balance_below_minimum_stake() {
         // the account doesn't exist yet.
         let deposit_block_height = 5;
         let withdrawal_block_height = 11;
-        let stop_height = withdrawal_block_height + DEFAULT_BLOCKS_PER_EPOCH + 1;
+        let withdrawal_epoch =
+            (withdrawal_block_height / DEFAULT_BLOCKS_PER_EPOCH) + VALIDATOR_WITHDRAWAL_NUM_EPOCHS;
+        let withdrawal_height = (withdrawal_epoch + 1) * DEFAULT_BLOCKS_PER_EPOCH - 1;
+        let stop_height = withdrawal_height + 2;
         let mut execution_requests_map = HashMap::new();
         execution_requests_map.insert(deposit_block_height, requests1);
         execution_requests_map.insert(withdrawal_block_height, requests2);
@@ -328,7 +328,7 @@ fn test_partial_withdrawal_balance_below_minimum_stake() {
 
         let engine_client_network = MockEngineNetworkBuilder::new(genesis_hash)
             .with_execution_requests(execution_requests_map)
-            .with_stop_at(41) // we stop at 41 because of the epoch+1 hold period before executing withdrawls
+            .with_stop_at(stop_height) // stop after the epoch+1 hold period on withdrawals
             .build();
         let initial_state = get_initial_state(genesis_hash, &validators, None, None, min_stake);
 
@@ -430,9 +430,6 @@ fn test_partial_withdrawal_balance_below_minimum_stake() {
         // Make sure that test_withdrawal2 was ignored, only test_withdraw1 should be submitted
         // to the execution layer.
         assert_eq!(withdrawals.len(), 1);
-        let withdrawal_epoch =
-            (withdrawal_block_height / DEFAULT_BLOCKS_PER_EPOCH) + VALIDATOR_WITHDRAWAL_NUM_EPOCHS;
-        let withdrawal_height = (withdrawal_epoch + 1) * DEFAULT_BLOCKS_PER_EPOCH - 1;
         let withdrawals = withdrawals
             .get(&withdrawal_height)
             .expect("missing withdrawal");

--- a/types/src/engine_client.rs
+++ b/types/src/engine_client.rs
@@ -27,7 +27,7 @@ use alloy_rpc_types_engine::{
 use tracing::{error, warn};
 
 use crate::Block;
-use alloy_transport::TransportError;
+use alloy_transport::{TransportError, TransportErrorKind};
 use alloy_transport_ipc::IpcConnect;
 use std::future::Future;
 
@@ -43,6 +43,15 @@ use std::future::Future;
 /// signal.
 #[derive(Debug)]
 pub struct EngineClientError(pub TransportError);
+
+impl EngineClientError {
+    /// Construct a custom, non-retryable engine-client error from a message.
+    /// Primarily for tests that simulate an execution-client failure (e.g. a
+    /// failed forkchoice commit at an epoch boundary).
+    pub fn custom(msg: &str) -> Self {
+        EngineClientError(TransportErrorKind::custom_str(msg))
+    }
+}
 
 impl std::fmt::Display for EngineClientError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {


### PR DESCRIPTION
Addresses: https://github.com/SeismicSystems/summit/issues/246 and https://github.com/SeismicSystems/summit/issues/325

Changes
 - Move finalized-block ack after epoch-boundary state persistence.
 - Clear `added_validators` / `removed_validators` before storing next-epoch consensus state.
 - Add a restart regression test that verifies persisted transition deltas are cleared and the active validator set is correct after reload.
 
 Note: once this and https://github.com/SeismicSystems/summit/pull/382 are on the same base, we should add a finalizer test that injects a commit failure at an epoch boundary and asserts the syncer ack is withheld (the Exact waiter resolves Err/canceled) and the node shuts down without durably advancing the epoch.