### PR TITLE
fix: bind finalized-header fields to the signed certificate

### DIFF
--- a/finalizer/src/actor.rs
+++ b/finalizer/src/actor.rs
@@ -903,9 +903,14 @@ impl<
             // Get participant count from the certificate signers
             let participant_count = finalization.certificate.signers.len();
 
-            // Store the finalized block header in the database
-            let finalized_header =
-                FinalizedHeader::new(block.header.clone(), finalization, participant_count);
+            // Store the finalized block header in the database. The binding
+            // between the block header and this finalization was just
+            // established by consensus (asserted above), so construct directly.
+            let finalized_header = FinalizedHeader::new_unchecked(
+                block.header.clone(),
+                finalization,
+                participant_count,
+            );
 
             #[cfg(feature = "prom")]
             let header_start = Instant::now();
@@ -925,8 +930,8 @@ impl<
                 self.context.register(
                     format!(
                         "<header>{}</header><prev_header>{}</prev_header>_finalized_header_stored",
-                        hex::encode(finalized_header.header.get_digest()),
-                        hex::encode(finalized_header.header.prev_epoch_header_hash())
+                        hex::encode(finalized_header.header().get_digest()),
+                        hex::encode(finalized_header.header().prev_epoch_header_hash())
                     ),
                     "chain height",
                     gauge,
@@ -1564,7 +1569,7 @@ impl<
             // the block that contains the last checkpoint
             let prev_header_hash =
                 if let Some(finalized_header) = self.db.get_most_recent_finalized_header().await {
-                    finalized_header.header.get_digest()
+                    finalized_header.header().get_digest()
                 } else {
                     self.genesis_hash.into()
                 };

--- a/finalizer/src/db.rs
+++ b/finalizer/src/db.rs
@@ -553,7 +553,8 @@ mod tests {
                     signature: create_dummy_signature().into(), // Valid dummy signature for test
                 },
             };
-            let finalized_header = summit_types::FinalizedHeader::new(header.clone(), finalized, 3);
+            let finalized_header =
+                summit_types::FinalizedHeader::new_unchecked(header.clone(), finalized, 3);
 
             // Test that no header exists initially
             assert!(db.get_finalized_header(100).await.is_none());
@@ -566,9 +567,9 @@ mod tests {
             let retrieved = db.get_finalized_header(100).await;
             assert!(retrieved.is_some());
             let retrieved = retrieved.unwrap();
-            assert_eq!(retrieved.header.height(), header.height());
-            assert_eq!(retrieved.header.get_digest(), header.get_digest());
-            assert_eq!(retrieved.header.timestamp(), header.timestamp());
+            assert_eq!(retrieved.header().height(), header.height());
+            assert_eq!(retrieved.header().get_digest(), header.get_digest());
+            assert_eq!(retrieved.header().timestamp(), header.timestamp());
 
             // Test that non-existent header returns None
             assert!(db.get_finalized_header(200).await.is_none());
@@ -601,23 +602,23 @@ mod tests {
                 },
             };
             let finalized_header2 =
-                summit_types::FinalizedHeader::new(header2.clone(), finalized2, 3);
+                summit_types::FinalizedHeader::new_unchecked(header2.clone(), finalized2, 3);
             db.store_finalized_header(200, &finalized_header2).await;
             db.commit().await;
 
             // Both headers should be accessible
             let h1 = db.get_finalized_header(100).await.unwrap();
             let h2 = db.get_finalized_header(200).await.unwrap();
-            assert_eq!(h1.header.height(), 100);
-            assert_eq!(h2.header.height(), 200);
-            assert_ne!(h1.header.get_digest(), h2.header.get_digest());
+            assert_eq!(h1.header().height(), 100);
+            assert_eq!(h2.header().height(), 200);
+            assert_ne!(h1.header().get_digest(), h2.header().get_digest());
 
             // Test get_most_recent_finalized_header returns the latest header
             let most_recent = db.get_most_recent_finalized_header().await;
             assert!(most_recent.is_some());
             let most_recent = most_recent.unwrap();
-            assert_eq!(most_recent.header.height(), 200);
-            assert_eq!(most_recent.header.get_digest(), header2.get_digest());
+            assert_eq!(most_recent.header().height(), 200);
+            assert_eq!(most_recent.header().get_digest(), header2.get_digest());
         });
     }
 
@@ -664,7 +665,7 @@ mod tests {
                 },
             };
             let finalized_header1 =
-                summit_types::FinalizedHeader::new(header1.clone(), finalized1, 3);
+                summit_types::FinalizedHeader::new_unchecked(header1.clone(), finalized1, 3);
 
             let header3 = summit_types::Header::new(
                 [7u8; 32].into(),  // parent
@@ -694,7 +695,7 @@ mod tests {
                 },
             };
             let finalized_header3 =
-                summit_types::FinalizedHeader::new(header3.clone(), finalized3, 3);
+                summit_types::FinalizedHeader::new_unchecked(header3.clone(), finalized3, 3);
 
             let header2 = summit_types::Header::new(
                 [5u8; 32].into(), // parent
@@ -724,7 +725,7 @@ mod tests {
                 },
             };
             let finalized_header2 =
-                summit_types::FinalizedHeader::new(header2.clone(), finalized2, 3);
+                summit_types::FinalizedHeader::new_unchecked(header2.clone(), finalized2, 3);
 
             // Store headers in non-sequential order: 100, 300, 200
             db.store_finalized_header(100, &finalized_header1).await;
