### PR TITLE
fix: reject inverted validator stake bounds

### DIFF
--- a/finalizer/src/actor.rs
+++ b/finalizer/src/actor.rs
@@ -878,7 +878,13 @@ impl<
             }
 
             // Apply protocol parameter changes
-            let stake_changed = self.canonical_state.apply_protocol_parameter_changes();
+            let stake_changed = match self.canonical_state.apply_protocol_parameter_changes() {
+                Ok(stake_changed) => stake_changed,
+                Err(e) => {
+                    warn!("skipping invalid protocol parameter changes at epoch boundary: {e}");
+                    false
+                }
+            };
 
             // Build the committee for the next epoch.
             self.validator_exit = self.update_validator_committee(stake_changed);

--- a/types/src/consensus_state.rs
+++ b/types/src/consensus_state.rs
@@ -17,6 +17,17 @@ use metrics::histogram;
 use std::collections::{BTreeMap, VecDeque};
 use std::num::NonZeroU64;
 
+const INVALID_STAKE_INTERVAL: &str =
+    "validator_minimum_stake must be less than or equal to validator_maximum_stake";
+
+fn validate_stake_interval(minimum_stake: u64, maximum_stake: u64) -> Result<(), Error> {
+    if minimum_stake <= maximum_stake {
+        Ok(())
+    } else {
+        Err(Error::Invalid("ConsensusState", INVALID_STAKE_INTERVAL))
+    }
+}
+
 #[derive(Debug)]
 pub struct ConsensusState {
     pub(crate) epoch: u64,
@@ -790,7 +801,18 @@ impl ConsensusState {
             .collect()
     }
 
-    pub fn apply_protocol_parameter_changes(&mut self) -> bool {
+    pub fn apply_protocol_parameter_changes(&mut self) -> Result<bool, Error> {
+        let prospective_minimum_stake = self.prospective_minimum_stake();
+        let prospective_maximum_stake = self.prospective_maximum_stake();
+        if let Err(err) =
+            validate_stake_interval(prospective_minimum_stake, prospective_maximum_stake)
+        {
+            self.protocol_param_changes.clear();
+            self.ssz_tree
+                .rebuild_protocol_params(&self.protocol_param_changes);
+            return Err(err);
+        }
+
         let mut min_or_max_stake_changed = false;
         for param in self.protocol_param_changes.drain(0..) {
             match param {
@@ -839,7 +861,7 @@ impl ConsensusState {
         // Protocol param changes have been consumed — update the (now empty) collection root
         self.ssz_tree
             .rebuild_protocol_params(&self.protocol_param_changes);
-        min_or_max_stake_changed
+        Ok(min_or_max_stake_changed)
     }
 
     /// Rebuild the entire SSZ state tree from scratch.
@@ -1040,6 +1062,7 @@ impl Read for ConsensusState {
 
         let validator_minimum_stake = buf.try_get_u64().map_err(|_| Error::EndOfBuffer)?;
         let validator_maximum_stake = buf.try_get_u64().map_err(|_| Error::EndOfBuffer)?;
+        validate_stake_interval(validator_minimum_stake, validator_maximum_stake)?;
         let allowed_timestamp_future_ms = buf.try_get_u64().map_err(|_| Error::EndOfBuffer)?;
 
         let mut treasury_address_bytes = [0u8; 20];
@@ -1898,10 +1921,50 @@ mod tests {
         assert_ne!(state.ssz_tree().root(), r1);
 
         // apply_protocol_parameter_changes consumes them
-        let changed = state.apply_protocol_parameter_changes();
+        let changed = state.apply_protocol_parameter_changes().unwrap();
         assert!(changed);
         assert_eq!(state.get_minimum_stake(), 40_000_000_000);
         assert_eq!(state.get_maximum_stake(), 80_000_000_000);
+    }
+
+    #[test]
+    fn protocol_param_batch_accepts_valid_final_stake_interval() {
+        let mut state = ConsensusState::default();
+        state.push_protocol_param_change(ProtocolParam::MaximumStake(20_000_000_000));
+        state.push_protocol_param_change(ProtocolParam::MinimumStake(10_000_000_000));
+
+        let changed = state.apply_protocol_parameter_changes().unwrap();
+
+        assert!(changed);
+        assert_eq!(state.get_minimum_stake(), 10_000_000_000);
+        assert_eq!(state.get_maximum_stake(), 20_000_000_000);
+    }
+
+    #[test]
+    fn protocol_param_batch_rejects_inverted_final_stake_interval() {
+        let mut state = ConsensusState::default();
+        let root_before = state.ssz_tree().root();
+        state.push_protocol_param_change(ProtocolParam::MinimumStake(80_000_000_000));
+
+        let err = state.apply_protocol_parameter_changes().unwrap_err();
+
+        assert!(matches!(err, Error::Invalid("ConsensusState", _)));
+        assert_eq!(state.get_minimum_stake(), 32_000_000_000);
+        assert_eq!(state.get_maximum_stake(), 32_000_000_000);
+        assert_eq!(state.ssz_tree().root(), root_before);
+        assert_eq!(state.protocol_param_changes.len(), 0);
+    }
+
+    #[test]
+    fn consensus_state_decode_rejects_inverted_stake_interval() {
+        let mut state = ConsensusState::default();
+        state.validator_minimum_stake = 80_000_000_000;
+        state.validator_maximum_stake = 32_000_000_000;
+
+        let mut encoded = state.encode();
+        let err = ConsensusState::decode(&mut encoded).unwrap_err();
+
+        assert!(matches!(err, Error::Invalid("ConsensusState", _)));
     }
 
     #[test]
@@ -2213,7 +2276,7 @@ mod tests {
 
         // --- Simulate epoch transition ---
         // Apply protocol param changes (none in this case)
-        state.apply_protocol_parameter_changes();
+        state.apply_protocol_parameter_changes().unwrap();
 
         // Activate the joining validator
         let mut account = state.get_account(&new_pubkey).unwrap().clone();
@@ -2263,7 +2326,7 @@ mod tests {
 
         // --- Simulate protocol param change ---
         state.push_protocol_param_change(ProtocolParam::MinimumStake(16_000_000_000));
-        state.apply_protocol_parameter_changes();
+        state.apply_protocol_parameter_changes().unwrap();
 
         let param_root = state.ssz_tree().root();
         state.rebuild_ssz_tree();

--- a/types/src/genesis.rs
+++ b/types/src/genesis.rs
@@ -146,6 +146,13 @@ impl Genesis {
         if self.blocks_per_epoch == 0 {
             return Err("blocks_per_epoch must be greater than 0".into());
         }
+        if self.validator_minimum_stake > self.validator_maximum_stake {
+            return Err(format!(
+                "validator_minimum_stake {} exceeds validator_maximum_stake {}",
+                self.validator_minimum_stake, self.validator_maximum_stake
+            )
+            .into());
+        }
         if self.allowed_timestamp_future_ms < MIN_ALLOWED_TIMESTAMP_FUTURE_MS
             || self.allowed_timestamp_future_ms > MAX_ALLOWED_TIMESTAMP_FUTURE_MS
         {
@@ -300,6 +307,13 @@ mod tests {
     fn rejects_max_deposits_per_epoch_u64_max() {
         let mut genesis = Genesis::load_from_file("../example_genesis.toml").unwrap();
         genesis.max_deposits_per_epoch = u64::MAX;
+        assert!(genesis.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_inverted_validator_stake_interval() {
+        let mut genesis = Genesis::load_from_file("../example_genesis.toml").unwrap();
+        genesis.validator_minimum_stake = genesis.validator_maximum_stake + 1;
         assert!(genesis.validate().is_err());
     }
 


### PR DESCRIPTION
Addresses https://github.com/SeismicSystems/summit/issues/230.

Changes:
  - Reject genesis and decoded consensus states with `validator_minimum_stake > validator_maximum_stake`
  - Validate protocol-parameter batches against the final prospective stake interval before applying them
  - Skip and drain invalid protocol-parameter batches without shutting down the finalizer