### PR TITLE
fix: bind pending_execution_requests into the SSZ state root

### DIFF
--- a/docs/ssz-merklization.md
+++ b/docs/ssz-merklization.md
@@ -36,7 +36,7 @@ The state tree is a two-level design: a fixed top-level tree containing scalar f
 
 ### Top-Level Tree
 
-32 leaf slots (depth 5), 22 used. Each leaf is a 32-byte `hash_tree_root` value. Leaves 22–31 are unused (zero-filled).
+32 leaf slots (depth 5), 23 used. Each leaf is a 32-byte `hash_tree_root` value. Leaves 23–31 are unused (zero-filled).
 
 | Leaf Index | Field | Type |
 |------------|-------|------|
@@ -62,6 +62,7 @@ The state tree is a two-level design: a fixed top-level tree containing scalar f
 | 19 | `max_deposits_per_epoch` | Scalar |
 | 20 | `max_withdrawals_per_epoch` | Scalar |
 | 21 | `observers_per_validator` | Scalar |
+| 22 | `pending_execution_requests` | Collection root |
 
 ### Collection Subtrees
 
@@ -141,6 +142,13 @@ A `HashMap<pubkey, (epoch_slot, item_slot)>` index enables O(1) proof lookup by 
 #### Removed Validators
 
 1 leaf per item (validator pubkey hash).
+
+#### Pending Execution Requests
+
+1 leaf per item. Each deferred request is an opaque byte blob hashed as an SSZ
+byte list: packed into 32-byte chunks (final chunk zero-padded), merkleized, then
+`mix_in_length(chunks_root, byte_len)`. The collection root is
+`mix_in_length(subtree.root(), request_count)`, like the other collections.
 
 ## Leaf Encoding
 
@@ -232,6 +240,8 @@ Protocol parameters, added validators, and removed validators always rebuild the
 | `push_removed_validator()` | `rebuild_removed_validators()` |
 | `set_removed_validators()` | `rebuild_removed_validators()` |
 | `clear_removed_validators()` | `rebuild_removed_validators()` |
+| `push_pending_execution_request()` | `rebuild_pending_execution_requests()` |
+| `take_pending_execution_requests()` | `rebuild_pending_execution_requests()` |
 
 ### Tier 6: Queue Pop — Full Rebuild
 

