### PR TITLE
fix: force verifier-only schemes in observer mode

### DIFF
--- a/node/src/args.rs
+++ b/node/src/args.rs
@@ -649,7 +649,7 @@ where
         authenticated::discovery::Network::new(context.with_label("network"), p2p_cfg);
 
     let oracle = DiscoveryOracle::new(oracle);
-    let config = EngineConfig::get_engine_config(
+    let mut config = EngineConfig::get_engine_config(
         engine_client,
         oracle,
         key_store,
@@ -661,6 +661,7 @@ where
         checkpoint_finalized_header,
     )
     .unwrap();
+    config.force_verifier_only = flags.observer.is_some();
 
     let pending_limit = Quota::per_second(NonZeroU32::new(512).unwrap());
     let pending = network.register(PENDING_CHANNEL, pending_limit, MESSAGE_BACKLOG);

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -58,6 +58,7 @@ pub struct EngineConfig<C: EngineClient, S: Signer, O: NetworkOracle<S::PublicKe
     pub checkpoint_last_block: Option<Block>,
     pub checkpoint_finalized_header: Option<FinalizedHeader<MultisigScheme>>,
     pub blocks_per_epoch: u64,
+    pub force_verifier_only: bool,
 }
 
 impl<C: EngineClient, S: Signer, O: NetworkOracle<S::PublicKey>> EngineConfig<C, S, O> {
@@ -101,6 +102,7 @@ impl<C: EngineClient, S: Signer, O: NetworkOracle<S::PublicKey>> EngineConfig<C,
             checkpoint_last_block,
             checkpoint_finalized_header,
             blocks_per_epoch: genesis.blocks_per_epoch,
+            force_verifier_only: false,
         })
     }
 }

--- a/node/src/engine.rs
+++ b/node/src/engine.rs
@@ -130,11 +130,14 @@ where
             BUFFER_POOL_CAPACITY,
         );
 
-        let encoded = cfg.key_store.consensus_key.encode();
-        let private_scalar = group::Private::decode(&mut encoded.as_ref())
-            .expect("failed to extract scalar from private key");
-        let scheme_provider: SummitSchemeProvider =
-            SummitSchemeProvider::new(private_scalar, cfg.namespace.as_bytes().to_vec());
+        let scheme_provider = if cfg.force_verifier_only {
+            SummitSchemeProvider::verifier_only(cfg.namespace.as_bytes().to_vec())
+        } else {
+            let encoded = cfg.key_store.consensus_key.encode();
+            let private_scalar = group::Private::decode(&mut encoded.as_ref())
+                .expect("failed to extract scalar from private key");
+            SummitSchemeProvider::new(private_scalar, cfg.namespace.as_bytes().to_vec())
+        };
 
         let cancellation_token = CancellationToken::new();
         #[cfg(feature = "permissioned")]

--- a/node/src/test_harness/common.rs
+++ b/node/src/test_harness/common.rs
@@ -658,6 +658,7 @@ where
         checkpoint_last_block: None,
         checkpoint_finalized_header: None,
         blocks_per_epoch: DEFAULT_BLOCKS_PER_EPOCH,
+        force_verifier_only: false,
     }
 }
 

