### PR TITLE
fix: bind deposit signatures to genesis hash

### DIFF
--- a/finalizer/src/actor.rs
+++ b/finalizer/src/actor.rs
@@ -11,7 +11,7 @@ use commonware_consensus::simplex::scheme::bls12381_multisig;
 use commonware_consensus::simplex::types::Finalization;
 use commonware_consensus::types::Epoch;
 use commonware_cryptography::bls12381::primitives::variant::Variant;
-use commonware_cryptography::{Digestible, Hasher, Sha256, Signer, Verifier as _, bls12381};
+use commonware_cryptography::{Digestible, Signer, Verifier as _, bls12381};
 use commonware_runtime::{Clock, ContextCell, Handle, Metrics, Spawner, Storage, spawn_cell};
 use commonware_storage::translator::EightCap;
 use commonware_utils::acknowledgement::{Acknowledgement, Exact};
@@ -48,6 +48,7 @@ use summit_types::utils::{
 };
 use summit_types::{
     AddedValidator, Block, BlockAuxData, Digest, FinalizedHeader, PublicKey, Signature,
+    deposit_signature_domain,
 };
 use summit_types::{EngineClient, consensus_state::ConsensusState};
 use tokio_util::sync::CancellationToken;
@@ -284,7 +285,7 @@ pub struct Finalizer<
 
     genesis_hash: [u8; 32],
     protocol_consts: ProtocolConsts,
-    protocol_version_digest: Digest,
+    deposit_signature_domain: Digest,
     oracle: O,
     node_public_key: PublicKey,
     validator_exit: bool,
@@ -395,7 +396,7 @@ impl<
                 pending_notarized_max: cfg.pending_notarized_max,
                 genesis_hash: cfg.genesis_hash,
                 protocol_consts: cfg.protocol_consts,
-                protocol_version_digest: Sha256::hash(&cfg.protocol_version.to_le_bytes()),
+                deposit_signature_domain: deposit_signature_domain(cfg.genesis_hash),
                 node_public_key: cfg.node_public_key,
                 validator_exit: false,
                 cancellation_token: cfg.cancellation_token,
@@ -715,7 +716,7 @@ impl<
                 &block,
                 &mut self.canonical_state,
                 &self.protocol_consts,
-                self.protocol_version_digest,
+                self.deposit_signature_domain,
             )
             .await
             {
@@ -1174,7 +1175,7 @@ impl<
                 &block,
                 &mut fork_state,
                 &self.protocol_consts,
-                self.protocol_version_digest,
+                self.deposit_signature_domain,
             )
             .await
             {
@@ -1897,7 +1898,7 @@ async fn execute_block<
     block: &Block,
     state: &mut ConsensusState,
     consts: &ProtocolConsts,
-    protocol_version_digest: Digest,
+    deposit_signature_domain: Digest,
 ) -> Result<ExecuteOutcome, summit_types::EngineClientError> {
     #[cfg(feature = "prom")]
     let block_processing_start = Instant::now();
@@ -1951,7 +1952,7 @@ async fn execute_block<
         block,
         new_height,
         state,
-        protocol_version_digest,
+        deposit_signature_domain,
         consts,
     )
     .await;
@@ -2030,7 +2031,7 @@ async fn parse_execution_requests<
     block: &Block,
     new_height: u64,
     state: &mut ConsensusState,
-    protocol_version_digest: Digest,
+    deposit_signature_domain: Digest,
     consts: &ProtocolConsts,
 ) {
     // Combine any pending execution requests with the current block's requests.
@@ -2079,7 +2080,7 @@ async fn parse_execution_requests<
                                 context,
                                 &deposit_request,
                                 state,
-                                protocol_version_digest,
+                                deposit_signature_domain,
                                 new_height,
                                 state.get_minimum_stake(),
                                 state.get_maximum_stake(),
@@ -2606,7 +2607,7 @@ fn verify_deposit_request<R: Storage + Metrics + Clock + Spawner + governor::clo
     #[allow(unused)] context: &ContextCell<R>,
     deposit_request: &DepositRequest,
     state: &ConsensusState,
-    protocol_version_digest: Digest,
+    deposit_signature_domain: Digest,
     #[allow(unused)] new_height: u64,
     validator_minimum_stake: u64,
     validator_maximum_stake: u64,
@@ -2674,7 +2675,7 @@ fn verify_deposit_request<R: Storage + Metrics + Clock + Spawner + governor::clo
         return Err(DepositRejectionReason::Refund);
     }
 