@@ -732,8 +733,8 @@ mod tests {
 
             // Most recent should be height 100
             let most_recent = db.get_most_recent_finalized_header().await.unwrap();
-            assert_eq!(most_recent.header.height(), 100);
-            assert_eq!(most_recent.header.get_digest(), header1.get_digest());
+            assert_eq!(most_recent.header().height(), 100);
+            assert_eq!(most_recent.header().get_digest(), header1.get_digest());
 
             // Store height 300
             db.store_finalized_header(300, &finalized_header3).await;
@@ -741,8 +742,8 @@ mod tests {
 
             // Most recent should now be height 300
             let most_recent = db.get_most_recent_finalized_header().await.unwrap();
-            assert_eq!(most_recent.header.height(), 300);
-            assert_eq!(most_recent.header.get_digest(), header3.get_digest());
+            assert_eq!(most_recent.header().height(), 300);
+            assert_eq!(most_recent.header().get_digest(), header3.get_digest());
 
             // Store height 200 (lower than current max)
             db.store_finalized_header(200, &finalized_header2).await;
@@ -750,16 +751,16 @@ mod tests {
 
             // Most recent should still be height 300
             let most_recent = db.get_most_recent_finalized_header().await.unwrap();
-            assert_eq!(most_recent.header.height(), 300);
-            assert_eq!(most_recent.header.get_digest(), header3.get_digest());
+            assert_eq!(most_recent.header().height(), 300);
+            assert_eq!(most_recent.header().get_digest(), header3.get_digest());
 
             // Verify all headers are still individually accessible
             let h1 = db.get_finalized_header(100).await.unwrap();
             let h2 = db.get_finalized_header(200).await.unwrap();
             let h3 = db.get_finalized_header(300).await.unwrap();
-            assert_eq!(h1.header.height(), 100);
-            assert_eq!(h2.header.height(), 200);
-            assert_eq!(h3.header.height(), 300);
+            assert_eq!(h1.header().height(), 100);
+            assert_eq!(h2.header().height(), 200);
+            assert_eq!(h3.header().height(), 300);
         });
     }
 

--- a/node/src/bin/observer.rs
+++ b/node/src/bin/observer.rs
@@ -427,7 +427,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             )
             .expect("failed to decode finalized header");
 