--- a/node/src/tests/observer.rs
+++ b/node/src/tests/observer.rs
@@ -69,6 +69,7 @@ fn test_observer_reaches_end_height() {
 
         // Derive the observer's p2p identity from validator[0]'s master key.
         let master_priv_key = validator_key_stores[0].node_key.clone();
+        let master_consensus_key = validator_key_stores[0].consensus_key.clone();
         let master_pub_key = master_priv_key.public_key();
         let observer_signer = ExtPrivateKey::derive_child_signer(&master_priv_key, observer_index);
         let observer_pubkey = observer_signer.public_key();
@@ -118,18 +119,15 @@ fn test_observer_reaches_end_height() {
             engine.start(pending, recovered, resolver, orchestrator, broadcast);
         }
 
-        // Build the observer engine: ExtPrivateKey signer + throwaway BLS key.
-        // Its node pubkey (derived) is NOT in the validator `participants` list,
-        // so Simplex won't treat it as a participant; it follows the chain only.
+        // Build the observer engine from a validator keystore. The observer must
+        // still run verifier-only consensus even though the BLS key can sign.
         let observer_uid = format!("observer_{observer_pubkey}");
         let observer_engine_client = engine_client_network.create_client(observer_uid.clone());
-        let mut observer_rng = StdRng::seed_from_u64(n_validators as u64 + 100);
-        let observer_consensus_key = bls12381::PrivateKey::random(&mut observer_rng);
         let observer_key_store = KeyStore {
             node_key: observer_signer,
-            consensus_key: observer_consensus_key,
+            consensus_key: master_consensus_key,
         };
-        let observer_config = get_default_engine_config(
+        let mut observer_config = get_default_engine_config(
             observer_engine_client,
             SimulatedOracle::new(oracle.clone()),
             observer_uid.clone(),
@@ -139,6 +137,7 @@ fn test_observer_reaches_end_height() {
             validators.clone(),
             initial_state.clone(),
         );
+        observer_config.force_verifier_only = true;
         let observer_engine = Engine::new(context.with_label(&observer_uid), observer_config).await;
         let (pending, recovered, resolver, orchestrator, broadcast) =
             registrations.remove(&observer_pubkey).unwrap();

--- a/types/src/scheme.rs
+++ b/types/src/scheme.rs
@@ -41,7 +41,7 @@ pub trait SchemeProvider<D: Digest>: Clone + Send + Sync + 'static {
 pub struct SummitSchemeProvider {
     #[allow(clippy::type_complexity)]
     schemes: Arc<Mutex<HashMap<Epoch, Arc<MultisigScheme>>>>,
-    bls_private_key: group::Private,
+    bls_private_key: Option<group::Private>,
     namespace: Vec<u8>,
 }
 
@@ -49,7 +49,15 @@ impl SummitSchemeProvider {
     pub fn new(bls_private_key: group::Private, namespace: Vec<u8>) -> Self {
         Self {
             schemes: Arc::new(Mutex::new(HashMap::new())),
-            bls_private_key,
+            bls_private_key: Some(bls_private_key),
+            namespace,
+        }
+    }
+
+    pub fn verifier_only(namespace: Vec<u8>) -> Self {
+        Self {
+            schemes: Arc::new(Mutex::new(HashMap::new())),
+            bls_private_key: None,
             namespace,
         }
     }
@@ -119,28 +127,36 @@ impl<D: Digest> EpochSchemeProvider<D> for SummitSchemeProvider {
             .try_collect()
             .expect("failed to build BiMap");
 
-        // Try to create a signer if our private key is in the participant set.
-        // If not, fall back to verifier mode (observer/non-validator).
-        match MultisigScheme::signer(
-            &self.namespace,
-            participants.clone(),
-            self.bls_private_key.clone(),
-        ) {
-            Some(scheme) => {
-                tracing::debug!(
-                    epoch = transition.epoch.get(),
-                    "created signing scheme for epoch (active validator)"
-                );
-                scheme
+        if let Some(bls_private_key) = &self.bls_private_key {
+            // Try to create a signer if our private key is in the participant set.
+            // If not, fall back to verifier mode (observer/non-validator).
+            match MultisigScheme::signer(
+                &self.namespace,
+                participants.clone(),
+                bls_private_key.clone(),
+            ) {
+                Some(scheme) => {
+                    tracing::debug!(
+                        epoch = transition.epoch.get(),
+                        "created signing scheme for epoch (active validator)"
+                    );
+                    return scheme;
+                }
+                None => {
+                    tracing::info!(
+                        epoch = transition.epoch.get(),
+                        "private key not in validator set, entering verifier mode"
+                    );
+                }
             }
-            None => {
-                tracing::info!(
-                    epoch = transition.epoch.get(),
-                    "private key not in validator set, entering verifier mode (observer only)"
-                );
-                MultisigScheme::verifier(&self.namespace, participants)
-            }
+        } else {
+            tracing::info!(
+                epoch = transition.epoch.get(),
+                "consensus signing disabled, entering verifier mode"
+            );
         }
+
+        MultisigScheme::verifier(&self.namespace, participants)
     }
 }
 
@@ -150,4 +166,69 @@ pub struct EpochTransition<BLS = crate::bls12381::PublicKey> {
     pub epoch: Epoch,
     /// The public keys of the validator set
     pub validator_keys: Vec<(crate::PublicKey, BLS)>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Digest, bls12381};
+    use commonware_consensus::simplex::types::{Notarize, Proposal};
+    use commonware_consensus::types::{Round, View};
+    use commonware_cryptography::certificate::Scheme as _;
+
+    const NAMESPACE: &[u8] = b"test-scheme";
+
+    fn private_scalar(private_key: &bls12381::PrivateKey) -> group::Private {
+        let encoded = private_key.encode();
+        group::Private::decode(&mut encoded.as_ref()).expect("valid BLS private key")
+    }
+
+    fn sample_proposal(epoch: Epoch) -> Proposal<Digest> {
+        Proposal {
+            round: Round::new(epoch, View::new(1)),
+            parent: View::new(0),
+            payload: Digest::from([1u8; 32]),
+        }
+    }
+
+    #[test]
+    fn signing_provider_signs_when_key_matches_validator_set() {
+        let node_key = ed25519::PrivateKey::from_seed(1);
+        let consensus_key = bls12381::PrivateKey::from_seed(2);
+        let epoch = Epoch::new(3);
+        let transition = EpochTransition {
+            epoch,
+            validator_keys: vec![(node_key.public_key(), consensus_key.public_key())],
+        };
+        let provider =
+            SummitSchemeProvider::new(private_scalar(&consensus_key), NAMESPACE.to_vec());
+
+        let scheme = <SummitSchemeProvider as EpochSchemeProvider<Digest>>::scheme_for_epoch(
+            &provider,
+            &transition,
+        );
+
+        assert!(scheme.me().is_some());
+        assert!(Notarize::sign(&scheme, sample_proposal(epoch)).is_some());
+    }
+
+    #[test]
+    fn verifier_only_provider_never_signs_with_matching_validator_key() {
+        let node_key = ed25519::PrivateKey::from_seed(1);
+        let consensus_key = bls12381::PrivateKey::from_seed(2);
+        let epoch = Epoch::new(3);
+        let transition = EpochTransition {
+            epoch,
+            validator_keys: vec![(node_key.public_key(), consensus_key.public_key())],
+        };
+        let provider = SummitSchemeProvider::verifier_only(NAMESPACE.to_vec());
+
+        let scheme = <SummitSchemeProvider as EpochSchemeProvider<Digest>>::scheme_for_epoch(
+            &provider,
+            &transition,
+        );
+
+        assert!(scheme.me().is_none());
+        assert!(Notarize::sign(&scheme, sample_proposal(epoch)).is_none());
+    }
 }


### PR DESCRIPTION
Addresses https://github.com/SeismicSystems/summit/issues/250

Changes:
  - Force observer mode to use verifier-only consensus schemes, even when started from a validator keystore.
  - Add tests for verifier-only signing behavior and observer catch-up with validator BLS material.