### PR TITLE
fix: dynamic epocher snapshot isolation

### DIFF
--- a/finalizer/src/actor.rs
+++ b/finalizer/src/actor.rs
@@ -218,6 +218,8 @@ impl<
             gauge
         };
 
+        let shared_state = state.clone_with_shared_epocher();
+
         (
             Self {
                 context: ContextCell::new(context),
@@ -226,7 +228,7 @@ impl<
                 oracle: cfg.oracle,
                 pending_height_notifys: BTreeMap::new(),
                 db,
-                canonical_state: state.clone(),
+                canonical_state: state,
                 fork_states: BTreeMap::new(),
                 orphaned_blocks: BTreeMap::new(),
                 genesis_hash: cfg.genesis_hash,
@@ -242,7 +244,7 @@ impl<
                 #[cfg(debug_assertions)]
                 consensus_state_stored_gauge,
             },
-            state,
+            shared_state,
             FinalizerMailbox::new(tx),
         )
     }
@@ -462,7 +464,9 @@ impl<
                 ?block_digest,
                 "reusing fork state for finalized block"
             );
-            self.canonical_state = fork_state.consensus_state.clone();
+            let live_epocher = self.canonical_state.get_epocher().clone();
+            live_epocher.replace_with(fork_state.consensus_state.get_epocher());
+            self.canonical_state = fork_state.consensus_state.clone_with_epocher(live_epocher);
         } else {
             // Block was not notarized before finalization (catch-up or missed notarization)
             // Execute it now on canonical state

--- a/types/src/consensus_state.rs
+++ b/types/src/consensus_state.rs
@@ -17,7 +17,7 @@ use metrics::histogram;
 use std::collections::{BTreeMap, VecDeque};
 use std::num::NonZeroU64;
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct ConsensusState {
     pub(crate) epoch: u64,
     pub(crate) view: u64,
@@ -69,6 +69,12 @@ pub struct ConsensusState {
     pub(crate) proof_el_block_number: u64,
 }
 
+impl Clone for ConsensusState {
+    fn clone(&self) -> Self {
+        self.clone_with_epocher(self.epocher.snapshot())
+    }
+}
+
 impl Default for ConsensusState {
     fn default() -> Self {
         let mut s = Self {
@@ -107,6 +113,52 @@ impl Default for ConsensusState {
 }
 
 impl ConsensusState {
+    /// Clones state data while installing the supplied epocher handle.
+    ///
+    /// Most consensus snapshots should use `Clone`, which isolates the epoch
+    /// schedule. This is only for paths that deliberately control how the
+    /// cloned state participates in live epoch schedule propagation.
+    pub fn clone_with_epocher(&self, epocher: DynamicEpocher) -> Self {
+        Self {
+            epoch: self.epoch,
+            view: self.view,
+            latest_height: self.latest_height,
+            head_digest: self.head_digest,
+            deposit_queue: self.deposit_queue.clone(),
+            withdrawal_queue: self.withdrawal_queue.clone(),
+            validator_accounts: self.validator_accounts.clone(),
+            protocol_param_changes: self.protocol_param_changes.clone(),
+            pending_checkpoint: self.pending_checkpoint.clone(),
+            added_validators: self.added_validators.clone(),
+            removed_validators: self.removed_validators.clone(),
+            pending_execution_requests: self.pending_execution_requests.clone(),
+            forkchoice: self.forkchoice,
+            epoch_genesis_hash: self.epoch_genesis_hash,
+            validator_minimum_stake: self.validator_minimum_stake,
+            validator_maximum_stake: self.validator_maximum_stake,
+            allowed_timestamp_future_ms: self.allowed_timestamp_future_ms,
+            treasury_address: self.treasury_address,
+            max_deposits_per_epoch: self.max_deposits_per_epoch,
+            max_withdrawals_per_epoch: self.max_withdrawals_per_epoch,
+            observers_per_validator: self.observers_per_validator,
+            epocher,
+            ssz_tree: self.ssz_tree.clone(),
+            proof_tree: self.proof_tree.clone(),
+            proof_validator_keys: self.proof_validator_keys.clone(),
+            state_root: self.state_root,
+            proof_el_block_number: self.proof_el_block_number,
+        }
+    }
+
+    /// Clones state data while retaining the same live epocher handle.
+    ///
+    /// Most consensus snapshots should use `Clone`, which isolates the epoch
+    /// schedule. This is only for actor wiring that intentionally shares the
+    /// canonical epocher across components.
+    pub fn clone_with_shared_epocher(&self) -> Self {
+        self.clone_with_epocher(self.epocher.clone())
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         forkchoice: ForkchoiceState,
@@ -1244,6 +1296,43 @@ mod tests {
         assert_eq!(
             decoded_state.epoch_genesis_hash,
             original_state.epoch_genesis_hash
+        );
+    }
+
+    #[test]
+    fn test_clone_preserves_epoch_schedule_snapshot() {
+        let state = ConsensusState::new(
+            ForkchoiceState::default(),
+            0,
+            0,
+            NonZeroU64::new(10).unwrap(),
+            10_000,
+            Address::ZERO,
+            3,
+            16,
+            0,
+        );
+        state.get_epocher().advance_epoch(Epoch::new(0));
+
+        let cloned = state.clone();
+        let cloned_epoch_two_bounds_before = (
+            cloned.get_epocher().first(Epoch::new(2)),
+            cloned.get_epocher().last(Epoch::new(2)),
+        );
+
+        state
+            .get_epocher()
+            .update_length(NonZeroU64::new(20).unwrap())
+            .unwrap();
+        state.get_epocher().advance_epoch(Epoch::new(2));
+
+        assert_eq!(
+            (
+                cloned.get_epocher().first(Epoch::new(2)),
+                cloned.get_epocher().last(Epoch::new(2)),
+            ),
+            cloned_epoch_two_bounds_before,
+            "cloned consensus state must retain the epoch schedule captured at clone time",
         );
     }
 

--- a/types/src/dynamic_epocher.rs
+++ b/types/src/dynamic_epocher.rs
@@ -14,7 +14,7 @@ struct Segment {
 
 #[derive(Debug)]
 struct DynamicEpocherInner {
-    segments: Vec<Segment>,
+    segments: Arc<[Segment]>,
     current_epoch: Epoch,
 }
 
@@ -40,10 +40,36 @@ impl DynamicEpocher {
         };
         Self {
             inner: Arc::new(RwLock::new(DynamicEpocherInner {
-                segments: vec![segment],
+                segments: Arc::from(vec![segment]),
                 current_epoch: Epoch::new(0),
             })),
         }
+    }
+
+    /// Returns an isolated copy of the current epoch schedule.
+    pub fn snapshot(&self) -> Self {
+        let inner = self.inner.read().unwrap();
+        Self {
+            inner: Arc::new(RwLock::new(DynamicEpocherInner {
+                segments: Arc::clone(&inner.segments),
+                current_epoch: inner.current_epoch,
+            })),
+        }
+    }
+
+    /// Replaces this live handle's schedule with another epocher's current schedule.
+    pub fn replace_with(&self, other: &Self) {
+        if Arc::ptr_eq(&self.inner, &other.inner) {
+            return;
+        }
+
+        let (segments, current_epoch) = {
+            let other = other.inner.read().unwrap();
+            (Arc::clone(&other.segments), other.current_epoch)
+        };
+        let mut inner = self.inner.write().unwrap();
+        inner.segments = segments;
+        inner.current_epoch = current_epoch;
     }
 
     /// Returns the epoch length for the current epoch.
@@ -72,7 +98,7 @@ impl DynamicEpocher {
         if epoch.get() > inner.current_epoch.get() + 1 {
             return None;
         }
-        Self::bounds(&inner.segments, epoch)
+        Self::bounds(inner.segments.as_ref(), epoch)
     }
 
     /// Registers a new epoch length, taking effect at `current_epoch + 2`.
@@ -92,6 +118,7 @@ impl DynamicEpocher {
         let last_segment = inner
             .segments
             .last()
+            .cloned()
             .ok_or_else(|| anyhow!("no segments"))?;
         if target_epoch.get() < last_segment.start_epoch.get() {
             return Err(anyhow!(
@@ -101,20 +128,22 @@ impl DynamicEpocher {
             ));
         }
 
-        let (start_height, _) = Self::bounds(&inner.segments, target_epoch)
+        let (start_height, _) = Self::bounds(inner.segments.as_ref(), target_epoch)
             .ok_or_else(|| anyhow!("failed to compute bounds for epoch {}", target_epoch))?;
 
+        let mut segments = inner.segments.to_vec();
         // If the last segment starts at the same epoch, overwrite it.
         if last_segment.start_epoch == target_epoch {
-            let seg = inner.segments.last_mut().unwrap();
+            let seg = segments.last_mut().unwrap();
             seg.length = new_length.get();
         } else {
-            inner.segments.push(Segment {
+            segments.push(Segment {
                 start_epoch: target_epoch,
                 start_height,
                 length: new_length.get(),
             });
         }
+        inner.segments = Arc::from(segments);
         Ok(())
     }
 
@@ -160,7 +189,7 @@ impl Epocher for DynamicEpocher {
                     return None;
                 }
 
-                let (first, last) = Self::bounds(&inner.segments, epoch)?;
+                let (first, last) = Self::bounds(inner.segments.as_ref(), epoch)?;
                 return Some(EpochInfo::new(epoch, height, first, last));
             }
         }
@@ -172,7 +201,7 @@ impl Epocher for DynamicEpocher {
         if epoch.get() > inner.current_epoch.get() + 1 {
             return None;
         }
-        Self::bounds(&inner.segments, epoch).map(|(first, _)| first)
+        Self::bounds(inner.segments.as_ref(), epoch).map(|(first, _)| first)
     }
 
     fn last(&self, epoch: Epoch) -> Option<Height> {
@@ -180,7 +209,7 @@ impl Epocher for DynamicEpocher {
         if epoch.get() > inner.current_epoch.get() + 1 {
             return None;
         }
-        Self::bounds(&inner.segments, epoch).map(|(_, last)| last)
+        Self::bounds(inner.segments.as_ref(), epoch).map(|(_, last)| last)
     }
 }
 
@@ -198,7 +227,7 @@ impl Write for DynamicEpocher {
         let inner = self.inner.read().unwrap();
         buf.put_u64(inner.current_epoch.get());
         buf.put_u32(inner.segments.len() as u32);
-        for seg in &inner.segments {
+        for seg in inner.segments.iter() {
             buf.put_u64(seg.start_epoch.get());
             buf.put_u64(seg.start_height.get());
             buf.put_u64(seg.length);
@@ -231,7 +260,7 @@ impl Read for DynamicEpocher {
         }
         Ok(Self {
             inner: Arc::new(RwLock::new(DynamicEpocherInner {
-                segments,
+                segments: Arc::from(segments),
                 current_epoch,
             })),
         })
@@ -583,6 +612,61 @@ mod tests {
         assert_eq!(epocher.last(Epoch::new(3)), Some(Height::new(799)));
         assert_eq!(epocher.first(Epoch::new(4)), Some(Height::new(800)));
         assert_eq!(epocher.last(Epoch::new(4)), Some(Height::new(1099)));
+    }
+
+    #[test]
+    fn test_snapshot_isolates_query_window_and_schedule() {
+        let source = DynamicEpocher::new(NonZeroU64::new(10).unwrap());
+        source.advance_epoch(Epoch::new(0));
+
+        let snapshot = source.snapshot();
+
+        source.update_length(NonZeroU64::new(20).unwrap()).unwrap();
+        source.advance_epoch(Epoch::new(2));
+
+        assert_eq!(source.last(Epoch::new(2)), Some(Height::new(39)));
+        assert_eq!(snapshot.last(Epoch::new(2)), None);
+
+        snapshot.advance_epoch(Epoch::new(2));
+        assert_eq!(snapshot.first(Epoch::new(2)), Some(Height::new(20)));
+        assert_eq!(snapshot.last(Epoch::new(2)), Some(Height::new(29)));
+    }
+
+    #[test]
+    fn test_replace_with_updates_shared_live_handles() {
+        let live = DynamicEpocher::new(NonZeroU64::new(10).unwrap());
+        let live_observer = live.clone();
+        let fork = DynamicEpocher::new(NonZeroU64::new(10).unwrap());
+
+        fork.advance_epoch(Epoch::new(0));
+        fork.update_length(NonZeroU64::new(20).unwrap()).unwrap();
+        fork.advance_epoch(Epoch::new(2));
+
+        assert_eq!(live_observer.last(Epoch::new(2)), None);
+
+        live.replace_with(&fork);
+
+        assert_eq!(live.last(Epoch::new(2)), Some(Height::new(39)));
+        assert_eq!(live_observer.last(Epoch::new(2)), Some(Height::new(39)));
+    }
+
+    #[test]
+    fn test_replace_with_does_not_link_future_source_mutations() {
+        let live = DynamicEpocher::new(NonZeroU64::new(10).unwrap());
+        let fork = DynamicEpocher::new(NonZeroU64::new(10).unwrap());
+
+        fork.advance_epoch(Epoch::new(0));
+        fork.update_length(NonZeroU64::new(20).unwrap()).unwrap();
+        fork.advance_epoch(Epoch::new(2));
+
+        live.replace_with(&fork);
+
+        fork.update_length(NonZeroU64::new(30).unwrap()).unwrap();
+        fork.advance_epoch(Epoch::new(4));
+        live.advance_epoch(Epoch::new(4));
+
+        assert_eq!(fork.last(Epoch::new(4)), Some(Height::new(89)));
+        assert_eq!(live.last(Epoch::new(4)), Some(Height::new(79)));
     }
 
     #[test]


### PR DESCRIPTION
Addresses https://github.com/SeismicSystems/summit/issues/242.

Changes:
  - Add isolated DynamicEpocher snapshots with copy-on-write schedule storage.
  - Keep actor live handles synchronized by publishing promoted fork schedules back to the canonical shared epocher.
  - Add regression and edge tests for snapshot isolation, live-handle propagation, and post-replace mutation isolation.