--- a/types/src/consensus_state.rs
+++ b/types/src/consensus_state.rs
@@ -425,11 +425,16 @@ impl ConsensusState {
     }
 
     pub fn take_pending_execution_requests(&mut self) -> Vec<alloy_primitives::Bytes> {
-        std::mem::take(&mut self.pending_execution_requests)
+        let taken = std::mem::take(&mut self.pending_execution_requests);
+        self.ssz_tree
+            .rebuild_pending_execution_requests(&self.pending_execution_requests);
+        taken
     }
 
     pub fn push_pending_execution_request(&mut self, request: alloy_primitives::Bytes) {
         self.pending_execution_requests.push(request);
+        self.ssz_tree
+            .rebuild_pending_execution_requests(&self.pending_execution_requests);
     }
 
     pub fn pending_execution_requests(&self) -> &[alloy_primitives::Bytes] {
@@ -820,6 +825,7 @@ impl ConsensusState {
             self.max_deposits_per_epoch,
             self.max_withdrawals_per_epoch,
             self.observers_per_validator,
+            &self.pending_execution_requests,
         );
 
         // Capture root and freeze proof tree so get_state_root() / proof_tree() are valid
@@ -1469,6 +1475,34 @@ mod tests {
         let actual_size = actual_encoded.len();
 
         assert_eq!(predicted_size, actual_size);
+    }
+
+    #[test]
+    fn pending_execution_requests_bind_into_captured_state_root() {
+        let mut state = ConsensusState::default();
+        state.rebuild_ssz_tree();
+        state.capture_state_root(0);
+        let before = state.get_state_root();
+
+        // Buffering a deferred request via the production mutator must change the
+        // captured state root (the mutator keeps the SSZ subtree in sync).
+        state.push_pending_execution_request(alloy_primitives::Bytes::from(vec![0xAAu8; 40]));
+        state.capture_state_root(0);
+        let after = state.get_state_root();
+        assert_ne!(
+            before, after,
+            "pushing a pending execution request must change the captured state root"
+        );
+
+        // Draining them restores the prior (empty-collection) root.
+        let taken = state.take_pending_execution_requests();
+        assert_eq!(taken.len(), 1);
+        state.capture_state_root(0);
+        assert_eq!(
+            state.get_state_root(),
+            before,
+            "draining pending requests must restore the prior state root"
+        );
     }
 
     #[test]

--- a/types/src/ssz_hash.rs
+++ b/types/src/ssz_hash.rs
@@ -8,7 +8,7 @@ use crate::account::{ValidatorAccount, ValidatorStatus};
 use crate::execution_request::DepositRequest;
 use crate::header::AddedValidator;
 use crate::protocol_params::ProtocolParam;
-use crate::ssz_tree::merkleize;
+use crate::ssz_tree::{merkleize, mix_in_length};
 use crate::withdrawal::PendingWithdrawal;
 use alloy_primitives::Address;
 use commonware_cryptography::bls12381;
@@ -195,6 +195,25 @@ pub(crate) fn hash_fixed_bytes_96(bytes: &[u8; 96]) -> [u8; 32] {
     chunks[1].copy_from_slice(&bytes[32..64]);
     chunks[2].copy_from_slice(&bytes[64..96]);
     merkleize(&chunks)
+}
+
+/// Hash an arbitrary-length byte string as an SSZ byte list: pack into 32-byte
+/// chunks (zero-padding the final chunk), merkleize, then mix in the byte length.
+/// Distinct contents or lengths produce distinct roots.
+pub(crate) fn hash_byte_list(bytes: &[u8]) -> [u8; 32] {
+    let chunks: Vec<[u8; 32]> = if bytes.is_empty() {
+        vec![[0u8; 32]]
+    } else {
+        bytes
+            .chunks(32)
+            .map(|c| {
+                let mut chunk = [0u8; 32];
+                chunk[..c.len()].copy_from_slice(c);
+                chunk
+            })
+            .collect()
+    };
+    mix_in_length(merkleize(&chunks), bytes.len())
 }
 
 #[cfg(test)]
@@ -433,5 +452,25 @@ mod tests {
         let h2 = hash_fixed_bytes_96(&bytes);
         assert_eq!(h1, h2);
         assert_ne!(h1, [0u8; 32]);
+    }
+
+    #[test]
+    fn hash_byte_list_deterministic_and_sensitive() {
+        let base = hash_byte_list(&[1, 2, 3]);
+        // Deterministic.
+        assert_eq!(base, hash_byte_list(&[1, 2, 3]));
+        // Content-sensitive.
+        assert_ne!(base, hash_byte_list(&[1, 2, 4]));
+        // Length-sensitive: a shorter prefix and a zero-padded extension both differ,
+        // because the byte length is mixed in (the padded chunk alone would collide).
+        assert_ne!(base, hash_byte_list(&[1, 2]));
+        assert_ne!(base, hash_byte_list(&[1, 2, 3, 0]));
+        // Empty is deterministic and distinct from any non-empty list.
+        assert_eq!(hash_byte_list(&[]), hash_byte_list(&[]));
+        assert_ne!(hash_byte_list(&[]), base);
+        // Multi-chunk content (>32 bytes) is handled and content-sensitive.
+        let big = vec![7u8; 100];
+        assert_eq!(hash_byte_list(&big), hash_byte_list(&big));
+        assert_ne!(hash_byte_list(&big), hash_byte_list(&[7u8; 99]));
     }
 }

