### PR TITLE
chore: make RPC response limits configurable via CLI

### DIFF
--- a/node/src/args.rs
+++ b/node/src/args.rs
@@ -11,7 +11,10 @@ use commonware_codec::Read;
 use commonware_cryptography::{Signer, certificate::Scheme};
 use commonware_p2p::{Ingress, authenticated};
 use commonware_runtime::{Handle, Metrics as _, Runner, Spawner as _, tokio};
-use summit_rpc::{PathSender, start_rpc_server, start_rpc_server_for_genesis};
+use summit_rpc::{
+    DEFAULT_RPC_BODY_LIMIT_BYTES, PathSender, RpcBodyLimits, start_rpc_server,
+    start_rpc_server_for_genesis,
+};
 use tokio_util::sync::CancellationToken;
 
 use alloy_primitives::{Address, B256};
@@ -113,6 +116,14 @@ pub struct RunFlags {
     /// signing methods like `getDepositSignature`).
     #[arg(long, default_value_t = 3031)]
     pub admin_rpc_port: u16,
+
+    /// Maximum JSON-RPC request body size, in bytes.
+    #[arg(long, default_value_t = DEFAULT_RPC_BODY_LIMIT_BYTES)]
+    pub rpc_max_request_body_size: u32,
+
+    /// Maximum JSON-RPC response body size, in bytes.
+    #[arg(long, default_value_t = DEFAULT_RPC_BODY_LIMIT_BYTES)]
+    pub rpc_max_response_body_size: u32,
 
     /// Number of tokio worker threads (defaults to number of logical CPUs)
     #[arg(long)]
@@ -246,6 +257,10 @@ async fn run_node_inner(
     let genesis_path = flags.genesis_path.clone();
     let genesis_key_store_path = flags.key_store_path.clone();
     let genesis_rpc_port = flags.rpc_port;
+    let rpc_body_limits = RpcBodyLimits {
+        max_request_body_size: flags.rpc_max_request_body_size,
+        max_response_body_size: flags.rpc_max_response_body_size,
+    };
     let _rpc_handle = context
         .with_label("rpc_genesis")
         .spawn(move |_context| async move {
@@ -254,6 +269,7 @@ async fn run_node_inner(
                 genesis_sender,
                 genesis_key_store_path,
                 genesis_rpc_port,
+                rpc_body_limits,
                 cloned_token,
             )
             .await
@@ -468,6 +484,10 @@ async fn run_node_local_inner(
     let genesis_rpc_port = flags.rpc_port;
     let genesis_path = flags.genesis_path.clone();
     let genesis_key_store_path = flags.key_store_path.clone();
+    let rpc_body_limits = RpcBodyLimits {
+        max_request_body_size: flags.rpc_max_request_body_size,
+        max_response_body_size: flags.rpc_max_response_body_size,
+    };
     let _rpc_handle = context
         .with_label("rpc_genesis")
         .spawn(move |_context| async move {
@@ -476,6 +496,7 @@ async fn run_node_local_inner(
                 genesis_sender,
                 genesis_key_store_path,
                 genesis_rpc_port,
+                rpc_body_limits,
                 cloned_token,
             )
             .await
@@ -689,6 +710,10 @@ where
     let key_store_path = flags.key_store_path;
     let rpc_port = flags.rpc_port;
     let admin_rpc_port = flags.admin_rpc_port;
+    let rpc_body_limits = RpcBodyLimits {
+        max_request_body_size: flags.rpc_max_request_body_size,
+        max_response_body_size: flags.rpc_max_response_body_size,
+    };
     let stop_signal = context.stopped();
     let rpc_handle = context.with_label("rpc").spawn(move |_context| async move {
         if let Err(e) = start_rpc_server(
@@ -696,6 +721,7 @@ where
             key_store_path,
             rpc_port,
             admin_rpc_port,
+            rpc_body_limits,
             stop_signal,
             #[cfg(feature = "permissioned")]
             paused,

--- a/node/src/bin/observer.rs
+++ b/node/src/bin/observer.rs
@@ -502,6 +502,8 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         prom_ip: "0.0.0.0".into(),
         rpc_port: (3030 + (node * 10)) as u16,
         admin_rpc_port: (3031 + (node * 10)) as u16,
+        rpc_max_request_body_size: summit_rpc::DEFAULT_RPC_BODY_LIMIT_BYTES,
+        rpc_max_response_body_size: summit_rpc::DEFAULT_RPC_BODY_LIMIT_BYTES,
         worker_threads: Some(2),
         log_level: "debug".into(),
         db_prefix: format!("{node}"),

--- a/node/src/bin/protocol_params.rs
+++ b/node/src/bin/protocol_params.rs
@@ -401,6 +401,8 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         prom_ip: "0.0.0.0".into(),
         rpc_port: (3030 + (node * 10)) as u16,
         admin_rpc_port: (3031 + (node * 10)) as u16,
+        rpc_max_request_body_size: summit_rpc::DEFAULT_RPC_BODY_LIMIT_BYTES,
+        rpc_max_response_body_size: summit_rpc::DEFAULT_RPC_BODY_LIMIT_BYTES,
         worker_threads: Some(2),
         log_level: "debug".into(),
         db_prefix: format!("{node}"),

--- a/node/src/bin/stake_and_checkpoint.rs
+++ b/node/src/bin/stake_and_checkpoint.rs
@@ -688,6 +688,8 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         prom_ip: "0.0.0.0".into(),
         rpc_port: (3030 + (node * 10)) as u16,
         admin_rpc_port: (3031 + (node * 10)) as u16,
+        rpc_max_request_body_size: summit_rpc::DEFAULT_RPC_BODY_LIMIT_BYTES,
+        rpc_max_response_body_size: summit_rpc::DEFAULT_RPC_BODY_LIMIT_BYTES,
         worker_threads: Some(2),
         log_level: "debug".into(),
         db_prefix: format!("{node}"),

--- a/node/src/bin/stake_and_join_with_outdated_ckpt.rs
+++ b/node/src/bin/stake_and_join_with_outdated_ckpt.rs
@@ -806,6 +806,8 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         prom_ip: "0.0.0.0".into(),
         rpc_port: (3030 + (node * 10)) as u16,
         admin_rpc_port: (3031 + (node * 10)) as u16,
+        rpc_max_request_body_size: summit_rpc::DEFAULT_RPC_BODY_LIMIT_BYTES,
+        rpc_max_response_body_size: summit_rpc::DEFAULT_RPC_BODY_LIMIT_BYTES,
         worker_threads: Some(2),
         log_level: "debug".into(),
         db_prefix: format!("{node}"),

--- a/node/src/bin/sync_from_genesis.rs
+++ b/node/src/bin/sync_from_genesis.rs
@@ -671,6 +671,8 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         prom_ip: "0.0.0.0".into(),
         rpc_port: (3030 + (node * 10)) as u16,
         admin_rpc_port: (3031 + (node * 10)) as u16,
+        rpc_max_request_body_size: summit_rpc::DEFAULT_RPC_BODY_LIMIT_BYTES,
+        rpc_max_response_body_size: summit_rpc::DEFAULT_RPC_BODY_LIMIT_BYTES,
         worker_threads: Some(2),
         log_level: "debug".into(),
         db_prefix: format!("{node}"),

--- a/node/src/bin/testnet.rs
+++ b/node/src/bin/testnet.rs
@@ -188,6 +188,8 @@ fn get_node_flags(node: usize) -> RunFlags {
         prom_ip: "0.0.0.0".into(),
         rpc_port: (3030 + (node * 10)) as u16,
         admin_rpc_port: (3031 + (node * 10)) as u16,
+        rpc_max_request_body_size: summit_rpc::DEFAULT_RPC_BODY_LIMIT_BYTES,
+        rpc_max_response_body_size: summit_rpc::DEFAULT_RPC_BODY_LIMIT_BYTES,
         worker_threads: Some(2),
         log_level: "debug".into(),
         db_prefix: format!("{node}"),

--- a/node/src/bin/verify_consensus_state_proof.rs
+++ b/node/src/bin/verify_consensus_state_proof.rs
@@ -548,6 +548,8 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         prom_ip: "0.0.0.0".into(),
         rpc_port: (3030 + (node * 10)) as u16,
         admin_rpc_port: (3031 + (node * 10)) as u16,
+        rpc_max_request_body_size: summit_rpc::DEFAULT_RPC_BODY_LIMIT_BYTES,
+        rpc_max_response_body_size: summit_rpc::DEFAULT_RPC_BODY_LIMIT_BYTES,
         worker_threads: Some(2),
         log_level: "debug".into(),
         db_prefix: format!("{node}"),

--- a/node/src/bin/withdraw_and_exit.rs
+++ b/node/src/bin/withdraw_and_exit.rs
@@ -396,6 +396,8 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         prom_ip: "0.0.0.0".into(),
         rpc_port: (3030 + (node * 10)) as u16,
         admin_rpc_port: (3031 + (node * 10)) as u16,
+        rpc_max_request_body_size: summit_rpc::DEFAULT_RPC_BODY_LIMIT_BYTES,
+        rpc_max_response_body_size: summit_rpc::DEFAULT_RPC_BODY_LIMIT_BYTES,
         worker_threads: Some(2),
         log_level: "debug".into(),
         db_prefix: format!("{node}"),

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -30,11 +30,29 @@ use summit_types::Block;
 use summit_types::scheme::MultisigScheme;
 use tokio_util::sync::CancellationToken;
 
+pub const DEFAULT_RPC_BODY_LIMIT_BYTES: u32 = 50 * 1024 * 1024;
+
+#[derive(Debug, Clone, Copy)]
+pub struct RpcBodyLimits {
+    pub max_request_body_size: u32,
+    pub max_response_body_size: u32,
+}
+
+impl Default for RpcBodyLimits {
+    fn default() -> Self {
+        Self {
+            max_request_body_size: DEFAULT_RPC_BODY_LIMIT_BYTES,
+            max_response_body_size: DEFAULT_RPC_BODY_LIMIT_BYTES,
+        }
+    }
+}
+
 pub async fn start_rpc_server(
     finalizer_mailbox: FinalizerMailbox<MultisigScheme, Block>,
     key_store_path: String,
     port: u16,
     admin_port: u16,
+    body_limits: RpcBodyLimits,
     stop_signal: Signal,
     #[cfg(feature = "permissioned")] paused: Arc<AtomicBool>,
 ) -> anyhow::Result<()> {
@@ -52,8 +70,8 @@ pub async fn start_rpc_server(
 
     let public_server = builder::RpcServerBuilder::new(port)
         .with_max_connections(1000)
-        .with_max_request_body_size(10 * 1024 * 1024)
-        .with_max_response_body_size(10 * 1024 * 1024)
+        .with_max_request_body_size(body_limits.max_request_body_size)
+        .with_max_response_body_size(body_limits.max_response_body_size)
         .with_cors(Some("*".to_string()))
         .build()
         .await?;
@@ -67,8 +85,8 @@ pub async fn start_rpc_server(
 
     let admin_server = builder::RpcServerBuilder::new_localhost(admin_port)
         .with_max_connections(1000)
-        .with_max_request_body_size(10 * 1024 * 1024)
-        .with_max_response_body_size(10 * 1024 * 1024)
+        .with_max_request_body_size(body_limits.max_request_body_size)
+        .with_max_response_body_size(body_limits.max_response_body_size)
         .build()
         .await?;
 
@@ -115,8 +133,8 @@ pub async fn start_rpc_server_with_handle(
 
     let public_server = builder::RpcServerBuilder::new(port)
         .with_max_connections(1000)
-        .with_max_request_body_size(10 * 1024 * 1024)
-        .with_max_response_body_size(10 * 1024 * 1024)
+        .with_max_request_body_size(DEFAULT_RPC_BODY_LIMIT_BYTES)
+        .with_max_response_body_size(DEFAULT_RPC_BODY_LIMIT_BYTES)
         .with_cors(Some("*".to_string()))
         .build()
         .await?;
@@ -154,8 +172,8 @@ pub async fn start_rpc_server_pair_with_handle(
 
     let public_server = builder::RpcServerBuilder::new(port)
         .with_max_connections(1000)
-        .with_max_request_body_size(10 * 1024 * 1024)
-        .with_max_response_body_size(10 * 1024 * 1024)
+        .with_max_request_body_size(DEFAULT_RPC_BODY_LIMIT_BYTES)
+        .with_max_response_body_size(DEFAULT_RPC_BODY_LIMIT_BYTES)
         .with_cors(Some("*".to_string()))
         .build()
         .await?;
@@ -167,8 +185,8 @@ pub async fn start_rpc_server_pair_with_handle(
 
     let admin_server = builder::RpcServerBuilder::new_localhost(admin_port)
         .with_max_connections(1000)
-        .with_max_request_body_size(10 * 1024 * 1024)
-        .with_max_response_body_size(10 * 1024 * 1024)
+        .with_max_request_body_size(DEFAULT_RPC_BODY_LIMIT_BYTES)
+        .with_max_response_body_size(DEFAULT_RPC_BODY_LIMIT_BYTES)
         .build()
         .await?;
 
@@ -187,6 +205,7 @@ pub async fn start_rpc_server_for_genesis(
     genesis: PathSender,
     key_store_path: String,
     port: u16,
+    body_limits: RpcBodyLimits,
     cancel_token: CancellationToken,
 ) -> anyhow::Result<()> {
     let rpc_impl = SummitGenesisRpcServer::new(key_store_path, genesis);
@@ -199,6 +218,8 @@ pub async fn start_rpc_server_for_genesis(
     // remote caller cannot install genesis on this node before startup
     // loads it.
     let server = builder::RpcServerBuilder::new_localhost(port)
+        .with_max_request_body_size(body_limits.max_request_body_size)
+        .with_max_response_body_size(body_limits.max_response_body_size)
         .build()
         .await?;
     let addr = server.local_addr()?;
@@ -226,6 +247,8 @@ pub async fn start_rpc_server_for_genesis_with_handle(
     // See note on the production variant: localhost-only binding for the
     // first-boot genesis writer.
     let server = builder::RpcServerBuilder::new_localhost(port)
+        .with_max_request_body_size(DEFAULT_RPC_BODY_LIMIT_BYTES)
+        .with_max_response_body_size(DEFAULT_RPC_BODY_LIMIT_BYTES)
         .build()
         .await?;
     let addr = server.local_addr()?;


### PR DESCRIPTION
Addresses https://github.com/SeismicSystems/summit/issues/240.

Changes:
  - Added --rpc-max-request-body-size.
  - Added --rpc-max-response-body-size.
  - Introduced shared default DEFAULT_RPC_BODY_LIMIT_BYTES = 50 MiB.
  - Applied configured limits to public/admin RPC and genesis RPC startup.