### PR TITLE
fix: reject pending checkpoints in decoded checkpoint artifacts

### DIFF
--- a/types/src/checkpoint.rs
+++ b/types/src/checkpoint.rs
@@ -86,9 +86,20 @@ impl Decode for Checkpoint {
         let data: Vec<u8> = decoder.decode_next()?;
         let digest_bytes: [u8; 32] = decoder.decode_next()?;
 
+        // Bind the redundant `digest` field to `data`: a decoded checkpoint must
+        // satisfy `digest == sha256(data)`.
+        let digest = Digest::from(digest_bytes);
+        let mut hasher = Sha256::new();
+        hasher.update(&data);
+        if hasher.finalize() != digest {
+            return Err(ssz::DecodeError::BytesInvalid(
+                "checkpoint digest does not match sha256(data)".to_string(),
+            ));
+        }
+
         Ok(Self {
             data: Bytes::from(data),
-            digest: Digest::from(digest_bytes),
+            digest,
         })
     }
 }
@@ -1084,6 +1095,43 @@ mod tests {
         let outer_checkpoint = Checkpoint::new(&outer_state);
         let result = ConsensusState::try_from(&outer_checkpoint);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_from_ssz_bytes_rejects_digest_data_mismatch() {
+        // A decoded Checkpoint must satisfy `digest == sha256(data)`. Encoding a
+        // checkpoint whose stored digest does not match its data and decoding it
+        // must fail. This is the path `ConsensusState::read_cfg` uses to decode an
+        // embedded pending_checkpoint.
+        let valid = Checkpoint::new(&ConsensusState::default());
+        let tampered = Checkpoint {
+            data: valid.data.clone(),
+            digest: [0xFF; 32].into(),
+        };
+        assert!(Checkpoint::from_ssz_bytes(&tampered.as_ssz_bytes()).is_err());
+
+        // Sanity: a self-consistent checkpoint still round-trips.
+        assert_eq!(
+            Checkpoint::from_ssz_bytes(&valid.as_ssz_bytes()).unwrap(),
+            valid
+        );
+    }
+
+    #[test]
+    fn test_consensus_state_decode_rejects_tampered_pending_checkpoint_digest() {
+        use commonware_codec::Encode as _;
+
+        // ConsensusState::read_cfg decodes an embedded pending_checkpoint through
+        // Checkpoint::from_ssz_bytes, so a pending_checkpoint whose digest does
+        // not match its data must be rejected on decode rather than trusted.
+        let mut pending = Checkpoint::new(&ConsensusState::default());
+        pending.digest = [0xFF; 32].into();
+
+        let mut state = ConsensusState::default();
+        state.set_pending_checkpoint(Some(pending));
+
+        let mut encoded = state.encode();
+        assert!(ConsensusState::decode(&mut encoded).is_err());
     }
 
     #[test]

--- a/types/src/checkpoint.rs
+++ b/types/src/checkpoint.rs
@@ -139,7 +139,15 @@ impl TryFrom<&Checkpoint> for ConsensusState {
             return Err(Error::Invalid("Checkpoint", "Digest verification failed"));
         }
 
-        ConsensusState::read(&mut checkpoint.data.as_ref())
+        let state = ConsensusState::read(&mut checkpoint.data.as_ref())?;
+        if state.get_pending_checkpoint().is_some() {
+            return Err(Error::Invalid(
+                "Checkpoint",
+                "Pending checkpoint not allowed",
+            ));
+        }
+
+        Ok(state)
     }
 }
 
@@ -1061,6 +1069,21 @@ mod tests {
         } else {
             panic!("Expected Invalid error with digest verification message");
         }
+    }
+
+    #[test]
+    fn test_try_from_checkpoint_rejects_pending_checkpoint() {
+        let pending_state = ConsensusState::default();
+        let pending_checkpoint = Checkpoint::new(&pending_state);
+
+        let mut outer_state = ConsensusState::default();
+        outer_state.set_pending_checkpoint(Some(pending_checkpoint));
+
+        // The outer checkpoint digest is valid for the serialized state, but
+        // finalized checkpoint artifacts must not carry staged checkpoint data.
+        let outer_checkpoint = Checkpoint::new(&outer_state);
+        let result = ConsensusState::try_from(&outer_checkpoint);
+        assert!(result.is_err());
     }
 
     #[test]

--- a/types/src/consensus_state.rs
+++ b/types/src/consensus_state.rs
@@ -10,7 +10,7 @@ use crate::{Digest, PublicKey};
 use alloy_primitives::Address;
 use alloy_rpc_types_engine::ForkchoiceState;
 use bytes::{Buf, BufMut};
-use commonware_codec::{DecodeExt, Encode, EncodeSize, Error, Read, ReadExt, Write};
+use commonware_codec::{Encode, EncodeSize, Error, Read, ReadExt, Write};
 use commonware_cryptography::{bls12381, sha256};
 #[cfg(feature = "prom")]
 use metrics::histogram;
@@ -1365,7 +1365,7 @@ impl TryFrom<Checkpoint> for ConsensusState {
     type Error = Error;
 
     fn try_from(checkpoint: Checkpoint) -> Result<Self, Self::Error> {
-        ConsensusState::decode(checkpoint.data)
+        Self::try_from(&checkpoint)
     }
 }
 


### PR DESCRIPTION
Addresses https://github.com/SeismicSystems/summit/issues/253

Changes:
- Rejects checkpoint artifacts that decode to consensus state with a non-None pending_checkpoint. This closes the checkpoint recovery path that could carry staged checkpoint data into finalized artifacts.
- Adds a regression test.