--- a/types/src/ssz_state_tree.rs
+++ b/types/src/ssz_state_tree.rs
@@ -1,7 +1,11 @@
 //! Two-level SSZ binary Merkle tree for ConsensusState.
 //!
-//! The top-level tree has 32 leaf slots (17 used, depth 5). Scalar fields
-//! occupy leaves 0–10. Collection roots occupy leaves 11–16.
+//! The top-level tree has 32 leaf slots (23 used, depth 5). Scalar fields and
+//! collection roots are assigned to fixed leaf indices — see the field-index
+//! and `*_ROOT` constants below for the authoritative layout. Each collection
+//! root (validator accounts, deposit/withdrawal queues, protocol-param changes,
+//! added/removed validators, pending execution requests) is
+//! `mix_in_length(subtree_root, count)`.
 //!
 //! The validator accounts collection uses a dedicated subtree (`SszTree`)
 //! where each validator occupies 8 contiguous leaves (one per field),
@@ -19,7 +23,7 @@ use crate::account::ValidatorAccount;
 use crate::execution_request::DepositRequest;
 use crate::header::AddedValidator;
 use crate::protocol_params::ProtocolParam;
-use crate::ssz_hash::{SszHashTreeRoot, hash_fixed_bytes_64, hash_fixed_bytes_96};
+use crate::ssz_hash::{SszHashTreeRoot, hash_byte_list, hash_fixed_bytes_64, hash_fixed_bytes_96};
 use crate::ssz_tree::{SszTree, mix_in_length};
 use crate::withdrawal::PendingWithdrawal;
 use crate::withdrawal::WithdrawalQueue;
@@ -51,9 +55,10 @@ pub const TREASURY_ADDRESS: usize = 18;
 pub const MAX_DEPOSITS_PER_EPOCH: usize = 19;
 pub const MAX_WITHDRAWALS_PER_EPOCH: usize = 20;
 pub const OBSERVERS_PER_VALIDATOR: usize = 21;
+pub const PENDING_EXECUTION_REQUESTS_ROOT: usize = 22;
 
 /// Number of used leaf slots in the top-level tree.
-pub const NUM_TOP_LEAVES: usize = 22;
+pub const NUM_TOP_LEAVES: usize = 23;
 
 // --- Validator field indices (within each validator's 8-leaf subtree) ---
 
