### PR TITLE
fix: validate genesis before treating path as provisioned

### DIFF
--- a/node/src/args.rs
+++ b/node/src/args.rs
@@ -186,26 +186,6 @@ impl Command {
         }
     }
 
-    fn has_file(path: &str) -> bool {
-        let path_buf = get_expanded_path(path).expect("Invalid filepath");
-        path_buf.exists()
-            || !std::fs::read_to_string(&path_buf)
-                .unwrap_or_default()
-                .trim()
-                .is_empty()
-    }
-
-    fn check_sender(path: String, tx: oneshot::Sender<()>) -> PathSender {
-        let sender = match Self::has_file(&path) {
-            true => {
-                let _ = tx.send(());
-                None
-            }
-            false => Some(tx),
-        };
-        PathSender::new(path, sender)
-    }
-
     pub fn run_node(&self, flags: &RunFlags) {
         // Initialize tokio-console subscriber if feature is enabled
         #[cfg(feature = "tokio-console")]
@@ -246,29 +226,52 @@ impl Command {
     }
 }
 
-async fn run_node_inner(
-    context: tokio::Context,
-    flags: RunFlags,
-    key_store: KeyStore<PrivateKey>,
-    loaded: LoadedCheckpoint<MultisigScheme>,
-) {
-    let context = context.with_label("summit_cw");
-    let (genesis_tx, genesis_rx) = oneshot::channel();
+/// Resolve the node's genesis, provisioning it over the first-boot RPC if needed.
+///
+/// Behavior is decided by the state of the configured genesis path:
+/// - **Absent:** start the genesis provisioning RPC and wait for a valid genesis to
+///   be installed (`send_genesis` validates and atomically renames into place).
+/// - **Present and valid:** return it immediately; the provisioning RPC is never
+///   exposed once a usable genesis exists.
+/// - **Present but invalid** (empty, partial, or malformed): exit with a clear
+///   error. We do not fall back to provisioning when a file already occupies the
+///   path, and we do not silently crash-loop on every restart — the operator must
+///   remove or replace the file to recover.
+async fn acquire_genesis(context: &tokio::Context, flags: &RunFlags) -> Genesis {
+    let genesis_path = flags.genesis_path.clone();
 
+    let present = get_expanded_path(&genesis_path)
+        .map(|p| p.exists())
+        .unwrap_or(false);
+    if present {
+        match Genesis::load_from_file(&genesis_path) {
+            Ok(genesis) => return genesis,
+            Err(e) => {
+                error!(
+                    "existing genesis file '{genesis_path}' is invalid: {e}; remove or replace it to recover"
+                );
+                std::process::exit(1);
+            }
+        }
+    }
+
+    // First boot: no usable genesis yet. Wait for the provisioning RPC to install
+    // one. Because `send_genesis` validates and atomically renames, once the signal
+    // fires the file at the path is guaranteed to parse and validate.
+    let (genesis_tx, genesis_rx) = oneshot::channel();
     let cancel_token = CancellationToken::new();
     let cloned_token = cancel_token.clone();
-
-    let genesis_path = flags.genesis_path.clone();
     let genesis_key_store_path = flags.key_store_path.clone();
     let genesis_rpc_port = flags.rpc_port;
     let rpc_body_limits = RpcBodyLimits {
         max_request_body_size: flags.rpc_max_request_body_size,
         max_response_body_size: flags.rpc_max_response_body_size,
     };
+    let rpc_genesis_path = genesis_path.clone();
     let _rpc_handle = context
         .with_label("rpc_genesis")
         .spawn(move |_context| async move {
-            let genesis_sender = Command::check_sender(genesis_path, genesis_tx);
+            let genesis_sender = PathSender::new(rpc_genesis_path, Some(genesis_tx));
             if let Err(e) = start_rpc_server_for_genesis(
                 genesis_sender,
                 genesis_key_store_path,
@@ -282,12 +285,22 @@ async fn run_node_inner(
             }
         });
 
-    // Wait for genesis if needed
+    // Wait for genesis, then shut down the provisioning RPC.
     let _ = genesis_rx.await;
-    // Shut down the genesis rpc server after receiving the genesis file
     cancel_token.cancel();
 
-    let genesis = Genesis::load_from_file(&flags.genesis_path).expect("Can not find genesis file");
+    Genesis::load_from_file(&genesis_path).expect("genesis file should be valid after provisioning")
+}
+
+async fn run_node_inner(
+    context: tokio::Context,
+    flags: RunFlags,
+    key_store: KeyStore<PrivateKey>,
+    loaded: LoadedCheckpoint<MultisigScheme>,
+) {
+    let context = context.with_label("summit_cw");
+
+    let genesis = acquire_genesis(&context, &flags).await;
 
     let mut committee: Vec<Validator> = genesis.get_validators().expect("Failed to get validators");
     committee.sort_by(|lhs, rhs| lhs.node_public_key.cmp(&rhs.node_public_key));
@@ -481,40 +494,7 @@ async fn run_node_local_inner(
 ) {
     let context = context.with_label("summit_cw");
 
-    let (genesis_tx, genesis_rx) = oneshot::channel();
-
-    let cancel_token = CancellationToken::new();
-    let cloned_token = cancel_token.clone();
-    let genesis_rpc_port = flags.rpc_port;
-    let genesis_path = flags.genesis_path.clone();
-    let genesis_key_store_path = flags.key_store_path.clone();
-    let rpc_body_limits = RpcBodyLimits {
-        max_request_body_size: flags.rpc_max_request_body_size,
-        max_response_body_size: flags.rpc_max_response_body_size,
-    };
-    let _rpc_handle = context
-        .with_label("rpc_genesis")
-        .spawn(move |_context| async move {
-            let genesis_sender = Command::check_sender(genesis_path, genesis_tx);
-            if let Err(e) = start_rpc_server_for_genesis(
-                genesis_sender,
-                genesis_key_store_path,
-                genesis_rpc_port,
-                rpc_body_limits,
-                cloned_token,
-            )
-            .await
-            {
-                error!("RPC server failed: {}", e);
-            }
-        });
-
-    // Wait for genesis if needed
-    let _ = genesis_rx.await;
-    // Shut down the genesis rpc server after receiving the genesis file
-    cancel_token.cancel();
-
-    let genesis = Genesis::load_from_file(&flags.genesis_path).expect("Can not find genesis file");
+    let genesis = acquire_genesis(&context, &flags).await;
 
     let mut committee: Vec<Validator> = genesis.get_validators().expect("Failed to get validators");
     committee.sort_by(|lhs, rhs| lhs.node_public_key.cmp(&rhs.node_public_key));

--- a/node/src/args.rs
+++ b/node/src/args.rs
@@ -300,6 +300,17 @@ async fn run_node_inner(
 ) {
     let context = context.with_label("summit_cw");
 
+    // Initialize telemetry first, before genesis acquisition. First-boot
+    // provisioning can block in acquire_genesis waiting for the genesis RPC, so the
+    // subscriber must already be installed or those logs (and the RPC's own
+    // "listening" line) are silently dropped.
+    let log_level = Level::from_str(&flags.log_level).expect("Invalid log level");
+    let critical_log_dir = flags
+        .critical_log_dir
+        .as_ref()
+        .map(|p| get_expanded_path(p).expect("Invalid critical log directory path"));
+    let _critical_log_guard = crate::telemetry::init(log_level, critical_log_dir.as_deref());
+
     let genesis = acquire_genesis(&context, &flags).await;
 
     let mut committee: Vec<Validator> = genesis.get_validators().expect("Failed to get validators");
@@ -366,14 +377,6 @@ async fn run_node_inner(
         network_committee.push((our_public_key, our_ip));
         network_committee.sort();
     }
-
-    // Configure telemetry with optional critical file logger
-    let log_level = Level::from_str(&flags.log_level).expect("Invalid log level");
-    let critical_log_dir = flags
-        .critical_log_dir
-        .as_ref()
-        .map(|p| get_expanded_path(p).expect("Invalid critical log directory path"));
-    let _critical_log_guard = crate::telemetry::init(log_level, critical_log_dir.as_deref());
 
     // Start prometheus endpoint (merges Summit + commonware runtime metrics)
     #[cfg(feature = "prom")]

--- a/node/src/args.rs
+++ b/node/src/args.rs
@@ -226,6 +226,33 @@ impl Command {
     }
 }
 
+/// How the configured genesis path looks at startup. Extracted from
+/// [`acquire_genesis`] so the present-but-invalid decision can be exercised
+/// directly in tests — the live path calls `std::process::exit` on that case,
+/// which can't be asserted against in-process.
+enum GenesisPathState {
+    /// A valid genesis file is already present at the path.
+    Valid(Box<Genesis>),
+    /// A file exists at the path but does not parse/validate.
+    InvalidPresent(String),
+    /// No file at the path; first-boot provisioning is required.
+    Absent,
+}
+
+/// Classify the configured genesis path without side effects (no exit, no RPC).
+fn classify_genesis_path(genesis_path: &str) -> GenesisPathState {
+    let present = get_expanded_path(genesis_path)
+        .map(|p| p.exists())
+        .unwrap_or(false);
+    if !present {
+        return GenesisPathState::Absent;
+    }
+    match Genesis::load_from_file(genesis_path) {
+        Ok(genesis) => GenesisPathState::Valid(Box::new(genesis)),
+        Err(e) => GenesisPathState::InvalidPresent(e.to_string()),
+    }
+}
+
 /// Resolve the node's genesis, provisioning it over the first-boot RPC if needed.
 ///
 /// Behavior is decided by the state of the configured genesis path:
@@ -240,19 +267,15 @@ impl Command {
 async fn acquire_genesis(context: &tokio::Context, flags: &RunFlags) -> Genesis {
     let genesis_path = flags.genesis_path.clone();
 
-    let present = get_expanded_path(&genesis_path)
-        .map(|p| p.exists())
-        .unwrap_or(false);
-    if present {
-        match Genesis::load_from_file(&genesis_path) {
-            Ok(genesis) => return genesis,
-            Err(e) => {
-                error!(
-                    "existing genesis file '{genesis_path}' is invalid: {e}; remove or replace it to recover"
-                );
-                std::process::exit(1);
-            }
+    match classify_genesis_path(&genesis_path) {
+        GenesisPathState::Valid(genesis) => return *genesis,
+        GenesisPathState::InvalidPresent(e) => {
+            error!(
+                "existing genesis file '{genesis_path}' is invalid: {e}; remove or replace it to recover"
+            );
+            std::process::exit(1);
         }
+        GenesisPathState::Absent => {}
     }
 
     // First boot: no usable genesis yet. Wait for the provisioning RPC to install
@@ -290,6 +313,44 @@ async fn acquire_genesis(context: &tokio::Context, flags: &RunFlags) -> Genesis 
     cancel_token.cancel();
 
     Genesis::load_from_file(&genesis_path).expect("genesis file should be valid after provisioning")
+}
+
+#[cfg(test)]
+mod genesis_path_tests {
+    use super::*;
+
+    #[test]
+    fn classify_absent_when_file_missing() {
+        let path = std::env::temp_dir().join("summit_classify_genesis_absent.toml");
+        let _ = std::fs::remove_file(&path);
+        assert!(matches!(
+            classify_genesis_path(path.to_str().unwrap()),
+            GenesisPathState::Absent
+        ));
+    }
+
+    #[test]
+    fn classify_invalid_present_for_malformed_file() {
+        // Regression: an already-present but unparseable genesis file must be
+        // classified as InvalidPresent (rejected), never as Absent — otherwise
+        // startup would wrongly re-open first-boot provisioning over a stale or
+        // corrupt file instead of surfacing the error.
+        let path = std::env::temp_dir().join("summit_classify_genesis_invalid.toml");
+        std::fs::write(&path, b"definitely : not [valid genesis").unwrap();
+        let state = classify_genesis_path(path.to_str().unwrap());
+        let _ = std::fs::remove_file(&path);
+        assert!(matches!(state, GenesisPathState::InvalidPresent(_)));
+    }
+
+    #[test]
+    fn classify_valid_for_example_genesis() {
+        // The shipped example genesis must classify as a valid, present genesis.
+        let path = concat!(env!("CARGO_MANIFEST_DIR"), "/../example_genesis.toml");
+        assert!(matches!(
+            classify_genesis_path(path),
+            GenesisPathState::Valid(_)
+        ));
+    }
 }
 
 async fn run_node_inner(

--- a/rpc/src/error.rs
+++ b/rpc/src/error.rs
@@ -10,6 +10,7 @@ pub enum RpcError {
     EpochNotFound,
     InvalidPublicKey(String),
     GenesisPathError(String),
+    InvalidGenesis(String),
     IoError(String),
     InvalidKey(String),
     Internal(String),
@@ -48,6 +49,9 @@ impl From<RpcError> for ErrorObjectOwned {
             }
             RpcError::GenesisPathError(msg) => {
                 ErrorObjectOwned::owned(2001, "Invalid genesis path", Some(msg))
+            }
+            RpcError::InvalidGenesis(msg) => {
+                ErrorObjectOwned::owned(2005, "Invalid genesis content", Some(msg))
             }
             RpcError::IoError(msg) => ErrorObjectOwned::owned(2002, "I/O error", Some(msg)),
             RpcError::InvalidKey(msg) => {

--- a/rpc/src/genesis.rs
+++ b/rpc/src/genesis.rs
@@ -7,6 +7,7 @@ use jsonrpsee::core::RpcResult;
 use std::fs;
 use std::sync::Mutex;
 use summit_types::KeyPaths;
+use summit_types::genesis::Genesis;
 use summit_types::utils::get_expanded_path;
 
 pub struct PathSender {
@@ -66,8 +67,26 @@ impl SummitGenesisApiServer for SummitGenesisRpcServer {
                 .map_err(|e| RpcError::IoError(format!("Failed to create directory: {}", e)))?;
         }
 
-        fs::write(&path_buf, &genesis_content)
-            .map_err(|e| RpcError::IoError(format!("Failed to write genesis file: {}", e)))?;
+        // Stage the genesis to a temp file in the same directory, validate it, then
+        // atomically rename it into place. This guarantees the target path only ever
+        // holds a fully-written, parse-valid genesis: a partial/interrupted write or
+        // invalid content never appears there, so startup can treat path presence as
+        // a usable genesis without risking a crash loop.
+        let tmp_path = path_buf.with_extension("toml.tmp");
+
+        fs::write(&tmp_path, &genesis_content).map_err(|e| {
+            RpcError::IoError(format!("Failed to write temporary genesis file: {}", e))
+        })?;
+
+        if let Err(e) = Genesis::load_from_file(&tmp_path.to_string_lossy()) {
+            let _ = fs::remove_file(&tmp_path);
+            return Err(RpcError::InvalidGenesis(format!("rejected genesis content: {e}")).into());
+        }
+
+        fs::rename(&tmp_path, &path_buf).map_err(|e| {
+            let _ = fs::remove_file(&tmp_path);
+            RpcError::IoError(format!("Failed to install genesis file: {}", e))
+        })?;
 
         if let Some(sender) = self.genesis.sender.lock().unwrap().take() {
             let _ = sender.send(());

--- a/rpc/tests/integration_test.rs
+++ b/rpc/tests/integration_test.rs
@@ -197,6 +197,10 @@ activity_timeout_views = 256
 skip_timeout_views = 32
 max_message_size_bytes = 104857600
 namespace = "_SUMMIT"
+validator_minimum_stake = 32000000000
+validator_maximum_stake = 32000000000
+blocks_per_epoch = 10000
+allowed_timestamp_future_ms = 10000
 
 [[validators]]
 node_public_key = "1be3cb06d7cc347602421fb73838534e4b54934e28959de98906d120d0799ef2"
@@ -226,6 +230,55 @@ withdrawal_credentials = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
     );
 
     handle.stop().unwrap();
+}
+
+/// send_genesis must validate before installing: malformed or empty content is
+/// rejected, the target path is left untouched (no partial/garbage file that
+/// startup would treat as provisioned), and no temp file is left behind.
+#[tokio::test]
+async fn test_send_genesis_rejects_invalid_content() {
+    use summit_rpc::SummitGenesisApiClient;
+
+    for bad_content in [
+        "",
+        "this is not valid toml",
+        "eth_genesis_hash = \"0xdead\"\n",
+    ] {
+        let temp_dir = create_test_keystore().unwrap();
+        let key_store_path = temp_dir.path().to_str().unwrap().to_string();
+
+        let genesis_dir = tempfile::tempdir().unwrap();
+        let genesis_path = genesis_dir.path().join("genesis.toml");
+        let genesis_path_str = genesis_path.to_str().unwrap().to_string();
+
+        let path_sender = PathSender::new(genesis_path_str, None);
+        let (handle, addr) =
+            start_rpc_server_for_genesis_with_handle(path_sender, key_store_path, 0)
+                .await
+                .unwrap();
+
+        let url = format!("http://{}", addr);
+        let client = HttpClientBuilder::default().build(&url).unwrap();
+
+        let response = client.send_genesis(bad_content.to_string()).await;
+        assert!(
+            response.is_err(),
+            "sendGenesis should reject invalid content: {bad_content:?}"
+        );
+
+        // The target path must not exist — nothing partial/garbage installed.
+        assert!(
+            !genesis_path.exists(),
+            "target genesis path must not be created on invalid content: {bad_content:?}"
+        );
+        // No staging temp file left behind.
+        assert!(
+            !genesis_dir.path().join("genesis.toml.tmp").exists(),
+            "temp genesis file must be cleaned up on invalid content: {bad_content:?}"
+        );
+
+        handle.stop().unwrap();
+    }
 }
 
 /// The genesis provisioning RPC installs the chain's authoritative identity


### PR DESCRIPTION
Addresses https://github.com/SeismicSystems/summit/issues/222.

Changes:
- acquire_genesis replaces has_file/check_sender and classifies the configured path: absent → run the provisioning RPC and wait; present + valid → load it (RPC never exposed); present + invalid → exit with a clear error instead of crash-looping or falling back to provisioning.
- sendGenesis now stages to a temp file in the same dir, validates it with Genesis::load_from_file, then atomically renames into place; invalid content is rejected (RpcError::InvalidGenesis) and cleaned up. The target path never holds partial/invalid genesis.
- Telemetry is initialized before genesis acquisition so first-boot provisioning (which blocks waiting on the RPC) and the RPC's own "listening" line are actually logged - previously the subscriber wasn't installed until after this point and those logs were dropped.