-    let message = deposit_request.as_message(protocol_version_digest);
+    let message = deposit_request.as_message(deposit_signature_domain);
 
     let mut node_signature_bytes = &deposit_request.node_signature[..];
     let Ok(node_signature) = Signature::read(&mut node_signature_bytes) else {

--- a/finalizer/src/actor.rs
+++ b/finalizer/src/actor.rs
@@ -396,7 +396,10 @@ impl<
                 pending_notarized_max: cfg.pending_notarized_max,
                 genesis_hash: cfg.genesis_hash,
                 protocol_consts: cfg.protocol_consts,
-                deposit_signature_domain: deposit_signature_domain(cfg.genesis_hash),
+                deposit_signature_domain: deposit_signature_domain(
+                    cfg.genesis_hash,
+                    &cfg.namespace,
+                ),
                 node_public_key: cfg.node_public_key,
                 validator_exit: false,
                 cancellation_token: cfg.cancellation_token,

--- a/finalizer/src/config.rs
+++ b/finalizer/src/config.rs
@@ -22,6 +22,10 @@ pub struct FinalizerConfig<C: EngineClient, O: NetworkOracle<PublicKey>, V: Vari
     pub protocol_consts: ProtocolConsts,
     pub page_cache: CacheRef,
     pub genesis_hash: [u8; 32],
+    /// The Summit deployment namespace, mixed into the deposit-signature domain
+    /// alongside the genesis hash so deposit authorizations are bound to this
+    /// specific deployment (not just the EL genesis).
+    pub namespace: Vec<u8>,
     /// Optional initial state to initialize the finalizer with
     pub initial_state: ConsensusState,
     /// Protocol version for the consensus protocol

--- a/finalizer/src/tests/fork_handling.rs
+++ b/finalizer/src/tests/fork_handling.rs
@@ -166,6 +166,7 @@ fn test_orphaned_block_processed_when_parent_arrives() {
             drain_interval: Duration::from_millis(100),
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
+            namespace: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -251,6 +252,7 @@ fn test_losing_height_waiter_resolves_false_on_conflicting_finalization() {
             drain_interval: Duration::from_millis(100),
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
+            namespace: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -339,6 +341,7 @@ fn test_competing_digest_waiter_stays_pending_until_finalization() {
             drain_interval: Duration::from_millis(100),
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
+            namespace: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -428,6 +431,7 @@ fn test_finalization_resolves_lower_waiters_and_preserves_future_waiters() {
             drain_interval: Duration::from_millis(100),
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
+            namespace: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -517,6 +521,7 @@ fn test_multiple_forks_tracked() {
             drain_interval: Duration::from_millis(100),
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
+            namespace: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -602,6 +607,7 @@ fn test_dead_fork_block_discarded() {
             drain_interval: Duration::from_millis(100),
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
+            namespace: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -703,6 +709,7 @@ fn test_fork_states_pruned_after_finalization() {
             drain_interval: Duration::from_millis(100),
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
+            namespace: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -823,6 +830,7 @@ fn test_orphaned_blocks_pruned_after_finalization() {
             drain_interval: Duration::from_millis(100),
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
+            namespace: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -935,6 +943,7 @@ fn test_fork_state_reused_when_notarized_then_finalized() {
             drain_interval: Duration::from_millis(100),
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
+            namespace: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -1043,6 +1052,7 @@ fn test_competing_fork_pruned_on_finalization() {
             drain_interval: Duration::from_millis(100),
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
+            namespace: Vec::new(),
             _variant_marker: PhantomData,
         };
 

--- a/finalizer/src/tests/state_queries.rs
+++ b/finalizer/src/tests/state_queries.rs
@@ -170,6 +170,7 @@ fn test_generate_state_proof_preserves_batch_cardinality_for_missing_keys() {
             drain_interval: Duration::from_millis(100),
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
+            namespace: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -261,6 +262,7 @@ fn test_get_latest_epoch() {
             drain_interval: Duration::from_millis(100),
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
+            namespace: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -373,6 +375,7 @@ fn test_get_epoch_genesis_hash() {
             drain_interval: Duration::from_millis(100),
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
+            namespace: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -473,6 +476,7 @@ fn test_get_aux_data_from_canonical_chain() {
             drain_interval: Duration::from_millis(100),
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
+            namespace: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -547,6 +551,7 @@ fn test_get_aux_data_returns_none_for_invalid_parent() {
             drain_interval: Duration::from_millis(100),
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
+            namespace: Vec::new(),
             _variant_marker: PhantomData,
         };
 

--- a/finalizer/src/tests/syncing.rs
+++ b/finalizer/src/tests/syncing.rs
@@ -196,6 +196,7 @@ fn test_initial_startup_sync_waits_for_valid() {
             drain_interval: Duration::from_millis(100),
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
+            namespace: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -269,6 +270,7 @@ fn test_initial_startup_sync_zero_forkchoice_skips_sync() {
             drain_interval: Duration::from_millis(100),
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
+            namespace: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -342,6 +344,7 @@ fn test_execute_block_retries_on_syncing() {
             drain_interval: Duration::from_millis(100),
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
+            namespace: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -430,6 +433,7 @@ fn test_notarized_block_retries_on_syncing() {
             drain_interval: Duration::from_millis(100),
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
+            namespace: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -510,6 +514,7 @@ fn test_checkpoint_startup_full_flow() {
             drain_interval: Duration::from_millis(100),
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
+            namespace: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -630,6 +635,7 @@ fn test_finalizer_mailbox_responsive_under_persistent_syncing() {
             drain_interval: Duration::from_millis(100),
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
+            namespace: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -751,6 +757,7 @@ fn test_finalizer_mailbox_responsive_during_startup_syncing() {
             drain_interval: Duration::from_millis(100),
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
+            namespace: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -835,6 +842,7 @@ fn test_finalizer_shuts_down_when_pending_notarized_cap_is_reached() {
             drain_interval: Duration::from_millis(100),
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 2,
+            namespace: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -937,6 +945,7 @@ fn test_finalizer_finalized_buffer_drains_in_order() {
             drain_interval: Duration::from_millis(50),
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
+            namespace: Vec::new(),
             _variant_marker: PhantomData,
         };
 

--- a/finalizer/src/tests/validator_lifecycle.rs
+++ b/finalizer/src/tests/validator_lifecycle.rs
@@ -223,6 +223,7 @@ fn test_validator_exit_triggers_cancellation() {
             drain_interval: Duration::from_millis(100),
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
+            namespace: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -356,6 +357,7 @@ fn last_block_exit_dominates_concurrent_max_stake_reduction() {
             drain_interval: Duration::from_millis(100),
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
+            namespace: Vec::new(),
             _variant_marker: PhantomData,
         };
 

--- a/node/src/args.rs
+++ b/node/src/args.rs
@@ -702,6 +702,7 @@ where
 
     let backfiller = network.register(BACKFILLER_CHANNEL, config.backfill_quota, MESSAGE_BACKLOG);
 
+    let genesis_hash = config.genesis_hash;
     let engine: Engine<_, _, _, _> = Engine::new(context.with_label("engine"), config).await;
     #[cfg(feature = "permissioned")]
     let paused = engine.paused.clone();
@@ -724,6 +725,7 @@ where
         if let Err(e) = start_rpc_server(
             finalizer_mailbox,
             key_store_path,
+            genesis_hash,
             rpc_port,
             admin_rpc_port,
             rpc_body_limits,

--- a/node/src/args.rs
+++ b/node/src/args.rs
@@ -703,6 +703,7 @@ where
     let backfiller = network.register(BACKFILLER_CHANNEL, config.backfill_quota, MESSAGE_BACKLOG);
 
     let genesis_hash = config.genesis_hash;
+    let namespace = config.namespace.as_bytes().to_vec();
     let engine: Engine<_, _, _, _> = Engine::new(context.with_label("engine"), config).await;
     #[cfg(feature = "permissioned")]
     let paused = engine.paused.clone();
@@ -726,6 +727,7 @@ where
             finalizer_mailbox,
             key_store_path,
             genesis_hash,
+            namespace,
             rpc_port,
             admin_rpc_port,
             rpc_body_limits,

--- a/node/src/bin/stake_and_checkpoint.rs
+++ b/node/src/bin/stake_and_checkpoint.rs
@@ -15,9 +15,9 @@ use alloy::providers::ProviderBuilder;
 use alloy::signers::local::PrivateKeySigner;
 use alloy_primitives::{Address, U256};
 use clap::Parser;
-use commonware_cryptography::Sha256;
-use commonware_cryptography::{Hasher, Signer, bls12381, ed25519::PrivateKey};
+use commonware_cryptography::{Signer, bls12381, ed25519::PrivateKey};
 use commonware_runtime::{Clock, Runner as _, Spawner as _, tokio as cw_tokio};
+use commonware_utils::from_hex_formatted;
 use futures::{FutureExt, pin_mut};
 use jsonrpsee::http_client::HttpClientBuilder;
 use ssz::Decode;
@@ -33,9 +33,9 @@ use std::{
 use summit::args::{RunFlags, run_node_local};
 use summit::test_harness::transactions::send_deposit_transaction;
 use summit_rpc::SummitApiClient;
-use summit_types::PROTOCOL_VERSION;
 use summit_types::checkpoint::Checkpoint;
 use summit_types::consensus_state::ConsensusState;
+use summit_types::deposit_signature_domain;
 use summit_types::execution_request::DepositRequest;
 use summit_types::genesis::Genesis;
 use summit_types::reth::Reth;
@@ -98,6 +98,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut genesis = Genesis::load_from_file(GENESIS_PATH).expect("Failed to load genesis file");
     genesis.blocks_per_epoch = E2E_BLOCKS_PER_EPOCH;
+    let genesis_hash: [u8; 32] = from_hex_formatted(&genesis.eth_genesis_hash)
+        .expect("bad eth_genesis_hash")
+        .try_into()
+        .expect("bad eth_genesis_hash");
 
     // Write modified genesis for nodes to use
     fs::create_dir_all(&data_dir_path).expect("Failed to create data directory");
@@ -272,8 +276,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 index: 0, // not included in the signature
             };
 
-            let protocol_version_digest = Sha256::hash(&PROTOCOL_VERSION.to_le_bytes());
-            let message = deposit_request.as_message(protocol_version_digest);
+            let deposit_domain = deposit_signature_domain(genesis_hash);
+            let message = deposit_request.as_message(deposit_domain);
 
             // Sign with node (ed25519) key
             let node_signature = ed25519_private_key.sign(&[], &message);

--- a/node/src/bin/stake_and_checkpoint.rs
+++ b/node/src/bin/stake_and_checkpoint.rs
@@ -276,7 +276,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 index: 0, // not included in the signature
             };
 
-            let deposit_domain = deposit_signature_domain(genesis_hash);
+            let deposit_domain = deposit_signature_domain(genesis_hash, b"_SUMMIT");
             let message = deposit_request.as_message(deposit_domain);
 
             // Sign with node (ed25519) key

--- a/node/src/bin/stake_and_join_with_outdated_ckpt.rs
+++ b/node/src/bin/stake_and_join_with_outdated_ckpt.rs
@@ -279,7 +279,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 index: 0, // not included in the signature
             };
 
-            let deposit_domain = deposit_signature_domain(genesis_hash);
+            let deposit_domain = deposit_signature_domain(genesis_hash, b"_SUMMIT");
             let message = deposit_request.as_message(deposit_domain);
 
             // Sign with node (ed25519) key

--- a/node/src/bin/stake_and_join_with_outdated_ckpt.rs
+++ b/node/src/bin/stake_and_join_with_outdated_ckpt.rs
@@ -16,9 +16,9 @@ use alloy::rpc::types::TransactionRequest;
 use alloy::signers::local::PrivateKeySigner;
 use alloy_primitives::{Address, U256, keccak256};
 use clap::Parser;
-use commonware_cryptography::Sha256;
-use commonware_cryptography::{Hasher, Signer, bls12381, ed25519::PrivateKey};
+use commonware_cryptography::{Signer, bls12381, ed25519::PrivateKey};
 use commonware_runtime::{Clock, Runner as _, Spawner as _, tokio as cw_tokio};
+use commonware_utils::from_hex_formatted;
 use futures::{FutureExt, pin_mut};
 use jsonrpsee::http_client::HttpClientBuilder;
 use ssz::Decode;
@@ -33,9 +33,9 @@ use std::{
 };
 use summit::args::{RunFlags, run_node_local};
 use summit_rpc::SummitApiClient;
-use summit_types::PROTOCOL_VERSION;
 use summit_types::checkpoint::Checkpoint;
 use summit_types::consensus_state::ConsensusState;
+use summit_types::deposit_signature_domain;
 use summit_types::execution_request::DepositRequest;
 use summit_types::execution_request::compute_deposit_data_root;
 use summit_types::genesis::Genesis;
@@ -102,6 +102,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut genesis = Genesis::load_from_file(GENESIS_PATH).expect("Failed to load genesis file");
     genesis.blocks_per_epoch = E2E_BLOCKS_PER_EPOCH;
+    let genesis_hash: [u8; 32] = from_hex_formatted(&genesis.eth_genesis_hash)
+        .expect("bad eth_genesis_hash")
+        .try_into()
+        .expect("bad eth_genesis_hash");
 
     // Write modified genesis for nodes to use
     fs::create_dir_all(&data_dir_path).expect("Failed to create data directory");
@@ -275,8 +279,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 index: 0, // not included in the signature
             };
 
-            let protocol_version_digest = Sha256::hash(&PROTOCOL_VERSION.to_le_bytes());
-            let message = deposit_request.as_message(protocol_version_digest);
+            let deposit_domain = deposit_signature_domain(genesis_hash);
+            let message = deposit_request.as_message(deposit_domain);
 
             // Sign with node (ed25519) key
             let node_signature = ed25519_private_key.sign(&[], &message);

--- a/node/src/bin/sync_from_genesis.rs
+++ b/node/src/bin/sync_from_genesis.rs
@@ -376,7 +376,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 index: 0,
             };
 
-            let deposit_domain = deposit_signature_domain(genesis_hash);
+            let deposit_domain = deposit_signature_domain(genesis_hash, b"_SUMMIT");
             let message = deposit_request.as_message(deposit_domain);
 
             // Sign with node (ed25519) key

--- a/node/src/bin/sync_from_genesis.rs
+++ b/node/src/bin/sync_from_genesis.rs
@@ -37,8 +37,7 @@ use alloy::signers::local::PrivateKeySigner;
 use alloy_primitives::{Address, U256};
 use clap::Parser;
 use commonware_codec::DecodeExt;
-use commonware_cryptography::Sha256;
-use commonware_cryptography::{Hasher, Signer, bls12381, ed25519::PrivateKey};
+use commonware_cryptography::{Signer, bls12381, ed25519::PrivateKey};
 use commonware_runtime::{Clock, Runner as _, Spawner as _, tokio as cw_tokio};
 use commonware_utils::from_hex_formatted;
 use futures::{FutureExt, pin_mut};
@@ -57,8 +56,8 @@ use summit::args::{RunFlags, run_node_local};
 use summit::engine::VALIDATOR_WITHDRAWAL_NUM_EPOCHS;
 use summit::test_harness::transactions::send_deposit_transaction;
 use summit_rpc::SummitApiClient;
-use summit_types::PROTOCOL_VERSION;
 use summit_types::PublicKey;
+use summit_types::deposit_signature_domain;
 use summit_types::execution_request::DepositRequest;
 use summit_types::genesis::Genesis;
 use summit_types::reth::Reth;
@@ -115,6 +114,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut genesis = Genesis::load_from_file(GENESIS_PATH).expect("Failed to load genesis file");
     genesis.blocks_per_epoch = E2E_BLOCKS_PER_EPOCH;
+    let genesis_hash: [u8; 32] = from_hex_formatted(&genesis.eth_genesis_hash)
+        .expect("bad eth_genesis_hash")
+        .try_into()
+        .expect("bad eth_genesis_hash");
 
     // Write modified genesis for nodes to use
     fs::create_dir_all(&data_dir_path).expect("Failed to create data directory");
@@ -373,8 +376,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 index: 0,
             };
 
-            let protocol_version_digest = Sha256::hash(&PROTOCOL_VERSION.to_le_bytes());
-            let message = deposit_request.as_message(protocol_version_digest);
+            let deposit_domain = deposit_signature_domain(genesis_hash);
+            let message = deposit_request.as_message(deposit_domain);
 
             // Sign with node (ed25519) key
             let node_signature = ed25519_private_key.sign(&[], &message);

--- a/node/src/engine.rs
+++ b/node/src/engine.rs
@@ -156,6 +156,7 @@ where
                 },
                 page_cache: page_cache.clone(),
                 genesis_hash: cfg.genesis_hash,
+                namespace: cfg.namespace.as_bytes().to_vec(),
                 initial_state: cfg.initial_state,
                 protocol_version: PROTOCOL_VERSION,
                 node_public_key: cfg.key_store.node_key.public_key().clone(),

--- a/node/src/test_harness/common.rs
+++ b/node/src/test_harness/common.rs
@@ -1,8 +1,7 @@
-use commonware_cryptography::{Hasher, Sha256, Signer, bls12381};
+use commonware_cryptography::{Signer, bls12381};
 use commonware_math::algebra::Random;
 use std::num::NonZeroU64;
 
-use crate::engine::PROTOCOL_VERSION;
 use crate::test_harness::mock_engine_client::MockEngineNetwork;
 use crate::{config::EngineConfig, engine::Engine};
 use alloy_eips::eip7685::Requests;
@@ -34,7 +33,7 @@ use summit_types::execution_request::{
 use summit_types::keystore::KeyStore;
 use summit_types::network_oracle::NetworkOracle;
 use summit_types::scheme::MultisigScheme;
-use summit_types::{Block, Digest, EngineClient, PrivateKey, PublicKey};
+use summit_types::{Block, Digest, EngineClient, PrivateKey, PublicKey, deposit_signature_domain};
 use tokio::sync::mpsc;
 
 pub const DEFAULT_BLOCKS_PER_EPOCH: u64 = 10;
@@ -362,7 +361,11 @@ pub async fn assert_state_root_consensus_skip(
 }
 
 pub fn get_domain() -> Digest {
-    Sha256::hash(&PROTOCOL_VERSION.to_le_bytes())
+    let genesis_hash = from_hex_formatted(GENESIS_HASH).expect("failed to decode genesis hash");
+    let genesis_hash: [u8; 32] = genesis_hash
+        .try_into()
+        .expect("failed to convert genesis hash");
+    deposit_signature_domain(genesis_hash)
 }
 
 pub fn get_initial_state(
@@ -481,7 +484,7 @@ pub fn extract_validator_id(metric: &str) -> Option<String> {
 /// # Arguments
 /// * `index` - The deposit index value used for generating deterministic keys and in the signature
 /// * `amount` - The deposit amount in gwei
-/// * `domain` - The domain value used in the signature (typically genesis hash)
+/// * `domain` - The domain value used in the signature
 /// * `private_key` - Optional ED25519 private key to use; if None, generates deterministic key from index
 /// * `withdrawal_credentials` - Optional withdrawal credentials; if None, generates Eth1 format credentials
 ///

--- a/node/src/test_harness/common.rs
+++ b/node/src/test_harness/common.rs
@@ -365,7 +365,7 @@ pub fn get_domain() -> Digest {
     let genesis_hash: [u8; 32] = genesis_hash
         .try_into()
         .expect("failed to convert genesis hash");
-    deposit_signature_domain(genesis_hash)
+    deposit_signature_domain(genesis_hash, b"_SUMMIT")
 }
 
 pub fn get_initial_state(

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -52,6 +52,7 @@ pub async fn start_rpc_server(
     finalizer_mailbox: FinalizerMailbox<MultisigScheme, Block>,
     key_store_path: String,
     genesis_hash: [u8; 32],
+    namespace: Vec<u8>,
     port: u16,
     admin_port: u16,
     body_limits: RpcBodyLimits,
@@ -62,6 +63,7 @@ pub async fn start_rpc_server(
         key_store_path,
         finalizer_mailbox,
         genesis_hash,
+        &namespace,
         #[cfg(feature = "permissioned")]
         paused,
     );
@@ -120,6 +122,7 @@ pub async fn start_rpc_server_with_handle(
     finalizer_mailbox: FinalizerMailbox<MultisigScheme, Block>,
     key_store_path: String,
     genesis_hash: [u8; 32],
+    namespace: Vec<u8>,
     port: u16,
     #[cfg(feature = "permissioned")] paused: Arc<AtomicBool>,
 ) -> anyhow::Result<(ServerHandle, SocketAddr)> {
@@ -127,6 +130,7 @@ pub async fn start_rpc_server_with_handle(
         key_store_path,
         finalizer_mailbox,
         genesis_hash,
+        &namespace,
         #[cfg(feature = "permissioned")]
         paused,
     );
@@ -160,6 +164,7 @@ pub async fn start_rpc_server_pair_with_handle(
     finalizer_mailbox: FinalizerMailbox<MultisigScheme, Block>,
     key_store_path: String,
     genesis_hash: [u8; 32],
+    namespace: Vec<u8>,
     port: u16,
     admin_port: u16,
     #[cfg(feature = "permissioned")] paused: Arc<AtomicBool>,
@@ -168,6 +173,7 @@ pub async fn start_rpc_server_pair_with_handle(
         key_store_path,
         finalizer_mailbox,
         genesis_hash,
+        &namespace,
         #[cfg(feature = "permissioned")]
         paused,
     );

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -47,9 +47,11 @@ impl Default for RpcBodyLimits {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn start_rpc_server(
     finalizer_mailbox: FinalizerMailbox<MultisigScheme, Block>,
     key_store_path: String,
+    genesis_hash: [u8; 32],
     port: u16,
     admin_port: u16,
     body_limits: RpcBodyLimits,
@@ -59,6 +61,7 @@ pub async fn start_rpc_server(
     let rpc_impl = SummitRpcServer::new(
         key_store_path,
         finalizer_mailbox,
+        genesis_hash,
         #[cfg(feature = "permissioned")]
         paused,
     );
@@ -116,12 +119,14 @@ pub struct RpcHandles {
 pub async fn start_rpc_server_with_handle(
     finalizer_mailbox: FinalizerMailbox<MultisigScheme, Block>,
     key_store_path: String,
+    genesis_hash: [u8; 32],
     port: u16,
     #[cfg(feature = "permissioned")] paused: Arc<AtomicBool>,
 ) -> anyhow::Result<(ServerHandle, SocketAddr)> {
     let rpc_impl = SummitRpcServer::new(
         key_store_path,
         finalizer_mailbox,
+        genesis_hash,
         #[cfg(feature = "permissioned")]
         paused,
     );
@@ -154,6 +159,7 @@ pub async fn start_rpc_server_with_handle(
 pub async fn start_rpc_server_pair_with_handle(
     finalizer_mailbox: FinalizerMailbox<MultisigScheme, Block>,
     key_store_path: String,
+    genesis_hash: [u8; 32],
     port: u16,
     admin_port: u16,
     #[cfg(feature = "permissioned")] paused: Arc<AtomicBool>,
@@ -161,6 +167,7 @@ pub async fn start_rpc_server_pair_with_handle(
     let rpc_impl = SummitRpcServer::new(
         key_store_path,
         finalizer_mailbox,
+        genesis_hash,
         #[cfg(feature = "permissioned")]
         paused,
     );

--- a/rpc/src/server.rs
+++ b/rpc/src/server.rs
@@ -12,7 +12,7 @@ use crate::types::{
 use alloy_primitives::{Address, U256, hex::FromHex as _};
 use async_trait::async_trait;
 use commonware_codec::{DecodeExt as _, Encode as _};
-use commonware_cryptography::{Hasher as _, Sha256, Signer};
+use commonware_cryptography::Signer;
 use commonware_utils::from_hex_formatted;
 use jsonrpsee::core::RpcResult;
 use ssz::Encode as _;
@@ -24,7 +24,7 @@ use summit_finalizer::FinalizerMailbox;
 use summit_types::Block;
 use summit_types::scheme::MultisigScheme;
 use summit_types::{
-    KeyPaths, PROTOCOL_VERSION, PublicKey,
+    Digest, KeyPaths, PublicKey, deposit_signature_domain,
     execution_request::{DepositRequest, compute_deposit_data_root},
 };
 
@@ -32,6 +32,7 @@ use summit_types::{
 pub struct SummitRpcServer {
     key_store_path: String,
     finalizer_mailbox: FinalizerMailbox<MultisigScheme, Block>,
+    deposit_signature_domain: Digest,
     #[cfg(feature = "permissioned")]
     paused: Arc<AtomicBool>,
 }
@@ -40,11 +41,13 @@ impl SummitRpcServer {
     pub fn new(
         key_store_path: String,
         finalizer_mailbox: FinalizerMailbox<MultisigScheme, Block>,
+        genesis_hash: [u8; 32],
         #[cfg(feature = "permissioned")] paused: Arc<AtomicBool>,
     ) -> Self {
         Self {
             key_store_path,
             finalizer_mailbox,
+            deposit_signature_domain: deposit_signature_domain(genesis_hash),
             #[cfg(feature = "permissioned")]
             paused,
         }
@@ -337,8 +340,7 @@ impl SummitAdminApiServer for SummitRpcServer {
             index: 0,
         };
 
-        let protocol_version_digest = Sha256::hash(&PROTOCOL_VERSION.to_le_bytes());
-        let message = req.as_message(protocol_version_digest);
+        let message = req.as_message(self.deposit_signature_domain);
 
         let node_signature = node_priv_key.sign(&[], &message);
         let node_signature_bytes: [u8; 64] = node_signature

--- a/rpc/src/server.rs
+++ b/rpc/src/server.rs
@@ -42,12 +42,13 @@ impl SummitRpcServer {
         key_store_path: String,
         finalizer_mailbox: FinalizerMailbox<MultisigScheme, Block>,
         genesis_hash: [u8; 32],
+        namespace: &[u8],
         #[cfg(feature = "permissioned")] paused: Arc<AtomicBool>,
     ) -> Self {
         Self {
             key_store_path,
             finalizer_mailbox,
-            deposit_signature_domain: deposit_signature_domain(genesis_hash),
+            deposit_signature_domain: deposit_signature_domain(genesis_hash, namespace),
             #[cfg(feature = "permissioned")]
             paused,
         }

--- a/rpc/tests/integration_test.rs
+++ b/rpc/tests/integration_test.rs
@@ -11,6 +11,8 @@ use summit_rpc::{
 };
 use utils::{MockFinalizerState, create_test_finalizer_mailbox, create_test_keystore};
 
+const TEST_GENESIS_HASH: [u8; 32] = [7u8; 32];
+
 #[tokio::test]
 async fn test_health_endpoint() {
     use summit_rpc::SummitApiClient;
@@ -22,6 +24,7 @@ async fn test_health_endpoint() {
     let (handle, addr) = start_rpc_server_with_handle(
         mailbox,
         key_store_path,
+        TEST_GENESIS_HASH,
         0,
         #[cfg(feature = "permissioned")]
         Arc::new(AtomicBool::new(false)),
@@ -54,6 +57,7 @@ async fn test_get_latest_height() {
     let (handle, addr) = start_rpc_server_with_handle(
         mailbox,
         key_store_path,
+        TEST_GENESIS_HASH,
         0,
         #[cfg(feature = "permissioned")]
         Arc::new(AtomicBool::new(false)),
@@ -86,6 +90,7 @@ async fn test_get_latest_epoch() {
     let (handle, addr) = start_rpc_server_with_handle(
         mailbox,
         key_store_path,
+        TEST_GENESIS_HASH,
         0,
         #[cfg(feature = "permissioned")]
         Arc::new(AtomicBool::new(false)),
@@ -114,6 +119,7 @@ async fn test_validator_balance_not_found() {
     let (handle, addr) = start_rpc_server_with_handle(
         mailbox,
         key_store_path,
+        TEST_GENESIS_HASH,
         0,
         #[cfg(feature = "permissioned")]
         Arc::new(AtomicBool::new(false)),
@@ -146,6 +152,7 @@ async fn test_get_public_keys() {
     let (handle, addr) = start_rpc_server_with_handle(
         mailbox,
         key_store_path,
+        TEST_GENESIS_HASH,
         0,
         #[cfg(feature = "permissioned")]
         Arc::new(AtomicBool::new(false)),
@@ -271,6 +278,7 @@ async fn test_get_minimum_stake() {
     let (handle, addr) = start_rpc_server_with_handle(
         mailbox,
         key_store_path,
+        TEST_GENESIS_HASH,
         0,
         #[cfg(feature = "permissioned")]
         Arc::new(AtomicBool::new(false)),
@@ -299,9 +307,15 @@ async fn test_pause_rejects_invalid_signature() {
     let key_store_path = temp_dir.path().to_str().unwrap().to_string();
     let paused = Arc::new(AtomicBool::new(false));
 
-    let (handle, addr) = start_rpc_server_with_handle(mailbox, key_store_path, 0, paused.clone())
-        .await
-        .unwrap();
+    let (handle, addr) = start_rpc_server_with_handle(
+        mailbox,
+        key_store_path,
+        TEST_GENESIS_HASH,
+        0,
+        paused.clone(),
+    )
+    .await
+    .unwrap();
 
     let url = format!("http://{}", addr);
     let client = HttpClientBuilder::default().build(&url).unwrap();
@@ -336,9 +350,15 @@ async fn test_pause_rejects_stale_timestamp() {
     let key_store_path = temp_dir.path().to_str().unwrap().to_string();
     let paused = Arc::new(AtomicBool::new(false));
 
-    let (handle, addr) = start_rpc_server_with_handle(mailbox, key_store_path, 0, paused.clone())
-        .await
-        .unwrap();
+    let (handle, addr) = start_rpc_server_with_handle(
+        mailbox,
+        key_store_path,
+        TEST_GENESIS_HASH,
+        0,
+        paused.clone(),
+    )
+    .await
+    .unwrap();
 
     let url = format!("http://{}", addr);
     let client = HttpClientBuilder::default().build(&url).unwrap();
@@ -365,10 +385,15 @@ async fn test_is_paused_open_access() {
     let temp_dir = create_test_keystore().unwrap();
     let key_store_path = temp_dir.path().to_str().unwrap().to_string();
 
-    let (handle, addr) =
-        start_rpc_server_with_handle(mailbox, key_store_path, 0, Arc::new(AtomicBool::new(false)))
-            .await
-            .unwrap();
+    let (handle, addr) = start_rpc_server_with_handle(
+        mailbox,
+        key_store_path,
+        TEST_GENESIS_HASH,
+        0,
+        Arc::new(AtomicBool::new(false)),
+    )
+    .await
+    .unwrap();
 
     let url = format!("http://{}", addr);
     let client = HttpClientBuilder::default().build(&url).unwrap();
@@ -393,6 +418,7 @@ async fn test_get_maximum_stake() {
     let (handle, addr) = start_rpc_server_with_handle(
         mailbox,
         key_store_path,
+        TEST_GENESIS_HASH,
         0,
         #[cfg(feature = "permissioned")]
         Arc::new(AtomicBool::new(false)),
@@ -428,6 +454,7 @@ async fn test_get_deposit_signature_not_on_public_listener() {
     let handles = start_rpc_server_pair_with_handle(
         mailbox,
         key_store_path,
+        TEST_GENESIS_HASH,
         0,
         0,
         #[cfg(feature = "permissioned")]

--- a/rpc/tests/integration_test.rs
+++ b/rpc/tests/integration_test.rs
@@ -25,6 +25,7 @@ async fn test_health_endpoint() {
         mailbox,
         key_store_path,
         TEST_GENESIS_HASH,
+        b"_SUMMIT".to_vec(),
         0,
         #[cfg(feature = "permissioned")]
         Arc::new(AtomicBool::new(false)),
@@ -58,6 +59,7 @@ async fn test_get_latest_height() {
         mailbox,
         key_store_path,
         TEST_GENESIS_HASH,
+        b"_SUMMIT".to_vec(),
         0,
         #[cfg(feature = "permissioned")]
         Arc::new(AtomicBool::new(false)),
@@ -91,6 +93,7 @@ async fn test_get_latest_epoch() {
         mailbox,
         key_store_path,
         TEST_GENESIS_HASH,
+        b"_SUMMIT".to_vec(),
         0,
         #[cfg(feature = "permissioned")]
         Arc::new(AtomicBool::new(false)),
@@ -120,6 +123,7 @@ async fn test_validator_balance_not_found() {
         mailbox,
         key_store_path,
         TEST_GENESIS_HASH,
+        b"_SUMMIT".to_vec(),
         0,
         #[cfg(feature = "permissioned")]
         Arc::new(AtomicBool::new(false)),
@@ -153,6 +157,7 @@ async fn test_get_public_keys() {
         mailbox,
         key_store_path,
         TEST_GENESIS_HASH,
+        b"_SUMMIT".to_vec(),
         0,
         #[cfg(feature = "permissioned")]
         Arc::new(AtomicBool::new(false)),
@@ -279,6 +284,7 @@ async fn test_get_minimum_stake() {
         mailbox,
         key_store_path,
         TEST_GENESIS_HASH,
+        b"_SUMMIT".to_vec(),
         0,
         #[cfg(feature = "permissioned")]
         Arc::new(AtomicBool::new(false)),
@@ -311,6 +317,7 @@ async fn test_pause_rejects_invalid_signature() {
         mailbox,
         key_store_path,
         TEST_GENESIS_HASH,
+        b"_SUMMIT".to_vec(),
         0,
         paused.clone(),
     )
@@ -354,6 +361,7 @@ async fn test_pause_rejects_stale_timestamp() {
         mailbox,
         key_store_path,
         TEST_GENESIS_HASH,
+        b"_SUMMIT".to_vec(),
         0,
         paused.clone(),
     )
@@ -389,6 +397,7 @@ async fn test_is_paused_open_access() {
         mailbox,
         key_store_path,
         TEST_GENESIS_HASH,
+        b"_SUMMIT".to_vec(),
         0,
         Arc::new(AtomicBool::new(false)),
     )
@@ -419,6 +428,7 @@ async fn test_get_maximum_stake() {
         mailbox,
         key_store_path,
         TEST_GENESIS_HASH,
+        b"_SUMMIT".to_vec(),
         0,
         #[cfg(feature = "permissioned")]
         Arc::new(AtomicBool::new(false)),
@@ -455,6 +465,7 @@ async fn test_get_deposit_signature_not_on_public_listener() {
         mailbox,
         key_store_path,
         TEST_GENESIS_HASH,
+        b"_SUMMIT".to_vec(),
         0,
         0,
         #[cfg(feature = "permissioned")]

--- a/types/src/execution_request.rs
+++ b/types/src/execution_request.rs
@@ -690,8 +690,9 @@ mod tests {
             index: 42u64,
         };
 
-        let source_domain = crate::deposit_signature_domain([1u8; 32]);
-        let target_domain = crate::deposit_signature_domain([2u8; 32]);
+        let namespace = b"summit-network";
+        let source_domain = crate::deposit_signature_domain([1u8; 32], namespace);
+        let target_domain = crate::deposit_signature_domain([2u8; 32], namespace);
         assert_ne!(source_domain, target_domain);
 
         let source_message = deposit.as_message(source_domain);
@@ -709,6 +710,59 @@ mod tests {
                 .consensus_pubkey
                 .verify(&[], &source_message, &consensus_signature)
         );
+        assert!(
+            !deposit
+                .node_pubkey
+                .verify(&[], &target_message, &node_signature)
+        );
+        assert!(
+            !deposit
+                .consensus_pubkey
+                .verify(&[], &target_message, &consensus_signature)
+        );
+    }
+
+    #[test]
+    fn test_deposit_signature_domain_binds_deposit_to_namespace() {
+        // Two Summit deployments can share an EL genesis hash yet be distinct
+        // networks (different namespace). A deposit signature authorized for one
+        // namespace must not verify under another, even with an identical genesis
+        // hash and identical deposit fields.
+        let node_private_key = ed25519::PrivateKey::from_seed(1);
+        let consensus_private_key = bls12381::PrivateKey::from_seed(2);
+        let deposit = DepositRequest {
+            node_pubkey: node_private_key.public_key(),
+            consensus_pubkey: consensus_private_key.public_key(),
+            withdrawal_credentials: [3u8; 32],
+            amount: 32000000000u64,
+            node_signature: [0u8; 64],
+            consensus_signature: [0u8; 96],
+            index: 42u64,
+        };
+
+        // Same genesis hash, different namespace.
+        let genesis_hash = [7u8; 32];
+        let source_domain = crate::deposit_signature_domain(genesis_hash, b"summit-network-a");
+        let target_domain = crate::deposit_signature_domain(genesis_hash, b"summit-network-b");
+        assert_ne!(source_domain, target_domain);
+
+        let source_message = deposit.as_message(source_domain);
+        let target_message = deposit.as_message(target_domain);
+        let node_signature = node_private_key.sign(&[], &source_message);
+        let consensus_signature = consensus_private_key.sign(&[], &source_message);
+
+        // Valid under the originating namespace...
+        assert!(
+            deposit
+                .node_pubkey
+                .verify(&[], &source_message, &node_signature)
+        );
+        assert!(
+            deposit
+                .consensus_pubkey
+                .verify(&[], &source_message, &consensus_signature)
+        );
+        // ...but rejected under a different namespace despite the same genesis hash.
         assert!(
             !deposit
                 .node_pubkey

--- a/types/src/execution_request.rs
+++ b/types/src/execution_request.rs
@@ -651,7 +651,7 @@ mod tests {
     use super::*;
     use bytes::BytesMut;
     use commonware_codec::{ReadExt, Write};
-    use commonware_cryptography::Signer;
+    use commonware_cryptography::{Signer, Verifier as _, ed25519};
 
     #[test]
     fn test_deposit_request_codec() {
@@ -674,6 +674,51 @@ mod tests {
         // Test Read
         let decoded = DepositRequest::read(&mut buf.as_ref()).unwrap();
         assert_eq!(decoded, deposit);
+    }
+
+    #[test]
+    fn test_deposit_signature_domain_binds_deposit_to_genesis_hash() {
+        let node_private_key = ed25519::PrivateKey::from_seed(1);
+        let consensus_private_key = bls12381::PrivateKey::from_seed(2);
+        let deposit = DepositRequest {
+            node_pubkey: node_private_key.public_key(),
+            consensus_pubkey: consensus_private_key.public_key(),
+            withdrawal_credentials: [3u8; 32],
+            amount: 32000000000u64,
+            node_signature: [0u8; 64],
+            consensus_signature: [0u8; 96],
+            index: 42u64,
+        };
+
+        let source_domain = crate::deposit_signature_domain([1u8; 32]);
+        let target_domain = crate::deposit_signature_domain([2u8; 32]);
+        assert_ne!(source_domain, target_domain);
+
+        let source_message = deposit.as_message(source_domain);
+        let target_message = deposit.as_message(target_domain);
+        let node_signature = node_private_key.sign(&[], &source_message);
+        let consensus_signature = consensus_private_key.sign(&[], &source_message);
+
+        assert!(
+            deposit
+                .node_pubkey
+                .verify(&[], &source_message, &node_signature)
+        );
+        assert!(
+            deposit
+                .consensus_pubkey
+                .verify(&[], &source_message, &consensus_signature)
+        );
+        assert!(
+            !deposit
+                .node_pubkey
+                .verify(&[], &target_message, &node_signature)
+        );
+        assert!(
+            !deposit
+                .consensus_pubkey
+                .verify(&[], &target_message, &consensus_signature)
+        );
     }
 
     #[test]

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -44,11 +44,17 @@ pub type Activity = CActivity<Signature, Digest>;
 pub const PROTOCOL_VERSION: u32 = 1;
 const DEPOSIT_DOMAIN_TAG: &[u8] = b"summit-deposit-v1";
 
-pub fn deposit_signature_domain(genesis_hash: [u8; 32]) -> Digest {
-    let mut domain_data = Vec::with_capacity(DEPOSIT_DOMAIN_TAG.len() + 4 + 32);
+/// Domain for deposit-authorization signatures, bound to the full Summit
+/// deployment boundary: the EL genesis hash AND the Summit `namespace`.
+pub fn deposit_signature_domain(genesis_hash: [u8; 32], namespace: &[u8]) -> Digest {
+    let mut domain_data =
+        Vec::with_capacity(DEPOSIT_DOMAIN_TAG.len() + 4 + 32 + 4 + namespace.len());
     domain_data.extend_from_slice(DEPOSIT_DOMAIN_TAG);
     domain_data.extend_from_slice(&PROTOCOL_VERSION.to_le_bytes());
     domain_data.extend_from_slice(&genesis_hash);
+    // Length-prefix the variable-length namespace so the domain is unambiguous.
+    domain_data.extend_from_slice(&(namespace.len() as u32).to_le_bytes());
+    domain_data.extend_from_slice(namespace);
     Sha256::hash(&domain_data)
 }
 

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -29,6 +29,7 @@ pub mod withdrawal;
 use alloy_primitives::Address;
 use alloy_rpc_types_engine::ForkchoiceState;
 pub use block::*;
+use commonware_cryptography::{Hasher as _, Sha256};
 pub use engine_client::*;
 pub use genesis::*;
 pub use header::*;
@@ -41,6 +42,15 @@ pub type Digest = commonware_cryptography::sha256::Digest;
 pub type Activity = CActivity<Signature, Digest>;
 
 pub const PROTOCOL_VERSION: u32 = 1;
+const DEPOSIT_DOMAIN_TAG: &[u8] = b"summit-deposit-v1";
+
+pub fn deposit_signature_domain(genesis_hash: [u8; 32]) -> Digest {
+    let mut domain_data = Vec::with_capacity(DEPOSIT_DOMAIN_TAG.len() + 4 + 32);
+    domain_data.extend_from_slice(DEPOSIT_DOMAIN_TAG);
+    domain_data.extend_from_slice(&PROTOCOL_VERSION.to_le_bytes());
+    domain_data.extend_from_slice(&genesis_hash);
+    Sha256::hash(&domain_data)
+}
 
 /// Auxiliary data needed for block construction
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Addresses https://github.com/SeismicSystems/summit/issues/241.

Changes:
  - Add summit-deposit-v1 || PROTOCOL_VERSION || genesis_hash deposit domain.
  - Use the domain for RPC/admin signing and finalizer verification.
  - Update local deposit tooling and tests/helpers.
  - Add regression coverage for cross-genesis signature rejection.
  
  
Note: once this is merged, we have to update seismic-viem and the Python client.