### PR TITLE
fix: prune stale fork descendants on finalization

### DIFF
--- a/finalizer/src/actor.rs
+++ b/finalizer/src/actor.rs
@@ -914,7 +914,8 @@ impl<
         // execute a non-canonical block onto canonical state.
         let canonical_height = self.canonical_state.get_latest_height();
         let canonical_head = self.canonical_state.get_head_digest();
-        if height == canonical_height + 1 && block.parent() != canonical_head {
+
+        if height != canonical_height + 1 || block.parent() != canonical_head {
             error!(
                 target: "critical",
                 height,

--- a/finalizer/src/actor.rs
+++ b/finalizer/src/actor.rs
@@ -251,6 +251,7 @@ fn queue_deposit_refund(
 #[derive(Clone, Debug)]
 struct ForkState {
     block_digest: Digest,
+    parent_digest: Digest,
     consensus_state: ConsensusState,
 }
 
@@ -358,6 +359,12 @@ pub struct Finalizer<
 
     // Fork states (notarized but not yet finalized)
     fork_states: BTreeMap<u64, BTreeMap<Digest, ForkState>>,
+
+    // Tombstones for fork states that were executed before a conflicting
+    // ancestor finalized. Later NotifyAtHeight calls for these digests should
+    // fail immediately instead of being stored as waiters for a block that can
+    // no longer become canonical-compatible.
+    dead_fork_digests: HashSet<(u64, Digest)>,
 
     // Orphaned notarized blocks that arrived before their parent
     orphaned_blocks: BTreeMap<u64, HashMap<Digest, Vec<Block>>>,
@@ -496,6 +503,7 @@ impl<
                 db,
                 canonical_state: state,
                 fork_states: BTreeMap::new(),
+                dead_fork_digests: HashSet::new(),
                 orphaned_blocks: BTreeMap::new(),
                 pending_finalized: VecDeque::new(),
                 pending_notarized: VecDeque::new(),
@@ -743,7 +751,9 @@ impl<
                             } else {
                                 // If the block was already executed on one of the forks,
                                 // we send the notification immediately, otherwise we store the request
-                                if self.fork_states.get(&height)
+                                if self.dead_fork_digests.contains(&(height, block_digest)) {
+                                    let _ = response.send(false);
+                                } else if self.fork_states.get(&height)
                                         .map(|forks| forks.contains_key(&block_digest))
                                         .unwrap_or(false) {
                                     let _ = response.send(true);
@@ -1101,6 +1111,9 @@ impl<
         // Prune fork states at or below finalized height
         let total_forks = self.fork_states.len();
         self.fork_states.retain(|&h, _| h > height);
+        self.prune_fork_states_not_descending_from(height, block_digest);
+        self.dead_fork_digests
+            .retain(|(dead_height, _)| *dead_height > height);
         let remaining_forks = self.fork_states.len();
         let num_pruned_forks = total_forks - remaining_forks;
         if num_pruned_forks > 0 {
@@ -1452,6 +1465,14 @@ impl<
                 );
                 continue;
             }
+            if self.dead_fork_digests.contains(&(height, block_digest)) {
+                debug!(
+                    height,
+                    ?block_digest,
+                    "ignoring notarized block on dead fork"
+                );
+                continue;
+            }
             if self
                 .fork_states
                 .get(&height)
@@ -1608,6 +1629,7 @@ impl<
                 block_digest,
                 ForkState {
                     block_digest,
+                    parent_digest,
                     consensus_state: fork_state.clone(),
                 },
             );
@@ -1739,7 +1761,53 @@ impl<
         }
     }
 
+    fn prune_fork_states_not_descending_from(&mut self, height: u64, block_digest: Digest) {
+        let heights: Vec<u64> = self
+            .fork_states
+            .range((height + 1)..)
+            .map(|(&height, _)| height)
+            .collect();
+        let mut live_parents = HashSet::from([block_digest]);
+        let mut empty_heights = Vec::new();
+        let mut dead_forks = Vec::new();
+
+        for fork_height in heights {
+            let Some(forks) = self.fork_states.get_mut(&fork_height) else {
+                continue;
+            };
+
+            forks.retain(|&fork_digest, fork_state| {
+                let descends_from_canonical = live_parents.contains(&fork_state.parent_digest);
+                if !descends_from_canonical {
+                    dead_forks.push((fork_height, fork_digest));
+                }
+                descends_from_canonical
+            });
+            live_parents = forks.keys().copied().collect();
+
+            if forks.is_empty() {
+                empty_heights.push(fork_height);
+            }
+        }
+
+        for fork_height in empty_heights {
+            self.fork_states.remove(&fork_height);
+        }
+        for (fork_height, fork_digest) in dead_forks {
+            self.dead_fork_digests.insert((fork_height, fork_digest));
+            if let Some(senders) = self
+                .pending_height_notifys
+                .remove(&(fork_height, fork_digest))
+            {
+                for sender in senders {
+                    let _ = sender.send(false);
+                }
+            }
+        }
+    }
+
     fn height_notify_executed(&mut self, height: u64, block_digest: Digest) {
+        // Notify only waiters for this specific (height, digest) pair
         if let Some(senders) = self.pending_height_notifys.remove(&(height, block_digest)) {
             for sender in senders {
                 let _ = sender.send(true); // Ignore if receiver dropped

--- a/finalizer/src/actor.rs
+++ b/finalizer/src/actor.rs
@@ -907,6 +907,37 @@ impl<
             return Ok(HandleOutcome::Applied);
         }
 
+        // Simplex guarantees the finalized chain is linear, so the
+        // next finalized block must extend our canonical head. A mismatch means a
+        // consensus safety violation (>=1/3 Byzantine finalizing a block conflicting
+        // with an already-finalized ancestor) or local divergence. Halt rather than
+        // execute a non-canonical block onto canonical state.
+        let canonical_height = self.canonical_state.get_latest_height();
+        let canonical_head = self.canonical_state.get_head_digest();
+        if height == canonical_height + 1 && block.parent() != canonical_head {
+            error!(
+                target: "critical",
+                height,
+                ?block_digest,
+                block_parent = ?block.parent(),
+                ?canonical_head,
+                canonical_height,
+                "finalized block does not extend canonical head; refusing to apply"
+            );
+            #[cfg(feature = "prom")]
+            counter!(
+                "critical_errors_total",
+                "reason" => "finalized_block_non_canonical",
+                "severity" => "critical"
+            )
+            .increment(1);
+            return Err(anyhow!(
+                "finalized block at height {height} (digest {block_digest:?}) has parent {:?} \
+                 but canonical head is {canonical_head:?}; consensus safety violation or divergence",
+                block.parent()
+            ));
+        }
+
         // Try to find the fork state for this block (if it was notarized before finalization)
         if let Some(fork_state) = self
             .fork_states

--- a/finalizer/src/tests/fork_handling.rs
+++ b/finalizer/src/tests/fork_handling.rs
@@ -1039,6 +1039,129 @@ fn test_losing_fork_descendant_rejected_after_conflicting_ancestor_finalizes() {
 }
 
 #[test]
+fn test_finalized_dead_fork_descendant_out_of_sequence_halts() {
+    // Defense-in-depth for the finalized-block path: a finalized block must
+    // extend the canonical head at exactly canonical_height + 1. If a descendant
+    // of a losing fork is delivered as a *finalized* block out of sequence (which
+    // can only arise from a consensus safety violation plus out-of-order
+    // delivery — the syncer never delivers finalized blocks with a gap), the
+    // finalizer must halt rather than execute it onto canonical state.
+    //
+    // Scenario:
+    // 1. Notarize A1 -> A2 -> A3 (heights 1, 2, 3; all in fork_states).
+    // 2. Finalize conflicting B1 at height 1 (canonical -> 1; A1/A2/A3 pruned).
+    // 3. Deliver A3 (height 3) as a FinalizedBlock while canonical is 1.
+    // 4. The strict guard rejects it (3 != 1 + 1) and triggers coordinated
+    //    shutdown; canonical never advances to 3.
+
+    let cfg = deterministic::Config::default().with_seed(51);
+    let executor = Runner::from(cfg);
+    executor.start(|context| async move {
+        let genesis_hash = [0x51u8; 32];
+        let initial_state = create_test_initial_state(genesis_hash, NonZeroU64::new(10).unwrap());
+
+        let (orchestrator_tx, _orchestrator_rx) = futures_mpsc::channel(100);
+        let orchestrator_mailbox = summit_orchestrator::Mailbox::new(orchestrator_tx);
+
+        let node_key = ed25519::PrivateKey::from_seed(0);
+
+        // Hold a clone so we can observe the coordinated shutdown the guard triggers.
+        let cancellation_token = CancellationToken::new();
+        let token = cancellation_token.clone();
+
+        let finalizer_cfg = FinalizerConfig::<MockEngineClient, MockNetworkOracle, MinPk> {
+            mailbox_size: 100,
+            db_prefix: "test_finalized_dead_fork_out_of_sequence".to_string(),
+            engine_client: MockEngineClient::new(),
+            oracle: MockNetworkOracle,
+            protocol_consts: ProtocolConsts {
+                validator_num_warm_up_epochs: 2,
+                validator_withdrawal_num_epochs: 2,
+            },
+
+            page_cache: CacheRef::from_pooler(
+                &context,
+                std::num::NonZero::new(4096).unwrap(),
+                NZUsize!(100),
+            ),
+            genesis_hash,
+            initial_state,
+            protocol_version: 1,
+            node_public_key: node_key.public_key(),
+            cancellation_token,
+            drain_interval: Duration::from_millis(100),
+            buffered_blocks_warn_threshold: 100,
+            pending_notarized_max: 1000,
+            namespace: Vec::new(),
+            _variant_marker: PhantomData,
+        };
+
+        let (finalizer, _state, mut mailbox, _state_query) =
+            Finalizer::<_, MockEngineClient, MockNetworkOracle, ed25519::PrivateKey, MinPk>::new(
+                context.with_label("finalizer"),
+                finalizer_cfg,
+            )
+            .await;
+
+        let _handle = finalizer.start(orchestrator_mailbox);
+        context.sleep(Duration::from_millis(100)).await;
+
+        let genesis_block = Block::genesis(genesis_hash);
+        let genesis_digest = genesis_block.digest();
+
+        // Losing fork A1 -> A2 -> A3.
+        let block_a1 = create_test_block(genesis_digest, 1, 2, 9001);
+        let block_a1_digest = block_a1.digest();
+        let block_a2 = create_test_block(block_a1_digest, 2, 3, 9002);
+        let block_a2_digest = block_a2.digest();
+        let block_a3 = create_test_block(block_a2_digest, 3, 4, 9003);
+        // Conflicting winner B1 at height 1.
+        let block_b1 = create_test_block(genesis_digest, 1, 5, 9004);
+        assert_ne!(block_a1_digest, block_b1.digest());
+
+        mailbox
+            .report(Update::NotarizedBlock(block_a1.clone()))
+            .await;
+        mailbox
+            .report(Update::NotarizedBlock(block_a2.clone()))
+            .await;
+        mailbox
+            .report(Update::NotarizedBlock(block_a3.clone()))
+            .await;
+        context.sleep(Duration::from_millis(100)).await;
+
+        // Finalize the conflicting ancestor B1; this prunes the A-fork and
+        // advances canonical to height 1.
+        let (ack, _waiter) = Exact::handle();
+        mailbox
+            .report(Update::FinalizedBlock((block_b1.clone(), None), ack))
+            .await;
+        context.sleep(Duration::from_millis(100)).await;
+        assert_eq!(mailbox.get_latest_height().await, 1);
+        assert!(
+            !token.is_cancelled(),
+            "finalizer must still be running after a normal sequential finalization"
+        );
+
+        // Deliver the pruned descendant A3 (height 3) as a finalized block while
+        // canonical is only at height 1. The strict guard must reject it.
+        let (ack, _waiter) = Exact::handle();
+        mailbox
+            .report(Update::FinalizedBlock((block_a3.clone(), None), ack))
+            .await;
+        context.sleep(Duration::from_millis(100)).await;
+
+        assert!(
+            token.is_cancelled(),
+            "an out-of-sequence finalized block (height 3 while canonical is 1) \
+             must trigger coordinated shutdown rather than execute onto canonical state"
+        );
+
+        context.auditor().state()
+    });
+}
+
+#[test]
 fn test_orphaned_blocks_pruned_after_finalization() {
     // Test that orphaned_blocks at or below the finalized height are pruned.
     //

--- a/finalizer/src/tests/fork_handling.rs
+++ b/finalizer/src/tests/fork_handling.rs
@@ -905,6 +905,123 @@ fn test_fork_states_pruned_after_finalization() {
 }
 
 #[test]
+fn test_losing_fork_descendant_rejected_after_conflicting_ancestor_finalizes() {
+    // A notarized descendant of a losing fork must not remain usable after a
+    // conflicting ancestor finalizes.
+    //
+    // Scenario:
+    // 1. Notarize A1 at height 1 and A2 at height 2.
+    // 2. Finalize conflicting B1 at height 1.
+    // 3. A2 should no longer satisfy NotifyAtHeight or serve aux data.
+
+    let cfg = deterministic::Config::default().with_seed(49);
+    let executor = Runner::from(cfg);
+    executor.start(|context| async move {
+        let genesis_hash = [0x49u8; 32];
+        let initial_state = create_test_initial_state(genesis_hash, NonZeroU64::new(10).unwrap());
+
+        let (orchestrator_tx, _orchestrator_rx) = futures_mpsc::channel(100);
+        let orchestrator_mailbox = summit_orchestrator::Mailbox::new(orchestrator_tx);
+
+        let node_key = ed25519::PrivateKey::from_seed(0);
+
+        let finalizer_cfg = FinalizerConfig::<MockEngineClient, MockNetworkOracle, MinPk> {
+            mailbox_size: 100,
+            db_prefix: "test_losing_descendant_pruned".to_string(),
+            engine_client: MockEngineClient::new(),
+            oracle: MockNetworkOracle,
+            protocol_consts: ProtocolConsts {
+                validator_num_warm_up_epochs: 2,
+                validator_withdrawal_num_epochs: 2,
+            },
+
+            page_cache: CacheRef::from_pooler(
+                &context,
+                std::num::NonZero::new(4096).unwrap(),
+                NZUsize!(100),
+            ),
+            genesis_hash,
+            initial_state,
+            protocol_version: 1,
+            node_public_key: node_key.public_key(),
+            cancellation_token: CancellationToken::new(),
+            drain_interval: Duration::from_millis(100),
+            buffered_blocks_warn_threshold: 100,
+            pending_notarized_max: 1000,
+            namespace: Vec::new(),
+            _variant_marker: PhantomData,
+        };
+
+        let (finalizer, _state, mut mailbox, _state_query) =
+            Finalizer::<_, MockEngineClient, MockNetworkOracle, ed25519::PrivateKey, MinPk>::new(
+                context.with_label("finalizer"),
+                finalizer_cfg,
+            )
+            .await;
+
+        let _handle = finalizer.start(orchestrator_mailbox);
+        context.sleep(Duration::from_millis(100)).await;
+
+        let genesis_block = Block::genesis(genesis_hash);
+        let genesis_digest = genesis_block.digest();
+
+        let block_a1 = create_test_block(genesis_digest, 1, 2, 8001);
+        let block_a1_digest = block_a1.digest();
+        let block_a2 = create_test_block(block_a1_digest, 2, 3, 8002);
+        let block_a2_digest = block_a2.digest();
+        let block_b1 = create_test_block(genesis_digest, 1, 4, 8003);
+        let block_b1_digest = block_b1.digest();
+
+        assert_ne!(block_a1_digest, block_b1_digest);
+
+        mailbox
+            .report(Update::NotarizedBlock(block_a1.clone()))
+            .await;
+        mailbox
+            .report(Update::NotarizedBlock(block_a2.clone()))
+            .await;
+        context.sleep(Duration::from_millis(100)).await;
+
+        let notify_a2 = mailbox.notify_at_height(2, block_a2_digest).await;
+        assert!(
+            notify_a2.await.unwrap(),
+            "A2 should be tracked before the conflicting ancestor finalizes"
+        );
+
+        let (ack, _waiter) = Exact::handle();
+        mailbox
+            .report(Update::FinalizedBlock((block_b1.clone(), None), ack))
+            .await;
+        context.sleep(Duration::from_millis(100)).await;
+
+        assert_eq!(mailbox.get_latest_height().await, 1);
+        let notify_b1 = mailbox.notify_at_height(1, block_b1_digest).await;
+        assert!(
+            notify_b1.await.unwrap(),
+            "B1 should be canonical after finalization"
+        );
+
+        let notify_a2_after = mailbox.notify_at_height(2, block_a2_digest).await;
+        assert!(
+            !notify_a2_after.await.unwrap(),
+            "A2 descends from losing A1 and must not remain live"
+        );
+
+        let aux_data = mailbox
+            .get_aux_data(3, block_a2_digest)
+            .await
+            .await
+            .unwrap();
+        assert!(
+            aux_data.is_none(),
+            "A2 must not serve aux data after conflicting B1 finalizes"
+        );
+
+        context.auditor().state()
+    });
+}
+
+#[test]
 fn test_orphaned_blocks_pruned_after_finalization() {
     // Test that orphaned_blocks at or below the finalized height are pruned.
     //

--- a/finalizer/src/tests/fork_handling.rs
+++ b/finalizer/src/tests/fork_handling.rs
@@ -579,6 +579,14 @@ fn test_finalization_resolves_lower_waiters_and_preserves_future_waiters() {
         let stale_notify = mailbox.notify_at_height(1, stale_block.digest()).await;
         let future_notify = mailbox.notify_at_height(3, future_block.digest()).await;
 
+        // Finalize sequentially (the syncer never skips a height): canonical
+        // advances 0 -> 1 -> 2.
+        let (ack1, _waiter1) = Exact::handle();
+        mailbox
+            .report(Update::FinalizedBlock((block1.clone(), None), ack1))
+            .await;
+        context.sleep(Duration::from_millis(100)).await;
+
         let (ack, _waiter) = Exact::handle();
         mailbox
             .report(Update::FinalizedBlock((block2.clone(), None), ack))
@@ -868,6 +876,15 @@ fn test_fork_states_pruned_after_finalization() {
         assert!(notify1.await.unwrap(), "Block 1 should be in fork_states");
         assert!(notify2.await.unwrap(), "Block 2 should be in fork_states");
         assert!(notify3.await.unwrap(), "Block 3 should be in fork_states");
+
+        // Finalize sequentially: the syncer delivers finalized blocks in
+        // monotonic height order with no gaps, so the finalizer advances
+        // canonical 0 -> 1 -> 2 rather than jumping straight to height 2.
+        let (ack1, _waiter1) = Exact::handle();
+        mailbox
+            .report(Update::FinalizedBlock((block1.clone(), None), ack1))
+            .await;
+        context.sleep(Duration::from_millis(100)).await;
 
         // Now finalize block2 (height 2)
         let (ack, _waiter) = Exact::handle();


### PR DESCRIPTION
Addresses https://github.com/SeismicSystems/summit/issues/249.

Changes:
  - Track each fork state’s parent digest.
  - On finalization, keep only retained forks that descend from the finalized block.
  - Tombstone pruned fork digests so later waiters fail immediately.
  - Add a regression for A1 -> A2 followed by conflicting B1 finalization.