### PR TITLE
fix: preserve deferred last-block withdrawals

### DIFF
--- a/finalizer/src/actor.rs
+++ b/finalizer/src/actor.rs
@@ -35,6 +35,7 @@ use summit_types::consensus_state_query::{ConsensusStateRequest, ConsensusStateR
 use summit_types::execution_request::{
     DepositRequest, ExecutionRequest, ParsedExecutionRequest, WithdrawalRequest,
 };
+use summit_types::execution_request_origin::ExecutionRequestOrigin;
 use summit_types::ext_private_key::derive_observer_keys;
 use summit_types::network_oracle::NetworkOracle;
 use summit_types::protocol_params::ProtocolParam;
@@ -1777,9 +1778,8 @@ impl<
             // parse_execution_requests (so it appears in the next epoch's
             // last-block `removed_validators` header). The deferred exit
             // will replay on the next block's parse and zero the balance
-            // then; scheduling a stake-bound partial withdrawal here would
-            // set has_pending_withdrawal = true and cause the buffered
-            // exit's admission to be skipped as a duplicate.
+            // then; scheduling a stake-bound withdrawal here would duplicate
+            // the already-accepted deferred exit.
             let pending_exit_pubkeys = pubkeys_with_buffered_full_exit(&self.canonical_state);
 
             let validators_to_process: Vec<([u8; 32], u64, Address)> = self
@@ -2033,12 +2033,21 @@ async fn parse_execution_requests<
     protocol_version_digest: Digest,
     consts: &ProtocolConsts,
 ) {
-    // Combine any pending execution requests with the current block's requests
-    let mut all_requests = state.take_pending_execution_requests();
-    all_requests.extend(block.execution_requests.iter().cloned());
+    // Combine any pending execution requests with the current block's requests.
+    // Keep origin explicit so deferred replay can distinguish itself from a
+    // fresh request in the block currently being executed.
+    let pending_requests = state.take_pending_execution_requests();
+    let pending_requests = pending_requests
+        .iter()
+        .map(|request| (request.as_ref(), ExecutionRequestOrigin::Deferred));
+    let current_requests = block
+        .execution_requests
+        .iter()
+        .map(|request| (request.as_ref(), ExecutionRequestOrigin::CurrentBlock));
 
-    for request_bytes in &all_requests {
-        match ExecutionRequest::parse_eth_entry(request_bytes.as_ref()) {
+    for (request_bytes, origin) in pending_requests.chain(current_requests) {
+        let is_deferred = origin.is_deferred();
+        match ExecutionRequest::parse_eth_entry(request_bytes) {
             Ok(parsed_requests) => {
                 for parsed in parsed_requests {
                     match parsed {
@@ -2066,6 +2075,56 @@ async fn parse_execution_requests<
                         ParsedExecutionRequest::Valid(ExecutionRequest::Deposit(
                             deposit_request,
                         )) => {
+                            //<<<<<<< HEAD
+                            //    for request_bytes in &all_requests {
+                            //        match ExecutionRequest::parse_eth_entry(request_bytes.as_ref()) {
+                            //            Ok(parsed_requests) => {
+                            //                for parsed in parsed_requests {
+                            //                    match parsed {
+                            //                        ParsedExecutionRequest::MalformedDeposit(chunk) => {
+                            //                            // EIP-6110 grouping concatenates same-block deposit logs
+                            //                            // into one entry; a single contract-accepted but
+                            //                            // parser-invalid chunk must not poison the others.
+                            //                            // Route it through the same refund branch as a
+                            //                            // signature-invalid deposit.
+                            //                            info!(
+                            //                                reason = chunk.reason,
+                            //                                amount = chunk.amount,
+                            //                                index = chunk.index,
+                            //                                "refunding malformed deposit chunk",
+                            //                            );
+                            //                            queue_deposit_refund(
+                            //                                state,
+                            //                                chunk.withdrawal_credentials,
+                            //                                chunk.amount,
+                            //                                chunk.index,
+                            //                                DepositRejectionReason::MalformedKey,
+                            //                                consts,
+                            //                            );
+                            //                        }
+                            //                        ParsedExecutionRequest::Valid(ExecutionRequest::Deposit(
+                            //                            deposit_request,
+                            //                        )) => {
+                            //||||||| parent of 47173ec (fix: preserve deferred last-block withdrawals)
+                            //    for request_bytes in &all_requests {
+                            //        match ExecutionRequest::try_from_eth_entry(request_bytes.as_ref()) {
+                            //            Ok(execution_requests) => {
+                            //                for execution_request in execution_requests {
+                            //                    match execution_request {
+                            //                        ExecutionRequest::Deposit(deposit_request) => {
+                            //=======
+                            //    for (request_bytes, origin) in pending_requests.chain(current_requests) {
+                            //        match ExecutionRequest::try_from_eth_entry(request_bytes) {
+                            //            Ok(execution_requests) => {
+                            //                for execution_request in execution_requests {
+                            //                    let queued_request = QueuedExecutionRequest {
+                            //                        request: execution_request,
+                            //                        origin,
+                            //                    };
+                            //                    let is_deferred = queued_request.origin.is_deferred();
+                            //                    match queued_request.request {
+                            //                        ExecutionRequest::Deposit(deposit_request) => {
+                            //>>>>>>> 47173ec (fix: preserve deferred last-block withdrawals)
                             match verify_deposit_request(
                                 context,
                                 &deposit_request,
@@ -2152,10 +2211,16 @@ async fn parse_execution_requests<
 
                                 // If the validator already has a pending withdrawal request, we skip this withdrawal request
                                 if account.has_pending_withdrawal {
-                                    info!(
-                                        "Skipping withdrawal request because the validator already has a pending withdrawal request: {withdrawal_request:?}"
-                                    );
-                                    continue; // Skip this withdrawal request
+                                    if is_deferred {
+                                        info!(
+                                            "Replaying deferred withdrawal request for validator with pending withdrawal flag: {withdrawal_request:?}"
+                                        );
+                                    } else {
+                                        info!(
+                                            "Skipping withdrawal request because the validator already has a pending withdrawal request: {withdrawal_request:?}"
+                                        );
+                                        continue; // Skip this withdrawal request
+                                    }
                                 }
 
                                 // The balance minus any pending withdrawals have to be larger than the amount of the withdrawal request
@@ -2204,6 +2269,8 @@ async fn parse_execution_requests<
                                     );
                                     let mut deferred_request = vec![0x01];
                                     withdrawal_request.write(&mut deferred_request);
+                                    account.has_pending_withdrawal = true;
+                                    state.set_account(withdrawal_request.validator_pubkey, account);
                                     state.push_pending_execution_request(deferred_request.into());
                                     continue;
                                 } else if account.joining_epoch > state.get_epoch() {

--- a/finalizer/src/actor.rs
+++ b/finalizer/src/actor.rs
@@ -2075,56 +2075,6 @@ async fn parse_execution_requests<
                         ParsedExecutionRequest::Valid(ExecutionRequest::Deposit(
                             deposit_request,
                         )) => {
-                            //<<<<<<< HEAD
-                            //    for request_bytes in &all_requests {
-                            //        match ExecutionRequest::parse_eth_entry(request_bytes.as_ref()) {
-                            //            Ok(parsed_requests) => {
-                            //                for parsed in parsed_requests {
-                            //                    match parsed {
-                            //                        ParsedExecutionRequest::MalformedDeposit(chunk) => {
-                            //                            // EIP-6110 grouping concatenates same-block deposit logs
-                            //                            // into one entry; a single contract-accepted but
-                            //                            // parser-invalid chunk must not poison the others.
-                            //                            // Route it through the same refund branch as a
-                            //                            // signature-invalid deposit.
-                            //                            info!(
-                            //                                reason = chunk.reason,
-                            //                                amount = chunk.amount,
-                            //                                index = chunk.index,
-                            //                                "refunding malformed deposit chunk",
-                            //                            );
-                            //                            queue_deposit_refund(
-                            //                                state,
-                            //                                chunk.withdrawal_credentials,
-                            //                                chunk.amount,
-                            //                                chunk.index,
-                            //                                DepositRejectionReason::MalformedKey,
-                            //                                consts,
-                            //                            );
-                            //                        }
-                            //                        ParsedExecutionRequest::Valid(ExecutionRequest::Deposit(
-                            //                            deposit_request,
-                            //                        )) => {
-                            //||||||| parent of 47173ec (fix: preserve deferred last-block withdrawals)
-                            //    for request_bytes in &all_requests {
-                            //        match ExecutionRequest::try_from_eth_entry(request_bytes.as_ref()) {
-                            //            Ok(execution_requests) => {
-                            //                for execution_request in execution_requests {
-                            //                    match execution_request {
-                            //                        ExecutionRequest::Deposit(deposit_request) => {
-                            //=======
-                            //    for (request_bytes, origin) in pending_requests.chain(current_requests) {
-                            //        match ExecutionRequest::try_from_eth_entry(request_bytes) {
-                            //            Ok(execution_requests) => {
-                            //                for execution_request in execution_requests {
-                            //                    let queued_request = QueuedExecutionRequest {
-                            //                        request: execution_request,
-                            //                        origin,
-                            //                    };
-                            //                    let is_deferred = queued_request.origin.is_deferred();
-                            //                    match queued_request.request {
-                            //                        ExecutionRequest::Deposit(deposit_request) => {
-                            //>>>>>>> 47173ec (fix: preserve deferred last-block withdrawals)
                             match verify_deposit_request(
                                 context,
                                 &deposit_request,

--- a/node/src/tests/execution_requests/deposit_withdrawal_combined.rs
+++ b/node/src/tests/execution_requests/deposit_withdrawal_combined.rs
@@ -1,5 +1,7 @@
 use super::*;
-use alloy_primitives::hex;
+use alloy_eips::eip7685::Requests;
+use alloy_primitives::{Bytes, hex};
+use commonware_codec::Write;
 
 #[test_traced("INFO")]
 fn test_deposit_and_withdrawal_request_single() {
@@ -1288,6 +1290,205 @@ fn test_deposit_and_withdrawal_same_block() {
         );
 
         common::assert_state_root_consensus(&consensus_state_queries).await;
+
+        context.auditor().state()
+    })
+}
+
+#[test_traced("INFO")]
+fn test_last_block_withdrawal_before_same_block_deposit_not_dropped() {
+    // This uses a custom/noncanonical EIP-7685 entry order: withdrawal entry
+    // first, deposit entry second. The withdrawal lands on the last block of
+    // epoch 0, so it is deferred before the later top-up is parsed.
+    let n = 5;
+    let min_stake = 32_000_000_000;
+    let max_stake = 100_000_000_000;
+    let deposit_amount = 5_000_000_000;
+    let link = Link {
+        latency: Duration::from_millis(80),
+        jitter: Duration::from_millis(10),
+        success_rate: 0.98,
+    };
+
+    let cfg = deterministic::Config::default().with_seed(44);
+    let executor = Runner::from(cfg);
+    executor.start(|context| async move {
+        let (network, mut oracle) = Network::new(
+            context.with_label("network"),
+            simulated::Config {
+                max_size: 1024 * 1024,
+                disconnect_on_block: false,
+                tracked_peer_sets: NZUsize!(n as usize * 10),
+            },
+        );
+
+        network.start();
+
+        let mut key_stores = Vec::new();
+        let mut validators = Vec::new();
+        for i in 0..n {
+            let mut rng = StdRng::seed_from_u64(i as u64);
+            let node_key = PrivateKey::random(&mut rng);
+            let node_public_key = node_key.public_key();
+            let consensus_key = bls12381::PrivateKey::random(&mut rng);
+            let consensus_public_key = consensus_key.public_key();
+            key_stores.push(KeyStore {
+                node_key,
+                consensus_key,
+            });
+            validators.push((node_public_key, consensus_public_key));
+        }
+        validators.sort_by(|lhs, rhs| lhs.0.cmp(&rhs.0));
+        key_stores.sort_by_key(|ks| ks.node_key.public_key());
+
+        let addresses: Vec<Address> = (0..n).map(|i| Address::from([i as u8; 20])).collect();
+        let node_public_keys: Vec<_> = validators.iter().map(|(pk, _)| pk.clone()).collect();
+        let mut registrations = common::register_validators(&oracle, &node_public_keys).await;
+        common::link_validators(&mut oracle, &node_public_keys, link, None).await;
+
+        let genesis_hash =
+            from_hex_formatted(common::GENESIS_HASH).expect("failed to decode genesis hash");
+        let genesis_hash: [u8; 32] = genesis_hash
+            .try_into()
+            .expect("failed to convert genesis hash");
+
+        let validator_pubkey: [u8; 32] = validators[0].0.as_ref().try_into().unwrap();
+        let withdrawal_address = addresses[0];
+
+        let mut withdrawal_credentials = [0u8; 32];
+        withdrawal_credentials[0] = 0x01;
+        withdrawal_credentials[12..32].copy_from_slice(withdrawal_address.as_ref());
+
+        let (deposit, _, _) = common::create_deposit_request(
+            0,
+            deposit_amount,
+            common::get_domain(),
+            Some(key_stores[0].node_key.clone()),
+            Some(key_stores[0].consensus_key.clone()),
+            Some(withdrawal_credentials),
+        );
+        let withdrawal =
+            common::create_withdrawal_request(withdrawal_address, validator_pubkey, min_stake);
+
+        let mut withdrawal_entry = vec![0x01];
+        withdrawal.write(&mut withdrawal_entry);
+        let mut deposit_entry = vec![0x00];
+        deposit.write(&mut deposit_entry);
+        let requests = Requests::from(vec![
+            Bytes::from(withdrawal_entry),
+            Bytes::from(deposit_entry),
+        ]);
+
+        let request_block_height = DEFAULT_BLOCKS_PER_EPOCH - 1;
+        let deferred_withdrawal_epoch = 1 + VALIDATOR_WITHDRAWAL_NUM_EPOCHS;
+        let deferred_withdrawal_height =
+            (deferred_withdrawal_epoch + 1) * DEFAULT_BLOCKS_PER_EPOCH - 1;
+        let stop_height = deferred_withdrawal_height + 1;
+
+        let mut execution_requests_map = HashMap::new();
+        execution_requests_map.insert(request_block_height, requests);
+
+        let engine_client_network = MockEngineNetworkBuilder::new(genesis_hash)
+            .with_execution_requests(execution_requests_map)
+            .with_stop_at(stop_height)
+            .build();
+
+        let mut initial_state =
+            get_initial_state(genesis_hash, &validators, Some(&addresses), None, min_stake);
+        initial_state.set_maximum_stake(max_stake);
+
+        let mut public_keys = HashSet::new();
+        let mut consensus_state_queries = HashMap::new();
+        let mut withdrawn_validator_uid = String::new();
+        for (idx, key_store) in key_stores.into_iter().enumerate() {
+            let public_key = key_store.node_key.public_key();
+            public_keys.insert(public_key.clone());
+            let uid = format!("validator_{public_key}");
+            if idx == 0 {
+                withdrawn_validator_uid = uid.clone();
+            }
+            let namespace = String::from("_SUMMIT");
+            let engine_client = engine_client_network.create_client(uid.clone());
+            let config = get_default_engine_config(
+                engine_client,
+                SimulatedOracle::new(oracle.clone()),
+                uid.clone(),
+                genesis_hash,
+                namespace,
+                key_store,
+                validators.clone(),
+                initial_state.clone(),
+            );
+            let engine = Engine::new(context.with_label(&uid), config).await;
+            consensus_state_queries.insert(idx, engine.finalizer_mailbox.clone());
+
+            let (pending, recovered, resolver, orchestrator, broadcast) =
+                registrations.remove(&public_key).unwrap();
+            engine.start(pending, recovered, resolver, orchestrator, broadcast);
+        }
+
+        let mut height_reached = HashSet::new();
+        loop {
+            let metrics = context.encode();
+            let mut success = false;
+            for line in metrics.lines() {
+                if !line.starts_with("validator_") {
+                    continue;
+                }
+
+                let mut parts = line.split_whitespace();
+                let metric = parts.next().unwrap();
+                let value = parts.next().unwrap();
+
+                if metric.ends_with("finalizer_height") {
+                    let height = value.parse::<u64>().unwrap();
+                    if height >= stop_height {
+                        height_reached.insert(metric.to_string());
+                    }
+                }
+
+                if height_reached.len() as u32 == n - 1 {
+                    success = true;
+                    break;
+                }
+            }
+            if success {
+                break;
+            }
+            context.sleep(Duration::from_secs(1)).await;
+        }
+
+        let withdrawals = engine_client_network.get_withdrawals();
+        let full_withdrawal = withdrawals.values().flatten().find(|withdrawal| {
+            withdrawal.address == withdrawal_address && withdrawal.amount == min_stake
+        });
+        let top_up_refund = withdrawals.values().flatten().find(|withdrawal| {
+            withdrawal.address == withdrawal_address && withdrawal.amount == deposit_amount
+        });
+        assert!(
+            full_withdrawal.is_some(),
+            "last-block withdrawal must not be dropped by a later same-block top-up; withdrawals = {withdrawals:?}"
+        );
+        assert!(
+            top_up_refund.is_some(),
+            "same-block top-up after accepted withdrawal should be refunded; withdrawals = {withdrawals:?}"
+        );
+
+        let state_query = consensus_state_queries.get(&1).unwrap();
+        let account = state_query
+            .get_validator_account(validators[0].0.clone())
+            .await;
+        assert!(
+            account.is_none(),
+            "validator account should be removed after the full withdrawal; account = {account:?}"
+        );
+
+        assert!(
+            engine_client_network
+                .verify_consensus_skip(None, Some(stop_height), &[&withdrawn_validator_uid])
+                .is_ok()
+        );
+        common::assert_state_root_consensus_skip(&consensus_state_queries, &[0]).await;
 
         context.auditor().state()
     })

--- a/types/src/execution_request_origin.rs
+++ b/types/src/execution_request_origin.rs
@@ -1,0 +1,11 @@
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ExecutionRequestOrigin {
+    CurrentBlock,
+    Deferred,
+}
+
+impl ExecutionRequestOrigin {
+    pub fn is_deferred(self) -> bool {
+        matches!(self, Self::Deferred)
+    }
+}

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -7,6 +7,7 @@ pub mod consensus_state_query;
 pub mod dynamic_epocher;
 pub mod engine_client;
 pub mod execution_request;
+pub mod execution_request_origin;
 pub mod ext_private_key;
 pub mod genesis;
 pub mod header;


### PR DESCRIPTION
Addresses https://github.com/SeismicSystems/summit/issues/248.

Changes:
  - Adds explicit `ExecutionRequestOrigin` for current vs deferred request handling
  - Marks last-block deferred withdrawals as pending before buffering them
  - Allows deferred withdrawal replay through its own pending-withdrawal guard
  - Adds regression coverage for withdrawal-entry-before-deposit-entry ordering
  - Adds test `test_last_block_withdrawal_before_same_block_deposit_not_dropped` for verification