### PR TITLE
fix: genesis validation

### DIFF
--- a/types/src/consensus_state.rs
+++ b/types/src/consensus_state.rs
@@ -1187,6 +1187,21 @@ impl Read for ConsensusState {
 
         let max_deposits_per_epoch = buf.try_get_u64().map_err(|_| Error::EndOfBuffer)?;
         let max_withdrawals_per_epoch = buf.try_get_u64().map_err(|_| Error::EndOfBuffer)?;
+        // Enforce the same lower/upper bound the runtime protocol-parameter update
+        // path applies (see ProtocolParam::read_cfg / try_from). Genesis and runtime
+        // updates already range-check this, so an out-of-range value here means a
+        // crafted checkpoint/state artifact or tampered blob. A zero cap would let
+        // the epoch-final selector emit no withdrawals and roll every due exit/refund
+        // forward indefinitely, so reject it at decode rather than trust it.
+        if !(crate::protocol_params::MAX_WITHDRAWALS_PER_EPOCH_MIN
+            ..=crate::protocol_params::MAX_WITHDRAWALS_PER_EPOCH_MAX)
+            .contains(&max_withdrawals_per_epoch)
+        {
+            return Err(Error::Invalid(
+                "ConsensusState",
+                "max withdrawals per epoch out of bounds",
+            ));
+        }
         let observers_per_validator = buf.try_get_u32().map_err(|_| Error::EndOfBuffer)?;
         let minimum_validator_count = buf.try_get_u64().map_err(|_| Error::EndOfBuffer)?;
         if minimum_validator_count == 0 {
@@ -1927,6 +1942,42 @@ mod tests {
         let predicted_size = state.encode_size();
         let actual_size = state.encode().len();
         assert_eq!(predicted_size, actual_size);
+    }
+
+    #[test]
+    fn test_decode_rejects_out_of_range_max_withdrawals_per_epoch() {
+        use crate::protocol_params::{
+            MAX_WITHDRAWALS_PER_EPOCH_MAX, MAX_WITHDRAWALS_PER_EPOCH_MIN,
+        };
+
+        // Honest nodes only ever serialize a cap within [MIN, MAX] — genesis and
+        // runtime updates both range-check it. A decoded state outside that range
+        // can only come from a crafted checkpoint/state artifact or a tampered DB
+        // blob. The finalizer trusts this cap as authoritative (a zero cap silently
+        // drops every due withdrawal), so decoding must reject it rather than let
+        // the node start/restore from it.
+
+        // Valid boundary values must still decode.
+        for valid in [MAX_WITHDRAWALS_PER_EPOCH_MIN, MAX_WITHDRAWALS_PER_EPOCH_MAX] {
+            let mut state = ConsensusState::default();
+            state.max_withdrawals_per_epoch = valid;
+            let encoded = state.encode();
+            let decoded = ConsensusState::read(&mut encoded.as_ref()).unwrap_or_else(|_| {
+                panic!("valid max_withdrawals_per_epoch {valid} should decode")
+            });
+            assert_eq!(decoded.max_withdrawals_per_epoch, valid);
+        }
+
+        // Out-of-range values (0 below MIN, MAX+1 above MAX) must be rejected.
+        for invalid in [0, MAX_WITHDRAWALS_PER_EPOCH_MAX + 1] {
+            let mut state = ConsensusState::default();
+            state.max_withdrawals_per_epoch = invalid;
+            let encoded = state.encode();
+            assert!(
+                ConsensusState::read(&mut encoded.as_ref()).is_err(),
+                "max_withdrawals_per_epoch {invalid} should be rejected on decode"
+            );
+        }
     }
 
     #[test]

--- a/types/src/genesis.rs
+++ b/types/src/genesis.rs
@@ -173,6 +173,31 @@ impl Genesis {
         self.treasury_address
             .parse::<Address>()
             .map_err(|e| format!("invalid treasury_address: {e}"))?;
+        if self.leader_timeout_ms == 0 {
+            return Err("leader_timeout_ms must be greater than 0".into());
+        }
+        if self.notarization_timeout_ms == 0 {
+            return Err("notarization_timeout_ms must be greater than 0".into());
+        }
+        if self.nullify_timeout_ms == 0 {
+            return Err("nullify_timeout_ms must be greater than 0".into());
+        }
+        if self.activity_timeout_views == 0 {
+            return Err("activity_timeout_views must be greater than 0".into());
+        }
+        if self.skip_timeout_views == 0 {
+            return Err("skip_timeout_views must be greater than 0".into());
+        }
+        if self.leader_timeout_ms > self.notarization_timeout_ms {
+            return Err(
+                "leader_timeout_ms must be less than or equal to notarization_timeout_ms".into(),
+            );
+        }
+        if self.skip_timeout_views > self.activity_timeout_views {
+            return Err(
+                "skip_timeout_views must be less than or equal to activity_timeout_views".into(),
+            );
+        }
         // Genesis must respect the same upper bounds the runtime
         // protocol-parameter update path enforces; otherwise an unchecked
         // genesis value (e.g. supplied over a first-boot RPC) can drive
@@ -353,6 +378,43 @@ mod tests {
         genesis.max_withdrawals_per_epoch = MAX_WITHDRAWALS_PER_EPOCH_MAX + 1;
         assert!(genesis.validate().is_err());
         genesis.max_withdrawals_per_epoch = u64::MAX;
+        assert!(genesis.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_zero_simplex_timeouts() {
+        let mut genesis = Genesis::load_from_file("../example_genesis.toml").unwrap();
+        genesis.leader_timeout_ms = 0;
+        assert!(genesis.validate().is_err());
+
+        let mut genesis = Genesis::load_from_file("../example_genesis.toml").unwrap();
+        genesis.notarization_timeout_ms = 0;
+        assert!(genesis.validate().is_err());
+
+        let mut genesis = Genesis::load_from_file("../example_genesis.toml").unwrap();
+        genesis.nullify_timeout_ms = 0;
+        assert!(genesis.validate().is_err());
+
+        let mut genesis = Genesis::load_from_file("../example_genesis.toml").unwrap();
+        genesis.activity_timeout_views = 0;
+        assert!(genesis.validate().is_err());
+
+        let mut genesis = Genesis::load_from_file("../example_genesis.toml").unwrap();
+        genesis.skip_timeout_views = 0;
+        assert!(genesis.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_misordered_leader_and_notarization_timeouts() {
+        let mut genesis = Genesis::load_from_file("../example_genesis.toml").unwrap();
+        genesis.leader_timeout_ms = genesis.notarization_timeout_ms + 1;
+        assert!(genesis.validate().is_err());
+    }
+
+    #[test]
+    fn rejects_skip_timeout_above_activity_timeout() {
+        let mut genesis = Genesis::load_from_file("../example_genesis.toml").unwrap();
+        genesis.skip_timeout_views = genesis.activity_timeout_views + 1;
         assert!(genesis.validate().is_err());
     }
 

--- a/types/src/genesis.rs
+++ b/types/src/genesis.rs
@@ -1,9 +1,9 @@
 use crate::PublicKey;
 use crate::protocol_params::{
     DEFAULT_MINIMUM_VALIDATOR_COUNT, MAX_ALLOWED_TIMESTAMP_FUTURE_MS, MAX_EPOCH_LENGTH,
-    MAX_MAX_DEPOSITS_PER_EPOCH, MAX_OBSERVERS_PER_VALIDATOR, MAX_WITHDRAWALS_PER_EPOCH_MAX,
-    MAX_WITHDRAWALS_PER_EPOCH_MIN, MIN_ALLOWED_TIMESTAMP_FUTURE_MS, MIN_EPOCH_LENGTH,
-    MIN_MINIMUM_VALIDATOR_COUNT,
+    MAX_MAX_DEPOSITS_PER_EPOCH, MAX_MESSAGE_SIZE_BYTES_MAX, MAX_MESSAGE_SIZE_BYTES_MIN,
+    MAX_OBSERVERS_PER_VALIDATOR, MAX_WITHDRAWALS_PER_EPOCH_MAX, MAX_WITHDRAWALS_PER_EPOCH_MIN,
+    MIN_ALLOWED_TIMESTAMP_FUTURE_MS, MIN_EPOCH_LENGTH, MIN_MINIMUM_VALIDATOR_COUNT,
 };
 use alloy_primitives::Address;
 use anyhow::Context;
@@ -167,6 +167,19 @@ impl Genesis {
             return Err(format!(
                 "validator_minimum_stake {} exceeds validator_maximum_stake {}",
                 self.validator_minimum_stake, self.validator_maximum_stake
+            )
+            .into());
+        }
+        // The P2P message ceiling must hold the largest legitimate message (full
+        // blocks, checkpoints) yet stay bounded against per-message allocation DoS,
+        // and must not exceed u32::MAX (the p2p config converts it with `as u32`,
+        // which would otherwise silently truncate). A zero value would reject every
+        // message and brick networking.
+        if self.max_message_size_bytes < MAX_MESSAGE_SIZE_BYTES_MIN
+            || self.max_message_size_bytes > MAX_MESSAGE_SIZE_BYTES_MAX
+        {
+            return Err(format!(
+                "max_message_size_bytes must be between {MAX_MESSAGE_SIZE_BYTES_MIN} and {MAX_MESSAGE_SIZE_BYTES_MAX}"
             )
             .into());
         }
@@ -409,6 +422,28 @@ mod tests {
         genesis.blocks_per_epoch = MAX_EPOCH_LENGTH + 1;
         assert!(genesis.validate().is_err());
         genesis.blocks_per_epoch = u64::MAX;
+        assert!(genesis.validate().is_err());
+    }
+
+    #[test]
+    fn accepts_max_message_size_bytes_at_bounds() {
+        let mut genesis = Genesis::load_from_file("../example_genesis.toml").unwrap();
+        genesis.max_message_size_bytes = MAX_MESSAGE_SIZE_BYTES_MIN;
+        assert!(genesis.validate().is_ok());
+        genesis.max_message_size_bytes = MAX_MESSAGE_SIZE_BYTES_MAX;
+        assert!(genesis.validate().is_ok());
+    }
+
+    #[test]
+    fn rejects_max_message_size_bytes_outside_bounds() {
+        let mut genesis = Genesis::load_from_file("../example_genesis.toml").unwrap();
+        genesis.max_message_size_bytes = 0;
+        assert!(genesis.validate().is_err());
+        genesis.max_message_size_bytes = MAX_MESSAGE_SIZE_BYTES_MIN - 1;
+        assert!(genesis.validate().is_err());
+        genesis.max_message_size_bytes = MAX_MESSAGE_SIZE_BYTES_MAX + 1;
+        assert!(genesis.validate().is_err());
+        genesis.max_message_size_bytes = u64::MAX;
         assert!(genesis.validate().is_err());
     }
 

--- a/types/src/genesis.rs
+++ b/types/src/genesis.rs
@@ -1,9 +1,7 @@
 use crate::PublicKey;
 use crate::protocol_params::{
-    DEFAULT_MINIMUM_VALIDATOR_COUNT, MAX_ALLOWED_TIMESTAMP_FUTURE_MS, MAX_EPOCH_LENGTH,
-    MAX_MAX_DEPOSITS_PER_EPOCH, MAX_MESSAGE_SIZE_BYTES_MAX, MAX_MESSAGE_SIZE_BYTES_MIN,
-    MAX_OBSERVERS_PER_VALIDATOR, MAX_WITHDRAWALS_PER_EPOCH_MAX, MAX_WITHDRAWALS_PER_EPOCH_MIN,
-    MIN_ALLOWED_TIMESTAMP_FUTURE_MS, MIN_EPOCH_LENGTH, MIN_MINIMUM_VALIDATOR_COUNT,
+    DEFAULT_MINIMUM_VALIDATOR_COUNT, MAX_MESSAGE_SIZE_BYTES_MAX, MAX_MESSAGE_SIZE_BYTES_MIN,
+    MIN_MINIMUM_VALIDATOR_COUNT, ProtocolParam,
 };
 use alloy_primitives::Address;
 use anyhow::Context;
@@ -153,16 +151,12 @@ impl Genesis {
 
     fn validate(&self) -> Result<(), Box<dyn std::error::Error>> {
         // Genesis epoch length must satisfy the same bounds as a runtime
-        // EpochLength protocol-parameter update (see ProtocolParam). An oversized
-        // launch value defers every epoch-boundary mechanic — checkpoints, final-block
-        // withdrawals, committee transitions, queued param changes — until that
-        // boundary, turning epoch functionality into a liveness failure.
-        if self.blocks_per_epoch < MIN_EPOCH_LENGTH || self.blocks_per_epoch > MAX_EPOCH_LENGTH {
-            return Err(format!(
-                "blocks_per_epoch must be between {MIN_EPOCH_LENGTH} and {MAX_EPOCH_LENGTH}"
-            )
-            .into());
-        }
+        // EpochLength protocol-parameter update (hence the shared ProtocolParam
+        // validation). An oversized launch value defers every epoch-boundary
+        // mechanic — checkpoints, final-block withdrawals, committee transitions,
+        // queued param changes — until that boundary, turning epoch functionality
+        // into a liveness failure.
+        ProtocolParam::EpochLength(self.blocks_per_epoch).validate()?;
         if self.validator_minimum_stake > self.validator_maximum_stake {
             return Err(format!(
                 "validator_minimum_stake {} exceeds validator_maximum_stake {}",
@@ -183,15 +177,7 @@ impl Genesis {
             )
             .into());
         }
-        if self.allowed_timestamp_future_ms < MIN_ALLOWED_TIMESTAMP_FUTURE_MS
-            || self.allowed_timestamp_future_ms > MAX_ALLOWED_TIMESTAMP_FUTURE_MS
-        {
-            return Err(format!(
-                "allowed_timestamp_future_ms must be between {} and {}",
-                MIN_ALLOWED_TIMESTAMP_FUTURE_MS, MAX_ALLOWED_TIMESTAMP_FUTURE_MS
-            )
-            .into());
-        }
+        ProtocolParam::AllowedTimestampFuture(self.allowed_timestamp_future_ms).validate()?;
         self.treasury_address
             .parse::<Address>()
             .map_err(|e| format!("invalid treasury_address: {e}"))?;
@@ -220,33 +206,16 @@ impl Genesis {
                 "skip_timeout_views must be less than or equal to activity_timeout_views".into(),
             );
         }
-        // Genesis must respect the same upper bounds the runtime
-        // protocol-parameter update path enforces; otherwise an unchecked
-        // genesis value (e.g. supplied over a first-boot RPC) can drive
-        // consensus state outside any limit Summit policy was designed for.
-        if self.max_deposits_per_epoch > MAX_MAX_DEPOSITS_PER_EPOCH {
-            return Err(format!(
-                "max_deposits_per_epoch {} exceeds maximum {}",
-                self.max_deposits_per_epoch, MAX_MAX_DEPOSITS_PER_EPOCH
-            )
-            .into());
-        }
-        if self.max_withdrawals_per_epoch < MAX_WITHDRAWALS_PER_EPOCH_MIN
-            || self.max_withdrawals_per_epoch > MAX_WITHDRAWALS_PER_EPOCH_MAX
-        {
-            return Err(format!(
-                "max_withdrawals_per_epoch must be between {} and {}",
-                MAX_WITHDRAWALS_PER_EPOCH_MIN, MAX_WITHDRAWALS_PER_EPOCH_MAX
-            )
-            .into());
-        }
-        if u64::from(self.observers_per_validator) > MAX_OBSERVERS_PER_VALIDATOR {
-            return Err(format!(
-                "observers_per_validator {} exceeds maximum {}",
-                self.observers_per_validator, MAX_OBSERVERS_PER_VALIDATOR
-            )
-            .into());
-        }
+        // Genesis must respect the same bounds the runtime protocol-parameter
+        // update path enforces; otherwise an unchecked genesis value (e.g. supplied
+        // over a first-boot RPC) can drive consensus state outside any limit Summit
+        // policy was designed for. These reuse the single ProtocolParam validator so
+        // the genesis and runtime bounds cannot drift apart.
+        ProtocolParam::MaxDepositsPerEpoch(self.max_deposits_per_epoch).validate()?;
+        ProtocolParam::MaxWithdrawalsPerEpoch(self.max_withdrawals_per_epoch).validate()?;
+        ProtocolParam::ObserversPerValidator(u64::from(self.observers_per_validator)).validate()?;
+        // `minimum_validator_count` has no scalar bound in `ProtocolParam::validate`
+        // (it carries no `ParamBoundsError` variant), so its floor is enforced here.
         if self.minimum_validator_count < MIN_MINIMUM_VALIDATOR_COUNT {
             return Err(format!(
                 "minimum_validator_count {} is below minimum {}",
@@ -320,6 +289,10 @@ impl Genesis {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::protocol_params::{
+        MAX_EPOCH_LENGTH, MAX_MAX_DEPOSITS_PER_EPOCH, MAX_OBSERVERS_PER_VALIDATOR,
+        MAX_WITHDRAWALS_PER_EPOCH_MAX, MAX_WITHDRAWALS_PER_EPOCH_MIN, MIN_EPOCH_LENGTH,
+    };
 
     #[test]
     fn test_loading_genesis() {

--- a/types/src/genesis.rs
+++ b/types/src/genesis.rs
@@ -1,8 +1,9 @@
 use crate::PublicKey;
 use crate::protocol_params::{
-    DEFAULT_MINIMUM_VALIDATOR_COUNT, MAX_ALLOWED_TIMESTAMP_FUTURE_MS, MAX_MAX_DEPOSITS_PER_EPOCH,
-    MAX_OBSERVERS_PER_VALIDATOR, MAX_WITHDRAWALS_PER_EPOCH_MAX, MAX_WITHDRAWALS_PER_EPOCH_MIN,
-    MIN_ALLOWED_TIMESTAMP_FUTURE_MS, MIN_MINIMUM_VALIDATOR_COUNT,
+    DEFAULT_MINIMUM_VALIDATOR_COUNT, MAX_ALLOWED_TIMESTAMP_FUTURE_MS, MAX_EPOCH_LENGTH,
+    MAX_MAX_DEPOSITS_PER_EPOCH, MAX_OBSERVERS_PER_VALIDATOR, MAX_WITHDRAWALS_PER_EPOCH_MAX,
+    MAX_WITHDRAWALS_PER_EPOCH_MIN, MIN_ALLOWED_TIMESTAMP_FUTURE_MS, MIN_EPOCH_LENGTH,
+    MIN_MINIMUM_VALIDATOR_COUNT,
 };
 use alloy_primitives::Address;
 use anyhow::Context;
@@ -151,8 +152,16 @@ impl Genesis {
     }
 
     fn validate(&self) -> Result<(), Box<dyn std::error::Error>> {
-        if self.blocks_per_epoch == 0 {
-            return Err("blocks_per_epoch must be greater than 0".into());
+        // Genesis epoch length must satisfy the same bounds as a runtime
+        // EpochLength protocol-parameter update (see ProtocolParam). An oversized
+        // launch value defers every epoch-boundary mechanic — checkpoints, final-block
+        // withdrawals, committee transitions, queued param changes — until that
+        // boundary, turning epoch functionality into a liveness failure.
+        if self.blocks_per_epoch < MIN_EPOCH_LENGTH || self.blocks_per_epoch > MAX_EPOCH_LENGTH {
+            return Err(format!(
+                "blocks_per_epoch must be between {MIN_EPOCH_LENGTH} and {MAX_EPOCH_LENGTH}"
+            )
+            .into());
         }
         if self.validator_minimum_stake > self.validator_maximum_stake {
             return Err(format!(
@@ -378,6 +387,28 @@ mod tests {
         genesis.max_withdrawals_per_epoch = MAX_WITHDRAWALS_PER_EPOCH_MAX + 1;
         assert!(genesis.validate().is_err());
         genesis.max_withdrawals_per_epoch = u64::MAX;
+        assert!(genesis.validate().is_err());
+    }
+
+    #[test]
+    fn accepts_blocks_per_epoch_at_bounds() {
+        let mut genesis = Genesis::load_from_file("../example_genesis.toml").unwrap();
+        genesis.blocks_per_epoch = MIN_EPOCH_LENGTH;
+        assert!(genesis.validate().is_ok());
+        genesis.blocks_per_epoch = MAX_EPOCH_LENGTH;
+        assert!(genesis.validate().is_ok());
+    }
+
+    #[test]
+    fn rejects_blocks_per_epoch_outside_bounds() {
+        let mut genesis = Genesis::load_from_file("../example_genesis.toml").unwrap();
+        genesis.blocks_per_epoch = 0;
+        assert!(genesis.validate().is_err());
+        genesis.blocks_per_epoch = MIN_EPOCH_LENGTH - 1;
+        assert!(genesis.validate().is_err());
+        genesis.blocks_per_epoch = MAX_EPOCH_LENGTH + 1;
+        assert!(genesis.validate().is_err());
+        genesis.blocks_per_epoch = u64::MAX;
         assert!(genesis.validate().is_err());
     }
 

--- a/types/src/protocol_params.rs
+++ b/types/src/protocol_params.rs
@@ -16,6 +16,13 @@ pub const MIN_OBSERVERS_PER_VALIDATOR: u64 = 0;
 pub const MAX_OBSERVERS_PER_VALIDATOR: u64 = 256;
 pub const MIN_MINIMUM_VALIDATOR_COUNT: u64 = 1;
 pub const DEFAULT_MINIMUM_VALIDATOR_COUNT: u64 = 3;
+// Bounds on the genesis `max_message_size_bytes`. The floor must be large enough
+// to carry the largest legitimate P2P message (full blocks dominate; checkpoints
+// scale with validator count); below it, large-block sync stalls. The ceiling
+// bounds per-message allocation (anti-DoS) and stays well under `u32::MAX`, which
+// is the hard limit imposed by the `as u32` conversion at the p2p config boundary.
+pub const MAX_MESSAGE_SIZE_BYTES_MIN: u64 = 1 << 20; // 1 MiB
+pub const MAX_MESSAGE_SIZE_BYTES_MAX: u64 = 1 << 30; // 1 GiB
 
 #[derive(Clone, Debug)]
 pub enum ProtocolParam {

--- a/types/src/protocol_params.rs
+++ b/types/src/protocol_params.rs
@@ -37,6 +37,107 @@ pub enum ProtocolParam {
     MinimumValidatorCount(u64),
 }
 
+/// A protocol-parameter value that fell outside its allowed bounds.
+///
+/// This is the single source of truth for per-parameter value bounds, shared by
+/// every site that validates a [`ProtocolParam`]: the execution-request parse path
+/// ([`TryFrom<ProtocolParamRequest>`](ProtocolParam), the codec decode path
+/// ([`Read`]), and genesis validation. Each caller maps it into its own error
+/// type — [`reason`](Self::reason) yields the `&'static str` the codec layer
+/// requires, while [`Display`](std::fmt::Display) carries the offending value for
+/// the human-facing (anyhow / genesis) paths.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ParamBoundsError {
+    EpochLength(u64),
+    AllowedTimestampFuture(u64),
+    MaxDepositsPerEpoch(u64),
+    MaxWithdrawalsPerEpoch(u64),
+    ObserversPerValidator(u64),
+}
+
+impl ParamBoundsError {
+    /// Stable, value-free reason string. Required by [`commonware_codec::Error::Invalid`],
+    /// which only accepts `&'static str` and so cannot carry the offending value.
+    pub fn reason(&self) -> &'static str {
+        match self {
+            Self::EpochLength(_) => "epoch length out of bounds",
+            Self::AllowedTimestampFuture(_) => "allowed timestamp future out of bounds",
+            Self::MaxDepositsPerEpoch(_) => "max deposits per epoch out of bounds",
+            Self::MaxWithdrawalsPerEpoch(_) => "max withdrawals per epoch out of bounds",
+            Self::ObserversPerValidator(_) => "observers per validator out of bounds",
+        }
+    }
+}
+
+impl std::fmt::Display for ParamBoundsError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::EpochLength(v) => write!(
+                f,
+                "epoch length {v} must be between {MIN_EPOCH_LENGTH} and {MAX_EPOCH_LENGTH}"
+            ),
+            Self::AllowedTimestampFuture(v) => write!(
+                f,
+                "allowed timestamp future {v}ms must be between {MIN_ALLOWED_TIMESTAMP_FUTURE_MS} and {MAX_ALLOWED_TIMESTAMP_FUTURE_MS}"
+            ),
+            Self::MaxDepositsPerEpoch(v) => write!(
+                f,
+                "max deposits per epoch {v} must not exceed {MAX_MAX_DEPOSITS_PER_EPOCH}"
+            ),
+            Self::MaxWithdrawalsPerEpoch(v) => write!(
+                f,
+                "max withdrawals per epoch {v} must be between {MAX_WITHDRAWALS_PER_EPOCH_MIN} and {MAX_WITHDRAWALS_PER_EPOCH_MAX}"
+            ),
+            Self::ObserversPerValidator(v) => write!(
+                f,
+                "observers per validator {v} must not exceed {MAX_OBSERVERS_PER_VALIDATOR}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ParamBoundsError {}
+
+impl ProtocolParam {
+    /// Validate this parameter's value against its protocol bounds.
+    ///
+    /// The authoritative per-parameter bounds check. Every construction site
+    /// ([`TryFrom<ProtocolParamRequest>`](ProtocolParam), [`Read`], genesis) calls
+    /// this so the numeric bounds live in exactly one place. Variants without a
+    /// scalar bound ([`MinimumStake`](Self::MinimumStake),
+    /// [`MaximumStake`](Self::MaximumStake), [`TreasuryAddress`](Self::TreasuryAddress))
+    /// always pass — the stake-interval invariant is cross-field and is enforced in
+    /// `ConsensusState`.
+    pub fn validate(&self) -> Result<(), ParamBoundsError> {
+        match *self {
+            ProtocolParam::EpochLength(v)
+                if !(MIN_EPOCH_LENGTH..=MAX_EPOCH_LENGTH).contains(&v) =>
+            {
+                Err(ParamBoundsError::EpochLength(v))
+            }
+            ProtocolParam::AllowedTimestampFuture(v)
+                if !(MIN_ALLOWED_TIMESTAMP_FUTURE_MS..=MAX_ALLOWED_TIMESTAMP_FUTURE_MS)
+                    .contains(&v) =>
+            {
+                Err(ParamBoundsError::AllowedTimestampFuture(v))
+            }
+            ProtocolParam::MaxDepositsPerEpoch(v) if v > MAX_MAX_DEPOSITS_PER_EPOCH => {
+                Err(ParamBoundsError::MaxDepositsPerEpoch(v))
+            }
+            ProtocolParam::MaxWithdrawalsPerEpoch(v)
+                if !(MAX_WITHDRAWALS_PER_EPOCH_MIN..=MAX_WITHDRAWALS_PER_EPOCH_MAX)
+                    .contains(&v) =>
+            {
+                Err(ParamBoundsError::MaxWithdrawalsPerEpoch(v))
+            }
+            ProtocolParam::ObserversPerValidator(v) if v > MAX_OBSERVERS_PER_VALIDATOR => {
+                Err(ParamBoundsError::ObserversPerValidator(v))
+            }
+            _ => Ok(()),
+        }
+    }
+}
+
 impl TryFrom<ProtocolParamRequest> for ProtocolParam {
     type Error = anyhow::Error;
 
@@ -73,18 +174,9 @@ impl TryFrom<ProtocolParamRequest> for ProtocolParam {
                     ));
                 }
                 let bytes: [u8; 8] = request.param.as_slice().try_into()?;
-                let epoch_length = u64::from_le_bytes(bytes);
-                if epoch_length < MIN_EPOCH_LENGTH {
-                    return Err(anyhow!(
-                        "Epoch length {epoch_length} is below minimum {MIN_EPOCH_LENGTH}"
-                    ));
-                }
-                if epoch_length > MAX_EPOCH_LENGTH {
-                    return Err(anyhow!(
-                        "Epoch length {epoch_length} exceeds maximum {MAX_EPOCH_LENGTH}"
-                    ));
-                }
-                Ok(ProtocolParam::EpochLength(epoch_length))
+                let param = ProtocolParam::EpochLength(u64::from_le_bytes(bytes));
+                param.validate().map_err(|e| anyhow!("{e}"))?;
+                Ok(param)
             }
             0x03 => {
                 if request.param.len() != 8 {
@@ -94,20 +186,9 @@ impl TryFrom<ProtocolParamRequest> for ProtocolParam {
                     ));
                 }
                 let bytes: [u8; 8] = request.param.as_slice().try_into()?;
-                let allowed_timestamp_future = u64::from_le_bytes(bytes);
-                if allowed_timestamp_future < MIN_ALLOWED_TIMESTAMP_FUTURE_MS {
-                    return Err(anyhow!(
-                        "Allowed timestamp future {allowed_timestamp_future}ms is below minimum {MIN_ALLOWED_TIMESTAMP_FUTURE_MS}ms"
-                    ));
-                }
-                if allowed_timestamp_future > MAX_ALLOWED_TIMESTAMP_FUTURE_MS {
-                    return Err(anyhow!(
-                        "Allowed timestamp future {allowed_timestamp_future}ms exceeds maximum {MAX_ALLOWED_TIMESTAMP_FUTURE_MS}ms"
-                    ));
-                }
-                Ok(ProtocolParam::AllowedTimestampFuture(
-                    allowed_timestamp_future,
-                ))
+                let param = ProtocolParam::AllowedTimestampFuture(u64::from_le_bytes(bytes));
+                param.validate().map_err(|e| anyhow!("{e}"))?;
+                Ok(param)
             }
             0x04 => {
                 if request.param.len() != 20 {
@@ -127,13 +208,9 @@ impl TryFrom<ProtocolParamRequest> for ProtocolParam {
                     ));
                 }
                 let bytes: [u8; 8] = request.param.as_slice().try_into()?;
-                let max_deposits_per_epoch = u64::from_le_bytes(bytes);
-                if max_deposits_per_epoch > MAX_MAX_DEPOSITS_PER_EPOCH {
-                    return Err(anyhow!(
-                        "Max joining per epoch {max_deposits_per_epoch} exceeds maximum {MAX_MAX_DEPOSITS_PER_EPOCH}"
-                    ));
-                }
-                Ok(ProtocolParam::MaxDepositsPerEpoch(max_deposits_per_epoch))
+                let param = ProtocolParam::MaxDepositsPerEpoch(u64::from_le_bytes(bytes));
+                param.validate().map_err(|e| anyhow!("{e}"))?;
+                Ok(param)
             }
             0x06 => {
                 if request.param.len() != 8 {
@@ -143,20 +220,9 @@ impl TryFrom<ProtocolParamRequest> for ProtocolParam {
                     ));
                 }
                 let bytes: [u8; 8] = request.param.as_slice().try_into()?;
-                let max_withdrawals_per_epoch = u64::from_le_bytes(bytes);
-                if max_withdrawals_per_epoch < MAX_WITHDRAWALS_PER_EPOCH_MIN {
-                    return Err(anyhow!(
-                        "Max withdrawals per epoch {max_withdrawals_per_epoch} is below minimum {MAX_WITHDRAWALS_PER_EPOCH_MIN}"
-                    ));
-                }
-                if max_withdrawals_per_epoch > MAX_WITHDRAWALS_PER_EPOCH_MAX {
-                    return Err(anyhow!(
-                        "Max withdrawals per epoch {max_withdrawals_per_epoch} exceeds maximum {MAX_WITHDRAWALS_PER_EPOCH_MAX}"
-                    ));
-                }
-                Ok(ProtocolParam::MaxWithdrawalsPerEpoch(
-                    max_withdrawals_per_epoch,
-                ))
+                let param = ProtocolParam::MaxWithdrawalsPerEpoch(u64::from_le_bytes(bytes));
+                param.validate().map_err(|e| anyhow!("{e}"))?;
+                Ok(param)
             }
             0x07 => {
                 if request.param.len() != 8 {
@@ -166,15 +232,9 @@ impl TryFrom<ProtocolParamRequest> for ProtocolParam {
                     ));
                 }
                 let bytes: [u8; 8] = request.param.as_slice().try_into()?;
-                let observers_per_validator = u64::from_le_bytes(bytes);
-                if observers_per_validator > MAX_OBSERVERS_PER_VALIDATOR {
-                    return Err(anyhow!(
-                        "Observers per validator {observers_per_validator} exceeds maximum {MAX_OBSERVERS_PER_VALIDATOR}"
-                    ));
-                }
-                Ok(ProtocolParam::ObserversPerValidator(
-                    observers_per_validator,
-                ))
+                let param = ProtocolParam::ObserversPerValidator(u64::from_le_bytes(bytes));
+                param.validate().map_err(|e| anyhow!("{e}"))?;
+                Ok(param)
             }
             0x08 => {
                 if request.param.len() != 8 {
@@ -276,25 +336,19 @@ impl Read for ProtocolParam {
             }
             0x02 => {
                 let value = buf.try_get_u64().map_err(|_| Error::EndOfBuffer)?;
-                if !(MIN_EPOCH_LENGTH..=MAX_EPOCH_LENGTH).contains(&value) {
-                    return Err(Error::Invalid(
-                        "ProtocolParam",
-                        "epoch length out of bounds",
-                    ));
-                }
-                Ok(ProtocolParam::EpochLength(value))
+                let param = ProtocolParam::EpochLength(value);
+                param
+                    .validate()
+                    .map_err(|e| Error::Invalid("ProtocolParam", e.reason()))?;
+                Ok(param)
             }
             0x03 => {
                 let value = buf.try_get_u64().map_err(|_| Error::EndOfBuffer)?;
-                if !(MIN_ALLOWED_TIMESTAMP_FUTURE_MS..=MAX_ALLOWED_TIMESTAMP_FUTURE_MS)
-                    .contains(&value)
-                {
-                    return Err(Error::Invalid(
-                        "ProtocolParam",
-                        "allowed timestamp future out of bounds",
-                    ));
-                }
-                Ok(ProtocolParam::AllowedTimestampFuture(value))
+                let param = ProtocolParam::AllowedTimestampFuture(value);
+                param
+                    .validate()
+                    .map_err(|e| Error::Invalid("ProtocolParam", e.reason()))?;
+                Ok(param)
             }
             0x04 => {
                 let mut bytes = [0u8; 20];
@@ -304,34 +358,27 @@ impl Read for ProtocolParam {
             }
             0x05 => {
                 let value = buf.try_get_u64().map_err(|_| Error::EndOfBuffer)?;
-                if value > MAX_MAX_DEPOSITS_PER_EPOCH {
-                    return Err(Error::Invalid(
-                        "ProtocolParam",
-                        "max deposits per epoch out of bounds",
-                    ));
-                }
-                Ok(ProtocolParam::MaxDepositsPerEpoch(value))
+                let param = ProtocolParam::MaxDepositsPerEpoch(value);
+                param
+                    .validate()
+                    .map_err(|e| Error::Invalid("ProtocolParam", e.reason()))?;
+                Ok(param)
             }
             0x06 => {
                 let value = buf.try_get_u64().map_err(|_| Error::EndOfBuffer)?;
-                if !(MAX_WITHDRAWALS_PER_EPOCH_MIN..=MAX_WITHDRAWALS_PER_EPOCH_MAX).contains(&value)
-                {
-                    return Err(Error::Invalid(
-                        "ProtocolParam",
-                        "max withdrawals per epoch out of bounds",
-                    ));
-                }
-                Ok(ProtocolParam::MaxWithdrawalsPerEpoch(value))
+                let param = ProtocolParam::MaxWithdrawalsPerEpoch(value);
+                param
+                    .validate()
+                    .map_err(|e| Error::Invalid("ProtocolParam", e.reason()))?;
+                Ok(param)
             }
             0x07 => {
                 let value = buf.try_get_u64().map_err(|_| Error::EndOfBuffer)?;
-                if value > MAX_OBSERVERS_PER_VALIDATOR {
-                    return Err(Error::Invalid(
-                        "ProtocolParam",
-                        "observers per validator out of bounds",
-                    ));
-                }
-                Ok(ProtocolParam::ObserversPerValidator(value))
+                let param = ProtocolParam::ObserversPerValidator(value);
+                param
+                    .validate()
+                    .map_err(|e| Error::Invalid("ProtocolParam", e.reason()))?;
+                Ok(param)
             }
             0x08 => {
                 let value = buf.try_get_u64().map_err(|_| Error::EndOfBuffer)?;
@@ -661,6 +708,47 @@ mod tests {
             ProtocolParam::EpochLength(v) => assert_eq!(v, 500),
             _ => panic!("Expected EpochLength"),
         }
+    }
+
+    /// All three construction paths share `ProtocolParam::validate`, so an
+    /// out-of-bounds value must be rejected identically by the validator itself,
+    /// the execution-request parse path, and the codec decode path. This guards
+    /// against the centralized validator silently loosening any one path.
+    #[test]
+    fn all_entry_points_reject_same_out_of_bounds_value() {
+        let below_min = MIN_EPOCH_LENGTH - 1;
+        let above_max = MAX_EPOCH_LENGTH + 1;
+
+        for bad in [below_min, above_max] {
+            // 1. The param validator directly.
+            assert!(ProtocolParam::EpochLength(bad).validate().is_err());
+
+            // 2. The execution-request parse path.
+            let request = ProtocolParamRequest {
+                param_id: 0x02,
+                param: bad.to_le_bytes().to_vec(),
+            };
+            assert!(ProtocolParam::try_from(request).is_err());
+
+            // 3. The codec decode path.
+            let mut buf = BytesMut::new();
+            buf.put_u8(0x02);
+            buf.put_u64(bad);
+            assert!(ProtocolParam::read(&mut buf.as_ref()).is_err());
+        }
+
+        // A within-bounds value passes all three.
+        let good = MIN_EPOCH_LENGTH;
+        assert!(ProtocolParam::EpochLength(good).validate().is_ok());
+        let request = ProtocolParamRequest {
+            param_id: 0x02,
+            param: good.to_le_bytes().to_vec(),
+        };
+        assert!(ProtocolParam::try_from(request).is_ok());
+        let mut buf = BytesMut::new();
+        buf.put_u8(0x02);
+        buf.put_u64(good);
+        assert!(ProtocolParam::read(&mut buf.as_ref()).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
Builds on https://github.com/SeismicSystems/summit/pull/271.

Addresses https://github.com/SeismicSystems/summit/issues/247, https://github.com/SeismicSystems/summit/issues/224, https://github.com/SeismicSystems/summit/issues/223, https://github.com/SeismicSystems/summit/issues/221.

Adds validation for genesis entries.

Changes:
- Epoch length - genesis blocks_per_epoch must be MIN_EPOCH_LENGTH..=MAX_EPOCH_LENGTH.
- Max withdrawals/epoch - reject out-of-range max_withdrawals_per_epoch when decoding ConsensusState (covers checkpoint and raw-state load), matching genesis.
- Stake bounds - reject inverted min > max at genesis and on runtime stake updates, which would otherwise make the balance check unsatisfiable.
- Simplex timeouts - validate genesis timeout/view fields are nonzero and ordered.
- Max message size - genesis max_message_size_bytes must be 1 MiB..=1 GiB.