@@ -116,7 +121,7 @@ pub const ADDED_VALIDATOR_FIELDS_PER_ITEM: usize = 2;
 /// Two-level SSZ state tree mirroring ConsensusState.
 #[derive(Clone, Debug)]
 pub struct SszStateTree {
-    /// Top-level tree: 32 leaves (depth 5), 17 used.
+    /// Top-level tree: 32 leaves (depth 5), 23 used.
     top: SszTree,
 
     /// Validator accounts subtree. Rebuilt from BTreeMap on every mutation.
@@ -151,6 +156,10 @@ pub struct SszStateTree {
     /// Removed validators subtree.
     removed_validator_tree: SszTree,
     removed_validator_count: usize,
+
+    /// Pending execution requests subtree (one leaf per deferred request blob).
+    pending_execution_request_tree: SszTree,
+    pending_execution_request_count: usize,
 }
 
 impl SszStateTree {
@@ -172,6 +181,8 @@ impl SszStateTree {
             added_validator_count: 0,
             removed_validator_tree: SszTree::new(1),
             removed_validator_count: 0,
+            pending_execution_request_tree: SszTree::new(1),
+            pending_execution_request_count: 0,
         }
     }
 
@@ -856,6 +867,28 @@ impl SszStateTree {
         self.update_removed_validator_collection_root();
     }
 
+    /// Rebuild the pending-execution-requests subtree. Each deferred request is an
+    /// opaque byte blob hashed as an SSZ byte list; the collection root mixes in the
+    /// request count. Binds deferred deposits/withdrawals/exits into the state root.
+    pub fn rebuild_pending_execution_requests(&mut self, requests: &[alloy_primitives::Bytes]) {
+        let count = requests.len();
+        let capacity = count.max(1);
+        let mut tree = SszTree::new(capacity);
+        for (i, req) in requests.iter().enumerate() {
+            tree.set_leaf(i, hash_byte_list(req));
+        }
+        self.pending_execution_request_tree = tree;
+        self.pending_execution_request_count = count;
+        self.update_pending_execution_request_collection_root();
+    }
+
+    fn update_pending_execution_request_collection_root(&mut self) {
+        let subtree_root = self.pending_execution_request_tree.root();
+        let collection_root = mix_in_length(subtree_root, self.pending_execution_request_count);
+        self.top
+            .set_leaf(PENDING_EXECUTION_REQUESTS_ROOT, collection_root);
+    }
+
     fn update_removed_validator_collection_root(&mut self) {
         let subtree_root = self.removed_validator_tree.root();
         let collection_root = mix_in_length(subtree_root, self.removed_validator_count);
@@ -895,6 +928,7 @@ impl SszStateTree {
         max_deposits_per_epoch: u64,
         max_withdrawals_per_epoch: u64,
         observers_per_validator: u32,
+        pending_execution_requests: &[alloy_primitives::Bytes],
     ) {
         *self = Self::new();
 
@@ -925,6 +959,7 @@ impl SszStateTree {
         self.rebuild_protocol_params(protocol_param_changes);
         self.rebuild_added_validators(added_validators);
         self.rebuild_removed_validators(removed_validators);
+        self.rebuild_pending_execution_requests(pending_execution_requests);
     }
 
     // --- Proof generation ---
@@ -1799,6 +1834,7 @@ mod tests {
         inc.rebuild_protocol_params(&[]);
         inc.rebuild_added_validators(&BTreeMap::new());
         inc.rebuild_removed_validators(&[]);
+        inc.rebuild_pending_execution_requests(&[]);
 
         // Build via rebuild
         let mut rb = SszStateTree::new();
@@ -1825,9 +1861,37 @@ mod tests {
             3,
             16,
             5,
+            &[],
         );
 
         assert_eq!(inc.root(), rb.root());
+    }
+
+    #[test]
+    fn pending_execution_requests_affect_root() {
+        let mut tree = SszStateTree::new();
+        tree.rebuild_pending_execution_requests(&[]);
+        let empty_root = tree.root();
+
+        // Adding a deferred request changes the state root.
+        tree.rebuild_pending_execution_requests(&[alloy_primitives::Bytes::from(vec![1u8, 2, 3])]);
+        let one_root = tree.root();
+        assert_ne!(
+            empty_root, one_root,
+            "a pending execution request must be bound into the state root"
+        );
+
+        // Changing only the request contents changes the root.
+        tree.rebuild_pending_execution_requests(&[alloy_primitives::Bytes::from(vec![4u8, 5, 6])]);
+        assert_ne!(
+            one_root,
+            tree.root(),
+            "different pending request contents must produce a different root"
+        );
+
+        // Clearing returns to the empty-collection root.
+        tree.rebuild_pending_execution_requests(&[]);
+        assert_eq!(empty_root, tree.root());
     }
 
     #[test]
@@ -1860,6 +1924,7 @@ mod tests {
             3,
             16,
             0,
+            &[],
         );
 
         let root = tree.root();


### PR DESCRIPTION
Addresses https://github.com/SeismicSystems/summit/issues/259.

Changes:
- Add `PENDING_EXECUTION_REQUESTS_ROOT` (leaf 22) to the top-level tree with a subtree rebuilt like the other collections; collection root is `mix_in_length(subtree.root(), count)`.
- Each request blob is hashed as an SSZ byte list (`hash_byte_list`: pack into 32-byte chunks, merkleize, mix in byte length).
- Thread through `SszStateTree::rebuild` and `ConsensusState::rebuild_ssz_tree`, and keep the subtree in sync on `push_pending_execution_request` / `take_pending_execution_requests` so `capture_state_root` reflects it.