-            let signers = &finalized_header.finalization.certificate.signers;
+            let signers = &finalized_header.finalization().certificate.signers;
             let signer_count = signers.count();
             let expected_quorum = 2 * active_validators.len() / 3 + 1;
             assert!(
@@ -455,7 +455,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
             println!(
                 "    latest finalized block (epoch {}, view {}) has {} signers, none of which is the observer",
-                finalized_header.header.epoch(), finalized_header.header.view(), signer_count
+                finalized_header.header().epoch(), finalized_header.header().view(), signer_count
             );
 
             println!("Test completed successfully!");

--- a/node/src/tests/checkpointing/creation.rs
+++ b/node/src/tests/checkpointing/creation.rs
@@ -201,7 +201,7 @@ fn test_checkpoint_created() {
             .await
             .expect("failed to get finalized header");
         assert_eq!(
-            finalized_header.header.checkpoint_hash().as_ref(),
+            finalized_header.header().checkpoint_hash().as_ref(),
             checkpoint.digest.as_ref(),
             "checkpoint_hash in header should match checkpoint digest"
         );

--- a/node/src/tests/checkpointing/verification.rs
+++ b/node/src/tests/checkpointing/verification.rs
@@ -28,9 +28,12 @@ use summit_types::keystore::KeyStore;
 
 /// Returns a clone of `header` with the first byte of `prev_epoch_header_hash`
 /// flipped. The header fields are private, so the value is rebuilt via the
-/// public constructor. The epoch-header chain-link check runs before signature
-/// verification in `verify_checkpoint_chain`, so this isolates
-/// `PrevEpochHeaderHashMismatch` from any signature failure.
+/// public constructor. Callers must rebind the accompanying finalization's
+/// payload to the returned header's digest (see `rebind_finalization`): the
+/// payload/header binding check runs first in `verify_checkpoint_chain`, so a
+/// header with a stale payload would trip `PayloadDigestMismatch` before the
+/// chain-link check. The chain-link check runs before signature verification,
+/// so `PrevEpochHeaderHashMismatch` still surfaces without a valid signature.
 fn tamper_prev_epoch_header_hash(header: &Header) -> Header {
     let mut prev = header.prev_epoch_header_hash();
     prev.0[0] ^= 0xFF;
@@ -245,7 +248,7 @@ fn test_checkpoint_verification_fixed_committee() {
         let weak_subjectivity = checkpoint::WeakSubjectivityHeaderDigest {
             epoch: weak_subjectivity_epoch,
             header_digest: finalized_headers[weak_subjectivity_epoch as usize]
-                .header
+                .header()
                 .get_digest(),
         };
         checkpoint::verify_checkpoint_chain_with_weak_subjectivity(
@@ -278,7 +281,7 @@ fn test_checkpoint_verification_fixed_committee() {
 
         let stale_weak_subjectivity = checkpoint::WeakSubjectivityHeaderDigest {
             epoch: 0,
-            header_digest: finalized_headers[0].header.get_digest(),
+            header_digest: finalized_headers[0].header().get_digest(),
         };
         let err = checkpoint::verify_checkpoint_chain_with_weak_subjectivity(
             &genesis,
@@ -364,8 +367,17 @@ fn test_checkpoint_verification_fixed_committee() {
         // signature (which is over `header.digest`), so this exercises the
         // chain check independently.
         let mut chain_tampered_headers = finalized_headers.clone();
-        chain_tampered_headers[1].header =
-            tamper_prev_epoch_header_hash(&chain_tampered_headers[1].header);
+        let tampered_header = tamper_prev_epoch_header_hash(chain_tampered_headers[1].header());
+        let mut tampered_finalization = chain_tampered_headers[1].finalization().clone();
+        // Keep the payload bound to the tampered header so the chain-link check
+        // (not the payload-binding check) is the one that fails.
+        tampered_finalization.proposal.payload = tampered_header.get_digest();
+        let tampered_pc = chain_tampered_headers[1].participant_count();
+        chain_tampered_headers[1] = summit_types::FinalizedHeader::new_unchecked(
+            tampered_header,
+            tampered_finalization,
+            tampered_pc,
+        );
         let err =
             checkpoint::verify_checkpoint_chain(&genesis, &chain_tampered_headers, &raw_checkpoint)
                 .expect_err("verification should fail with broken chain link");
@@ -379,8 +391,18 @@ fn test_checkpoint_verification_fixed_committee() {
 
         // Same check for the genesis anchor (epoch 0).
         let mut genesis_anchor_tampered = finalized_headers.clone();
-        genesis_anchor_tampered[0].header =
-            tamper_prev_epoch_header_hash(&genesis_anchor_tampered[0].header);
+        let anchor_tampered_header =
+            tamper_prev_epoch_header_hash(genesis_anchor_tampered[0].header());
+        let mut anchor_tampered_finalization = genesis_anchor_tampered[0].finalization().clone();
+        // Keep the payload bound to the tampered header so the chain-link check
+        // (not the payload-binding check) is the one that fails.
+        anchor_tampered_finalization.proposal.payload = anchor_tampered_header.get_digest();
+        let anchor_tampered_pc = genesis_anchor_tampered[0].participant_count();
+        genesis_anchor_tampered[0] = summit_types::FinalizedHeader::new_unchecked(
+            anchor_tampered_header,
+            anchor_tampered_finalization,
+            anchor_tampered_pc,
+        );
         let err = checkpoint::verify_checkpoint_chain(
             &genesis,
             &genesis_anchor_tampered,

--- a/node/src/tests/checkpointing/verification.rs
+++ b/node/src/tests/checkpointing/verification.rs
@@ -317,18 +317,29 @@ fn test_checkpoint_verification_fixed_committee() {
             "expected WeakSubjectivityEpochUnavailable, got: {err}"
         );
 
-        // Verify that a tampered signature causes verification to fail
+        // A finalized header whose certificate payload no longer matches its
+        // header fields must be rejected by the digest-binding check. (Fields are
+        // private, so rebuild the entry via `new_unchecked` to simulate a caller
+        // that smuggles in a mismatched header/certificate pair.)
         let mut tampered_sig_headers = finalized_headers.clone();
-        tampered_sig_headers[1].finalization.proposal.payload.0[0] ^= 0xFF;
+        let victim_header = tampered_sig_headers[1].header().clone();
+        let mut bad_finalization = tampered_sig_headers[1].finalization().clone();
+        let victim_pc = tampered_sig_headers[1].participant_count();
+        bad_finalization.proposal.payload.0[0] ^= 0xFF;
+        tampered_sig_headers[1] = summit_types::FinalizedHeader::new_unchecked(
+            victim_header,
+            bad_finalization,
+            victim_pc,
+        );
         let err =
             checkpoint::verify_checkpoint_chain(&genesis, &tampered_sig_headers, &raw_checkpoint)
-                .expect_err("verification should fail with tampered signature");
+                .expect_err("verification should fail with tampered payload");
         assert!(
             matches!(
                 err,
-                CheckpointVerificationError::SignatureVerificationFailed { epoch: 1 }
+                CheckpointVerificationError::PayloadDigestMismatch { epoch: 1 }
             ),
-            "expected SignatureVerificationFailed for epoch 1, got: {err}"
+            "expected PayloadDigestMismatch for epoch 1, got: {err}"
         );
 
         // Verify that removing a header causes verification to fail
@@ -603,11 +614,11 @@ fn test_checkpoint_verification_dynamic_committee() {
         // Verify epoch 1's header has both added and removed validators
         let epoch_1_header = &finalized_headers[1];
         assert!(
-            !epoch_1_header.header.added_validators().is_empty(),
+            !epoch_1_header.header().added_validators().is_empty(),
             "epoch 1 header should have added_validators"
         );
         assert!(
-            !epoch_1_header.header.removed_validators().is_empty(),
+            !epoch_1_header.header().removed_validators().is_empty(),
             "epoch 1 header should have removed_validators"
         );
 

--- a/node/src/tests/execution_requests/protocol_params.rs
+++ b/node/src/tests/execution_requests/protocol_params.rs
@@ -1687,7 +1687,7 @@ fn test_removed_validators_at_epoch_boundary_stake_bound() {
             .await
             .expect("failed to get finalized header for last block of epoch 0");
 
-        let removed_validators = finalized_header.header.removed_validators();
+        let removed_validators = finalized_header.header().removed_validators();
         assert!(
             removed_validators.contains(&kicked_pubkey),
             "force-removed validator (stake-bound) should be in removed_validators of \
@@ -1927,7 +1927,7 @@ fn test_joining_validator_activation_cancelled_on_stake_bound_force_removal() {
             .await
             .expect("failed to get finalized header for last block of epoch 1");
 
-        let added = finalized_header.header.added_validators();
+        let added = finalized_header.header().added_validators();
         assert!(
             !added.iter().any(|av| av.node_key == new_validator_pubkey),
             "force-removed Joining validator should NOT appear in added_validators of \

--- a/node/src/tests/execution_requests/validator_set.rs
+++ b/node/src/tests/execution_requests/validator_set.rs
@@ -182,7 +182,7 @@ fn test_added_validators_at_epoch_boundary() {
         // Verify the header contains the new validator in added_validators
         // The new validator's joining_epoch = 2, and at block 19 (last block of epoch 1),
         // the header should include validators joining in epoch 2 (next_epoch).
-        let added_validators = finalized_header.header.added_validators();
+        let added_validators = finalized_header.header().added_validators();
 
         // Assert that added_validators contains the new validator
         assert!(
@@ -405,7 +405,7 @@ fn test_removed_validators_at_epoch_boundary() {
             .expect("Failed to get finalized header for last block of epoch 0");
 
         // Verify the header contains the withdrawing validator in removed_validators
-        let removed_validators = finalized_header.header.removed_validators();
+        let removed_validators = finalized_header.header().removed_validators();
 
         // Assert that removed_validators contains the withdrawing validator
         assert!(

--- a/node/src/tests/execution_requests/withdrawals.rs
+++ b/node/src/tests/execution_requests/withdrawals.rs
@@ -2716,7 +2716,7 @@ fn test_joining_validator_withdrawal_on_last_block_keeps_header_consistent() {
             .get_finalized_header(1)
             .await
             .expect("missing finalized header for epoch 1");
-        let added_epoch_1 = header_epoch_1.header.added_validators();
+        let added_epoch_1 = header_epoch_1.header().added_validators();
         assert!(
             added_epoch_1
                 .iter()
@@ -2733,7 +2733,7 @@ fn test_joining_validator_withdrawal_on_last_block_keeps_header_consistent() {
             .get_finalized_header(2)
             .await
             .expect("missing finalized header for epoch 2");
-        let removed_epoch_2 = header_epoch_2.header.removed_validators();
+        let removed_epoch_2 = header_epoch_2.header().removed_validators();
         assert!(
             removed_epoch_2.contains(&new_validator_pubkey),
             "epoch 2 header must include the joining validator in removed_validators \

--- a/rpc/src/server.rs
+++ b/rpc/src/server.rs
@@ -191,7 +191,7 @@ impl SummitApiServer for SummitRpcServer {
 
         Ok(FinalizedHeaderDigestRes {
             epoch,
-            digest: header.header.get_digest().0,
+            digest: header.header().get_digest().0,
         })
     }
 

--- a/rpc/tests/integration_test.rs
+++ b/rpc/tests/integration_test.rs
@@ -134,7 +134,7 @@ async fn test_get_finalized_header_digest() {
 
     let epoch = 3;
     let finalized_header = create_test_finalized_header(epoch);
-    let expected_digest = finalized_header.header.get_digest().0;
+    let expected_digest = finalized_header.header().get_digest().0;
     let state = MockFinalizerState {
         finalized_headers: [(epoch, Some(finalized_header))].into(),
         ..Default::default()

--- a/rpc/tests/utils.rs
+++ b/rpc/tests/utils.rs
@@ -220,6 +220,7 @@ pub fn create_test_finalized_header(epoch: u64) -> summit_types::FinalizedHeader
     };
 
     summit_types::FinalizedHeader::new(header, finalized, 3)
+        .expect("test finalized header should be payload-bound")
 }
 
 /// Creates a temporary key store directory with test keys

--- a/syncer/src/actor.rs
+++ b/syncer/src/actor.rs
@@ -448,7 +448,7 @@ where
         // If we have a checkpoint, finalize the last block to complete the checkpoint
         if let Some(checkpoint) = checkpoint {
             let height = checkpoint.last_block.height();
-            let finalization = checkpoint.finalized_header.map(|h| h.finalization);
+            let finalization = checkpoint.finalized_header.map(|h| h.into_finalization());
             self.store_finalization(
                 height,
                 checkpoint.last_block.digest(),

--- a/types/src/checkpoint.rs
+++ b/types/src/checkpoint.rs
@@ -174,6 +174,11 @@ pub enum CheckpointVerificationError {
     },
     ValidatorSetMismatch(String),
     ValidatorSetError(String),
+    /// A finalized header's fields do not hash to the digest signed by its
+    /// finalization certificate, so the header fields are not authenticated.
+    PayloadDigestMismatch {
+        epoch: u64,
+    },
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -240,6 +245,12 @@ impl fmt::Display for CheckpointVerificationError {
             }
             Self::ValidatorSetError(reason) => {
                 write!(f, "failed to construct validator set: {reason}")
+            }
+            Self::PayloadDigestMismatch { epoch } => {
+                write!(
+                    f,
+                    "epoch {epoch}: header fields do not match the finalization payload digest"
+                )
             }
         }
     }
@@ -316,10 +327,23 @@ pub fn verify_checkpoint_chain_with_weak_subjectivity(
         // Save the current participants — this is the signing set for this epoch
         signing_set = participants.clone();
         let expected_epoch = i as u64;
-        if finalized_header.header.epoch() != expected_epoch {
+
+        // Authenticate the header's fields against the signed certificate
+        // payload BEFORE trusting any of them. The certificate signs a digest;
+        // recompute it from the header's own fields (ignoring any cached/seeded
+        // value) and require equality. Without this, a typed `FinalizedHeader`
+        // carrying a valid certificate but mutated header fields (e.g.
+        // `checkpoint_hash`) would be trusted below.
+        if finalized_header.header().computed_digest()
+            != finalized_header.finalization().proposal.payload
+        {
+            return Err(CheckpointVerificationError::PayloadDigestMismatch { epoch: i as u64 });
+        }
+
+        if finalized_header.header().epoch() != expected_epoch {
             return Err(CheckpointVerificationError::NonContiguousEpochs {
                 expected: expected_epoch,
-                found: finalized_header.header.epoch(),
+                found: finalized_header.header().epoch(),
             });
         }
 
@@ -348,7 +372,7 @@ pub fn verify_checkpoint_chain_with_weak_subjectivity(
 
         // Verify the BLS aggregate signature
         if !finalized_header
-            .finalization
+            .finalization()
             .verify(&mut rng, &scheme, &Sequential)
         {
             return Err(CheckpointVerificationError::SignatureVerificationFailed {
@@ -357,14 +381,14 @@ pub fn verify_checkpoint_chain_with_weak_subjectivity(
         }
 
         // Update validator set for the next epoch
-        for added in finalized_header.header.added_validators() {
+        for added in finalized_header.header().added_validators() {
             let minpk_public: &<MinPk as Variant>::Public = added.consensus_key.as_ref();
             let encoded = minpk_public.encode();
             let variant_pk = <MinPk as Variant>::Public::decode(&mut encoded.as_ref())
                 .expect("failed to decode BLS public key");
             participants.push((added.node_key.clone(), variant_pk));
         }
-        for removed in finalized_header.header.removed_validators() {
+        for removed in finalized_header.header().removed_validators() {
             participants.retain(|(pk, _)| *pk != removed);
         }
         participants.sort_by(|a, b| a.0.cmp(&b.0));
@@ -417,7 +441,7 @@ pub fn verify_checkpoint_chain_with_weak_subjectivity(
     let mut hasher = Sha256::new();
     hasher.update(&checkpoint.data);
     let computed_digest = hasher.finalize();
-    if last_header.header.checkpoint_hash() != computed_digest {
+    if last_header.header().checkpoint_hash() != computed_digest {
         return Err(CheckpointVerificationError::CheckpointHashMismatch);
     }
 
@@ -482,6 +506,9 @@ mod tests {
     use crate::checkpoint::Checkpoint;
     use crate::consensus_state::ConsensusState;
     use crate::dynamic_epocher::DynamicEpocher;
+    use crate::genesis::Genesis;
+    use crate::header::FinalizedHeader;
+    use crate::scheme::MultisigScheme;
     use crate::ssz_state_tree::SszStateTree;
     use crate::withdrawal::WithdrawalQueue;
     use alloy_primitives::Address;
@@ -1187,6 +1214,232 @@ mod tests {
                 .unwrap()
                 .balance,
             32_000_000_000
+        );
+    }
+
+    // Builds a single-epoch checkpoint chain: a genesis validator set, a matching
+    // checkpoint, a *different* ("attacker-controlled") checkpoint, and an honest
+    // finalized header whose certificate genuinely signs the honest header digest
+    // and whose `checkpoint_hash` commits to the honest checkpoint.
+    fn checkpoint_verification_fixture() -> (
+        Genesis,
+        Checkpoint,
+        Checkpoint,
+        FinalizedHeader<MultisigScheme>,
+    ) {
+        use crate::account::{ValidatorAccount, ValidatorStatus};
+        use crate::genesis::GenesisValidator;
+        use crate::header::Header;
+        use commonware_codec::Encode as _;
+        use commonware_consensus::simplex::types::{Finalization, Finalize, Proposal};
+        use commonware_consensus::types::{Epoch, Round, View};
+        use commonware_cryptography::bls12381::primitives::group;
+        use commonware_cryptography::bls12381::primitives::variant::{MinPk, Variant};
+        use commonware_parallel::Sequential;
+        use commonware_utils::TryCollect;
+        use commonware_utils::hex;
+        use commonware_utils::ordered::BiMap;
+
+        let namespace = "checkpoint-typed-header-test".to_string();
+        let mut genesis_validators = Vec::new();
+        let mut validator_accounts = BTreeMap::new();
+        let mut participants = Vec::new();
+        let mut group_privates = Vec::new();
+
+        for i in 0..4u64 {
+            let node_key = ed25519::PrivateKey::from_seed(i);
+            let node_public_key = node_key.public_key();
+            let consensus_key = bls12381::PrivateKey::from_seed(100 + i);
+            let consensus_public_key = consensus_key.public_key();
+
+            let encoded_private = consensus_key.encode();
+            let group_private = group::Private::decode(&mut encoded_private.as_ref())
+                .expect("BLS private key should decode as group scalar");
+            group_privates.push(group_private);
+
+            let minpk_public: &<MinPk as Variant>::Public = consensus_public_key.as_ref();
+            let encoded_public = minpk_public.encode();
+            let variant_public = <MinPk as Variant>::Public::decode(&mut encoded_public.as_ref())
+                .expect("BLS public key should decode as MinPk public key");
+            participants.push((node_public_key.clone(), variant_public));
+
+            let withdrawal_credentials = Address::from([i as u8; 20]);
+            genesis_validators.push(GenesisValidator {
+                node_public_key: format!("0x{}", hex(node_public_key.as_ref())),
+                consensus_public_key: format!("0x{}", hex(consensus_public_key.as_ref())),
+                ip_address: format!("127.0.0.1:{}", 10_000 + i),
+                withdrawal_credentials: withdrawal_credentials.to_string(),
+            });
+
+            let account = ValidatorAccount {
+                consensus_public_key,
+                withdrawal_credentials,
+                balance: 32_000_000_000,
+                status: ValidatorStatus::Active,
+                has_pending_deposit: false,
+                has_pending_withdrawal: false,
+                joining_epoch: 0,
+                last_deposit_index: 0,
+            };
+            let key_bytes: [u8; 32] = node_public_key
+                .as_ref()
+                .try_into()
+                .expect("ed25519 public key should be 32 bytes");
+            validator_accounts.insert(key_bytes, account);
+        }
+
+        let genesis = Genesis {
+            validators: genesis_validators,
+            eth_genesis_hash: "0x00".to_string(),
+            leader_timeout_ms: 1_000,
+            notarization_timeout_ms: 1_000,
+            nullify_timeout_ms: 1_000,
+            activity_timeout_views: 10,
+            skip_timeout_views: 5,
+            max_message_size_bytes: 1_048_576,
+            namespace: namespace.clone(),
+            validator_minimum_stake: 32_000_000_000,
+            validator_maximum_stake: 64_000_000_000,
+            blocks_per_epoch: 10,
+            allowed_timestamp_future_ms: 10_000,
+            treasury_address: Address::ZERO.to_string(),
+            max_deposits_per_epoch: 3,
+            max_withdrawals_per_epoch: 16,
+            observers_per_validator: 0,
+        };
+
+        let mut state = ConsensusState::new(
+            Default::default(),
+            32_000_000_000,
+            64_000_000_000,
+            NonZeroU64::new(10).unwrap(),
+            10_000,
+            Address::ZERO,
+            3,
+            16,
+            0,
+        );
+        state.set_validator_accounts(validator_accounts);
+        let checkpoint = Checkpoint::new(&state);
+
+        // A distinct checkpoint the attacker would like the chain to authenticate.
+        let mut tampered_state = state.clone();
+        tampered_state.set_latest_height(1);
+        let tampered_checkpoint = Checkpoint::new(&tampered_state);
+        assert_ne!(checkpoint.digest, tampered_checkpoint.digest);
+
+        // Honest header commits to the honest checkpoint.
+        let header = Header::new(
+            [0u8; 32].into(),
+            0,
+            0,
+            0,
+            0,
+            [1u8; 32].into(),
+            [2u8; 32].into(),
+            checkpoint.digest,
+            [0u8; 32].into(),
+            Vec::new(),
+            Vec::new(),
+            [0u8; 32],
+        );
+
+        participants.sort_by(|lhs, rhs| lhs.0.cmp(&rhs.0));
+        let signers: BiMap<ed25519::PublicKey, <MinPk as Variant>::Public> =
+            participants.into_iter().try_collect().unwrap();
+        let schemes: Vec<_> = group_privates
+            .into_iter()
+            .filter_map(|private| {
+                MultisigScheme::signer(namespace.as_bytes(), signers.clone(), private)
+            })
+            .collect();
+
+        // Certificate genuinely signs the honest header digest.
+        let proposal = Proposal {
+            round: Round::new(Epoch::new(0), View::new(header.view())),
+            parent: View::new(header.height()),
+            payload: header.get_digest(),
+        };
+        let finalizes: Vec<_> = schemes
+            .iter()
+            .take(3)
+            .map(|scheme| Finalize::sign(scheme, proposal.clone()).unwrap())
+            .collect();
+        let finalization = Finalization::from_finalizes(&schemes[0], &finalizes, &Sequential)
+            .expect("finalization should aggregate");
+
+        let finalized_header = FinalizedHeader::new(header, finalization, schemes.len())
+            .expect("honest header is bound to its certificate");
+
+        (genesis, checkpoint, tampered_checkpoint, finalized_header)
+    }
+
+    // Closes the typed-API trust-boundary gap: a finalized header carries header
+    // fields (e.g. `checkpoint_hash`) and a certificate that signs a digest. The
+    // fields must be bound to the signed digest, otherwise an attacker can pair a
+    // genuine certificate (signing the honest digest) with header fields that
+    // point at attacker-controlled checkpoint data.
+    #[test]
+    fn test_checkpoint_verifier_rejects_typed_header_field_mutation() {
+        use crate::header::{FinalizedHeader, FinalizedHeaderError, Header};
+
+        let (genesis, checkpoint, tampered_checkpoint, honest) = checkpoint_verification_fixture();
+
+        // Sanity: the honest finalized header verifies against the honest checkpoint.
+        super::verify_checkpoint_chain(&genesis, std::slice::from_ref(&honest), &checkpoint)
+            .expect("fixture checkpoint should verify before tampering");
+
+        // Build a header identical to the honest one EXCEPT `checkpoint_hash`,
+        // which is swapped to authenticate the attacker-controlled checkpoint.
+        // Reuse the ORIGINAL finalization: its certificate still signs the honest
+        // header digest, so the BLS signature remains valid — only the header
+        // field was mutated.
+        let h = honest.header().clone();
+        let tampered_header = Header::new(
+            h.parent(),
+            h.height(),
+            h.timestamp(),
+            h.epoch(),
+            h.view(),
+            h.payload_hash(),
+            h.execution_request_hash(),
+            tampered_checkpoint.digest, // <-- mutated away from the signed digest
+            h.prev_epoch_header_hash(),
+            h.added_validators().to_vec(),
+            h.removed_validators(),
+            h.parent_beacon_block_root(),
+        );
+
+        // (1) The safe constructor rejects the unbound pairing outright.
+        let err = FinalizedHeader::new(
+            tampered_header.clone(),
+            honest.finalization().clone(),
+            honest.participant_count(),
+        )
+        .expect_err("FinalizedHeader::new must reject a mismatched header/payload");
+        assert_eq!(err, FinalizedHeaderError::PayloadDigestMismatch);
+
+        // (2) Even if a caller bypasses the safe constructor (e.g. via
+        // `new_unchecked`, simulating a post-construction field mutation that the
+        // private fields otherwise prevent), the verifier itself re-derives the
+        // binding and rejects it.
+        let smuggled = FinalizedHeader::new_unchecked(
+            tampered_header,
+            honest.finalization().clone(),
+            honest.participant_count(),
+        );
+        let result = super::verify_checkpoint_chain(
+            &genesis,
+            std::slice::from_ref(&smuggled),
+            &tampered_checkpoint,
+        );
+        assert!(
+            matches!(
+                result,
+                Err(super::CheckpointVerificationError::PayloadDigestMismatch { epoch: 0 })
+            ),
+            "verifier must reject a finalized header whose checkpoint_hash was \
+             mutated away from the signed certificate payload, got {result:?}"
         );
     }
 }

--- a/types/src/checkpoint.rs
+++ b/types/src/checkpoint.rs
@@ -352,9 +352,9 @@ pub fn verify_checkpoint_chain_with_weak_subjectivity(
         let expected_prev = if i == 0 {
             genesis_hash
         } else {
-            finalized_headers[i - 1].header.get_digest()
+            finalized_headers[i - 1].header().get_digest()
         };
-        if finalized_header.header.prev_epoch_header_hash() != expected_prev {
+        if finalized_header.header().prev_epoch_header_hash() != expected_prev {
             return Err(CheckpointVerificationError::PrevEpochHeaderHashMismatch {
                 epoch: expected_epoch,
             });
@@ -414,12 +414,12 @@ pub fn verify_checkpoint_chain_with_weak_subjectivity(
             );
         };
 
-        if anchor_header.header.get_digest() != weak_subjectivity.header_digest {
+        if anchor_header.header().get_digest() != weak_subjectivity.header_digest {
             return Err(
                 CheckpointVerificationError::WeakSubjectivityHeaderDigestMismatch {
                     epoch: weak_subjectivity.epoch,
                     expected: weak_subjectivity.header_digest,
-                    found: anchor_header.header.get_digest(),
+                    found: anchor_header.header().get_digest(),
                 },
             );
         }
@@ -1290,7 +1290,7 @@ mod tests {
 
         let genesis = Genesis {
             validators: genesis_validators,
-            eth_genesis_hash: "0x00".to_string(),
+            eth_genesis_hash: format!("0x{}", "00".repeat(32)),
             leader_timeout_ms: 1_000,
             notarization_timeout_ms: 1_000,
             nullify_timeout_ms: 1_000,
@@ -1306,6 +1306,7 @@ mod tests {
             max_deposits_per_epoch: 3,
             max_withdrawals_per_epoch: 16,
             observers_per_validator: 0,
+            minimum_validator_count: 1,
         };
 
         let mut state = ConsensusState::new(
@@ -1318,6 +1319,7 @@ mod tests {
             3,
             16,
             0,
+            1,
         );
         state.set_validator_accounts(validator_accounts);
         let checkpoint = Checkpoint::new(&state);

--- a/types/src/header.rs
+++ b/types/src/header.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::sync::OnceLock;
 
 use crate::PublicKey;
@@ -20,7 +21,7 @@ pub struct AddedValidator {
     pub consensus_key: bls12381::PublicKey,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
+#[derive(Clone, Debug, Encode, Decode)]
 pub struct Header {
     parent: SszDigest,
     height: u64,
@@ -160,15 +161,56 @@ impl Header {
         }
     }
 
+    /// Returns the (cached) digest of this header.
+    ///
+    /// The value is memoized in `self.digest`, and may have been *seeded* via
+    /// [`Header::new_with_digest`] (genesis seeds it with the genesis hash,
+    /// which is intentionally not the hash of the fields). This is correct for
+    /// block identity, but it means the cached value cannot be trusted to
+    /// reflect the current fields. Trust boundaries that authenticate a header
+    /// against a signed payload must use [`Header::computed_digest`] instead.
     pub fn get_digest(&self) -> Digest {
-        *self.digest.get_or_init(|| {
-            let bytes = self.encode();
-            let mut hasher = Sha256::new();
-            hasher.update(&bytes);
-            hasher.finalize()
-        })
+        *self.digest.get_or_init(|| self.computed_digest())
+    }
+
+    /// Recomputes the digest directly from the header's current fields,
+    /// ignoring any cached or seeded value.
+    ///
+    /// Use this (not [`Header::get_digest`]) when authenticating a header
+    /// against a signed certificate payload: it answers whether these fields
+    /// actually hash to the signed digest, and cannot be defeated by a header
+    /// constructed with a mismatched seed via [`Header::new_with_digest`].
+    pub fn computed_digest(&self) -> Digest {
+        let bytes = self.encode();
+        let mut hasher = Sha256::new();
+        hasher.update(&bytes);
+        hasher.finalize()
     }
 }
+
+// `digest` is a memoized value fully determined by the other fields, and may be
+// warm or cold depending on whether `get_digest` has been called (a decoded
+// header starts cold). It must not affect equality, so compare every field
+// except the cache. This cannot be `#[derive]`d because the derive would
+// include the `OnceLock` cache state.
+impl PartialEq for Header {
+    fn eq(&self, other: &Self) -> bool {
+        self.parent == other.parent
+            && self.height == other.height
+            && self.timestamp == other.timestamp
+            && self.epoch == other.epoch
+            && self.view == other.view
+            && self.payload_hash == other.payload_hash
+            && self.execution_request_hash == other.execution_request_hash
+            && self.checkpoint_hash == other.checkpoint_hash
+            && self.prev_epoch_header_hash == other.prev_epoch_header_hash
+            && self.added_validators == other.added_validators
+            && self.removed_validators == other.removed_validators
+            && self.parent_beacon_block_root == other.parent_beacon_block_root
+    }
+}
+
+impl Eq for Header {}
 
 // Size of AddedValidator in SSZ: 32 bytes (node_key) + 48 bytes (BLS consensus_key) = 80 bytes
 const ADDED_VALIDATOR_SSZ_SIZE: usize = 32 + 48;
@@ -367,15 +409,67 @@ impl Read for Header {
     }
 }
 
+/// Error constructing a [`FinalizedHeader`] via [`FinalizedHeader::new`].
+#[derive(Debug, PartialEq, Eq)]
+pub enum FinalizedHeaderError {
+    /// The finalization certificate's signed payload does not equal the digest
+    /// recomputed from the header's fields. The header is not bound to the
+    /// certificate.
+    PayloadDigestMismatch,
+}
+
+impl fmt::Display for FinalizedHeaderError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::PayloadDigestMismatch => {
+                write!(f, "finalization payload does not match the header digest")
+            }
+        }
+    }
+}
+
+impl std::error::Error for FinalizedHeaderError {}
+
+/// A header paired with the finalization certificate that finalized it.
+///
+/// The fields are private and the only validating constructor
+/// ([`FinalizedHeader::new`]) enforces that the certificate's signed payload
+/// equals the digest recomputed from the header's fields. This binds the
+/// (otherwise free-standing) header fields to the signed certificate, so
+/// consumers — e.g. [`crate::checkpoint::verify_checkpoint_chain`] — can trust
+/// header fields like `checkpoint_hash` without re-deriving the binding.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct FinalizedHeader<S: Scheme> {
-    pub header: Header,
-    pub finalization: Finalization<S, Digest>,
-    pub participant_count: usize,
+    header: Header,
+    finalization: Finalization<S, Digest>,
+    participant_count: usize,
 }
 
 impl<S: Scheme> FinalizedHeader<S> {
+    /// Constructs a `FinalizedHeader`, enforcing that the certificate's signed
+    /// payload equals the digest recomputed from the header's fields.
+    ///
+    /// Returns [`FinalizedHeaderError::PayloadDigestMismatch`] if the header is
+    /// not bound to the certificate.
     pub fn new(
+        header: Header,
+        finalization: Finalization<S, Digest>,
+        participant_count: usize,
+    ) -> Result<Self, FinalizedHeaderError> {
+        if finalization.proposal.payload != header.computed_digest() {
+            return Err(FinalizedHeaderError::PayloadDigestMismatch);
+        }
+        Ok(Self::new_unchecked(header, finalization, participant_count))
+    }
+
+    /// Constructs a `FinalizedHeader` **without** checking the payload/header
+    /// binding.
+    ///
+    /// Only for callers that have already established the binding through
+    /// another path (e.g. the finalizer constructing a header for a block it
+    /// just certified). Prefer [`FinalizedHeader::new`] for any header derived
+    /// from untrusted input.
+    pub fn new_unchecked(
         header: Header,
         finalization: Finalization<S, Digest>,
         participant_count: usize,
@@ -385,6 +479,23 @@ impl<S: Scheme> FinalizedHeader<S> {
             finalization,
             participant_count,
         }
+    }
+
+    pub fn header(&self) -> &Header {
+        &self.header
+    }
+
+    pub fn finalization(&self) -> &Finalization<S, Digest> {
+        &self.finalization
+    }
+
+    pub fn participant_count(&self) -> usize {
+        self.participant_count
+    }
+
+    /// Consumes the header, returning the owned finalization certificate.
+    pub fn into_finalization(self) -> Finalization<S, Digest> {
+        self.finalization
     }
 }
 
@@ -444,18 +555,9 @@ where
         let finalization = Finalization::<S, Digest>::read_cfg(&mut finalized_buf, &cfg)
             .map_err(|e| ssz::DecodeError::BytesInvalid(format!("{e:?}")))?;
 
-        // Ensure the finalization is for the header
-        if finalization.proposal.payload != header.get_digest() {
-            return Err(ssz::DecodeError::BytesInvalid(
-                "Finalization payload does not match header digest".to_string(),
-            ));
-        }
-
-        Ok(Self {
-            header,
-            finalization,
-            participant_count: participant_count as usize,
-        })
+        // Ensure the finalization is bound to the header (recompute from fields).
+        Self::new(header, finalization, participant_count as usize)
+            .map_err(|e| ssz::DecodeError::BytesInvalid(e.to_string()))
     }
 }
 
@@ -725,8 +827,8 @@ mod test {
         );
 
         let proposal = Proposal {
-            round: Round::new(Epoch::new(0), View::new(header.view)),
-            parent: View::new(header.height),
+            round: Round::new(Epoch::new(0), View::new(header.view())),
+            parent: View::new(header.height()),
             payload: header.get_digest(),
         };
 
@@ -743,21 +845,22 @@ mod test {
             header.clone(),
             finalized,
             3,
-        );
+        )
+        .expect("payload matches header digest");
 
         let encoded = finalized_header.encode();
         let decoded =
             FinalizedHeader::<bls12381_multisig::Scheme<PublicKey, MinPk>>::decode(encoded)
                 .unwrap();
 
-        assert_eq!(finalized_header.finalization, decoded.finalization);
-        assert_eq!(finalized_header.header, decoded.header);
+        assert_eq!(finalized_header.finalization(), decoded.finalization());
+        assert_eq!(finalized_header.header(), decoded.header());
         assert_eq!(
-            finalized_header.participant_count,
-            decoded.participant_count
+            finalized_header.participant_count(),
+            decoded.participant_count()
         );
 
-        assert_eq!(finalized_header.header, header);
+        assert_eq!(finalized_header.header(), &header);
     }
 
     #[test]
@@ -781,8 +884,8 @@ mod test {
         // Create a finalization with wrong payload
         let dummy_digest = [99u8; 32];
         let wrong_proposal = Proposal {
-            round: Round::new(Epoch::new(0), View::new(header.view)),
-            parent: View::new(header.height),
+            round: Round::new(Epoch::new(0), View::new(header.view())),
+            parent: View::new(header.height()),
             payload: dummy_digest.into(), // Wrong digest
         };
 
@@ -795,12 +898,10 @@ mod test {
             },
         };
 
+        // Build an unbound pairing via `new_unchecked` (the safe `new` would
+        // reject it), then confirm decode re-derives and rejects the mismatch.
         let finalized_header: FinalizedHeader<bls12381_multisig::Scheme<PublicKey, MinPk>> =
-            FinalizedHeader {
-                header,
-                finalization: wrong_finalized,
-                participant_count: 5,
-            };
+            FinalizedHeader::new_unchecked(header, wrong_finalized, 5);
 
         let encoded = finalized_header.as_ssz_bytes();
         let result = FinalizedHeader::<bls12381_multisig::Scheme<PublicKey, MinPk>>::from_ssz_bytes(
@@ -810,7 +911,7 @@ mod test {
         assert!(result.is_err());
         println!("{:?}", result);
         assert!(
-            matches!(result.unwrap_err(), ssz::DecodeError::BytesInvalid(msg) if msg.contains("Finalization payload does not match header digest"))
+            matches!(result.unwrap_err(), ssz::DecodeError::BytesInvalid(msg) if msg.contains("does not match the header digest"))
         );
     }
 
@@ -833,8 +934,8 @@ mod test {
         );
 
         let proposal = Proposal {
-            round: Round::new(Epoch::new(0), View::new(header.view)),
-            parent: View::new(header.height),
+            round: Round::new(Epoch::new(0), View::new(header.view())),
+            parent: View::new(header.height()),
             payload: header.get_digest(),
         };
 
@@ -849,7 +950,8 @@ mod test {
 
         let finalized_header = FinalizedHeader::<bls12381_multisig::Scheme<PublicKey, MinPk>>::new(
             header, finalized, 4,
-        );
+        )
+        .expect("payload matches header digest");
 
         let ssz_len = finalized_header.ssz_bytes_len();
         let encode_len = finalized_header.encode_size();


### PR DESCRIPTION
Builds on https://github.com/SeismicSystems/summit/pull/170.

Addresses https://github.com/SeismicSystems/summit/issues/261.

Changes:
- Header: add computed_digest() (recompute from fields, ignoring the seedable OnceLock cache); use it for all binding checks.
- FinalizedHeader: make fields private; new() validates the payload/digest binding (returns FinalizedHeaderError), new_unchecked() for callers that already established it; add accessors.
- verify_checkpoint_chain: recompute and enforce finalization.proposal.payload == header digest per header, before trusting any field (PayloadDigestMismatch).
- Header: hand-write PartialEq/Eq to exclude the memoized digest cache so equality is field-based regardless of cache warmth.
- Add negative tests for the new() rejection and verifier rejection.

