### PR TITLE
fix: bind pending_checkpoint into the SSZ state root

### DIFF
--- a/docs/ssz-merklization.md
+++ b/docs/ssz-merklization.md
@@ -36,7 +36,7 @@ The state tree is a two-level design: a fixed top-level tree containing scalar f
 
 ### Top-Level Tree
 
-32 leaf slots (depth 5), 23 used. Each leaf is a 32-byte `hash_tree_root` value. Leaves 23–31 are unused (zero-filled).
+32 leaf slots (depth 5), 24 used. Each leaf is a 32-byte `hash_tree_root` value. Leaves 24–31 are unused (zero-filled).
 
 | Leaf Index | Field | Type |
 |------------|-------|------|
@@ -63,6 +63,7 @@ The state tree is a two-level design: a fixed top-level tree containing scalar f
 | 20 | `max_withdrawals_per_epoch` | Scalar |
 | 21 | `observers_per_validator` | Scalar |
 | 22 | `pending_execution_requests` | Collection root |
+| 23 | `pending_checkpoint` | Scalar (checkpoint digest, or zero when absent) |
 
 ### Collection Subtrees
 
@@ -158,7 +159,7 @@ All leaf values are 32 bytes, produced by SSZ `hash_tree_root`:
 - **`u32`**: Little-endian encoded, zero-padded to 32 bytes. Used by: observers_per_validator.
 - **`bool`**: `0x01` or `0x00`, zero-padded to 32 bytes. Used by: has_pending_deposit, has_pending_withdrawal.
 - **`ValidatorStatus` (enum)**: Single byte (Active=0, Inactive=1, SubmittedExitRequest=2, Joining=3), zero-padded to 32 bytes.
-- **`[u8; 32]`**: Used directly as the leaf value. Used by: head_digest, epoch_genesis_hash, forkchoice hashes, withdrawal_credentials (deposit), pubkey (withdrawal).
+- **`[u8; 32]`**: Used directly as the leaf value. Used by: head_digest, epoch_genesis_hash, forkchoice hashes, withdrawal_credentials (deposit), pubkey (withdrawal), pending_checkpoint (the checkpoint digest, or the zero hash when no checkpoint is pending).
 - **`Address` (20 bytes)**: Zero-padded to 32 bytes. Used by: withdrawal_credentials (validator), address (withdrawal), treasury_address.
 - **Ed25519 public key (32 bytes)**: Used directly as the leaf value. Used by: node_pubkey (deposit), node_key (added validator), removed validator pubkeys.
 - **BLS public key (48 bytes)**: `SHA256(bytes[0..32] || pad(bytes[32..48]))` — 2 chunks hashed. Used by: consensus_pubkey (validator, deposit), consensus_key (added validator).
@@ -188,6 +189,8 @@ Single top-level leaf write + rehash of the 5-level path to root.
 | `set_max_withdrawals_per_epoch()` | `ssz_tree.set_max_withdrawals_per_epoch()` |
 | `set_observers_per_validator()` | `ssz_tree.set_observers_per_validator()` |
 | `set_next_withdrawal_index()` | `ssz_tree.set_next_withdrawal_index()` |
+| `set_pending_checkpoint()` | `ssz_tree.set_pending_checkpoint_digest()` |
+| `take_pending_checkpoint()` | `ssz_tree.set_pending_checkpoint_digest(None)` |
 | `set_forkchoice_head()` | `ssz_tree.set_forkchoice_head_block_hash()` |
 | `set_forkchoice_safe_and_finalized()` | Two setter calls (safe + finalized) |
 | `set_forkchoice()` | Three setter calls (head + safe + finalized) |

--- a/types/src/consensus_state.rs
+++ b/types/src/consensus_state.rs
@@ -369,6 +369,8 @@ impl ConsensusState {
 
     pub fn set_pending_checkpoint(&mut self, checkpoint: Option<Checkpoint>) {
         self.pending_checkpoint = checkpoint;
+        self.ssz_tree
+            .set_pending_checkpoint_digest(self.pending_checkpoint.as_ref().map(|cp| cp.digest.0));
     }
 
     pub fn get_added_validators(&self, epoch: u64) -> Option<&Vec<AddedValidator>> {
@@ -439,7 +441,9 @@ impl ConsensusState {
     }
 
     pub fn take_pending_checkpoint(&mut self) -> Option<Checkpoint> {
-        self.pending_checkpoint.take()
+        let taken = self.pending_checkpoint.take();
+        self.ssz_tree.set_pending_checkpoint_digest(None);
+        taken
     }
 
     pub fn push_protocol_param_change(&mut self, param: ProtocolParam) {
@@ -900,6 +904,7 @@ impl ConsensusState {
             self.max_withdrawals_per_epoch,
             self.observers_per_validator,
             &self.pending_execution_requests,
+            self.pending_checkpoint.as_ref().map(|cp| cp.digest.0),
         );
 
         // Capture root and freeze proof tree so get_state_root() / proof_tree() are valid
@@ -1614,6 +1619,35 @@ mod tests {
             state.get_state_root(),
             before,
             "draining pending requests must restore the prior state root"
+        );
+    }
+
+    #[test]
+    fn pending_checkpoint_binds_into_captured_state_root() {
+        let mut state = ConsensusState::default();
+        state.rebuild_ssz_tree();
+        state.capture_state_root(0);
+        let before = state.get_state_root();
+
+        // Setting the pending checkpoint via the production mutator binds its digest
+        // into the captured state root.
+        let checkpoint = Checkpoint::new(&state);
+        state.set_pending_checkpoint(Some(checkpoint));
+        state.capture_state_root(0);
+        let after = state.get_state_root();
+        assert_ne!(
+            before, after,
+            "setting a pending checkpoint must change the captured state root"
+        );
+
+        // Taking it restores the prior (no-checkpoint) root.
+        let taken = state.take_pending_checkpoint();
+        assert!(taken.is_some());
+        state.capture_state_root(0);
+        assert_eq!(
+            state.get_state_root(),
+            before,
+            "taking the pending checkpoint must restore the prior state root"
         );
     }
 

--- a/types/src/ssz_state_tree.rs
+++ b/types/src/ssz_state_tree.rs
@@ -1,6 +1,6 @@
 //! Two-level SSZ binary Merkle tree for ConsensusState.
 //!
-//! The top-level tree has 32 leaf slots (23 used, depth 5). Scalar fields and
+//! The top-level tree has 32 leaf slots (24 used, depth 5). Scalar fields and
 //! collection roots are assigned to fixed leaf indices — see the field-index
 //! and `*_ROOT` constants below for the authoritative layout. Each collection
 //! root (validator accounts, deposit/withdrawal queues, protocol-param changes,
@@ -56,9 +56,10 @@ pub const MAX_DEPOSITS_PER_EPOCH: usize = 19;
 pub const MAX_WITHDRAWALS_PER_EPOCH: usize = 20;
 pub const OBSERVERS_PER_VALIDATOR: usize = 21;
 pub const PENDING_EXECUTION_REQUESTS_ROOT: usize = 22;
+pub const PENDING_CHECKPOINT: usize = 23;
 
 /// Number of used leaf slots in the top-level tree.
-pub const NUM_TOP_LEAVES: usize = 23;
+pub const NUM_TOP_LEAVES: usize = 24;
 
 // --- Validator field indices (within each validator's 8-leaf subtree) ---
 
@@ -121,7 +122,7 @@ pub const ADDED_VALIDATOR_FIELDS_PER_ITEM: usize = 2;
 /// Two-level SSZ state tree mirroring ConsensusState.
 #[derive(Clone, Debug)]
 pub struct SszStateTree {
-    /// Top-level tree: 32 leaves (depth 5), 23 used.
+    /// Top-level tree: 32 leaves (depth 5), 24 used.
     top: SszTree,
 
     /// Validator accounts subtree. Rebuilt from BTreeMap on every mutation.
@@ -241,6 +242,16 @@ impl SszStateTree {
     pub fn set_observers_per_validator(&mut self, value: u32) {
         self.top
             .set_leaf(OBSERVERS_PER_VALIDATOR, value.hash_tree_root());
+    }
+
+    /// Set the pending-checkpoint leaf to the checkpoint digest (the value that
+    /// becomes the boundary `checkpoint_hash`), or the zero hash when absent. A
+    /// single scalar leaf — no subtree or proof support, since the pending
+    /// checkpoint only needs to be bound into the root, not proven on-chain. The
+    /// digest already commits the checkpoint data via SHA-256.
+    pub fn set_pending_checkpoint_digest(&mut self, digest: Option<[u8; 32]>) {
+        self.top
+            .set_leaf(PENDING_CHECKPOINT, digest.unwrap_or([0u8; 32]));
     }
 
     pub fn set_treasury_address(&mut self, address: &Address) {
@@ -929,6 +940,7 @@ impl SszStateTree {
         max_withdrawals_per_epoch: u64,
         observers_per_validator: u32,
         pending_execution_requests: &[alloy_primitives::Bytes],
+        pending_checkpoint_digest: Option<[u8; 32]>,
     ) {
         *self = Self::new();
 
@@ -960,6 +972,7 @@ impl SszStateTree {
         self.rebuild_added_validators(added_validators);
         self.rebuild_removed_validators(removed_validators);
         self.rebuild_pending_execution_requests(pending_execution_requests);
+        self.set_pending_checkpoint_digest(pending_checkpoint_digest);
     }
 
     // --- Proof generation ---
@@ -1835,6 +1848,7 @@ mod tests {
         inc.rebuild_added_validators(&BTreeMap::new());
         inc.rebuild_removed_validators(&[]);
         inc.rebuild_pending_execution_requests(&[]);
+        inc.set_pending_checkpoint_digest(None);
 
         // Build via rebuild
         let mut rb = SszStateTree::new();
@@ -1862,6 +1876,7 @@ mod tests {
             16,
             5,
             &[],
+            None,
         );
 
         assert_eq!(inc.root(), rb.root());
@@ -1895,6 +1910,33 @@ mod tests {
     }
 
     #[test]
+    fn pending_checkpoint_affects_root() {
+        let mut tree = SszStateTree::new();
+        tree.set_pending_checkpoint_digest(None);
+        let none_root = tree.root();
+
+        // Setting a pending checkpoint binds its digest into the root.
+        tree.set_pending_checkpoint_digest(Some([0xAB; 32]));
+        let some_root = tree.root();
+        assert_ne!(
+            none_root, some_root,
+            "a pending checkpoint must be bound into the state root"
+        );
+
+        // A different digest produces a different root.
+        tree.set_pending_checkpoint_digest(Some([0xCD; 32]));
+        assert_ne!(
+            some_root,
+            tree.root(),
+            "a different pending-checkpoint digest must produce a different root"
+        );
+
+        // Clearing returns to the no-checkpoint root.
+        tree.set_pending_checkpoint_digest(None);
+        assert_eq!(none_root, tree.root());
+    }
+
+    #[test]
     fn rebuild_proof_still_valid() {
         let (pk1, acc1) = make_validator(1);
         let mut accounts = BTreeMap::new();
@@ -1925,6 +1967,7 @@ mod tests {
             16,
             0,
             &[],
+            None,
         );
 
         let root = tree.root();


### PR DESCRIPTION
Builds on https://github.com/SeismicSystems/summit/pull/291.

Addresses https://github.com/SeismicSystems/summit/issues/258.

Changes:
- Add `PENDING_CHECKPOINT` as a single scalar leaf: the checkpoint digest when present, the zero hash when absent. No subtree or proof support - the field only needs to be bound into the root, not proven on-chain, and the digest already commits the checkpoint data via SHA-256. The tree takes the digest bytes, staying decoupled from the `Checkpoint` type.
- `set_pending_checkpoint` / `take_pending_checkpoint` now update the leaf, and `rebuild_ssz_tree` passes the digest, so `capture_state_root` reflects it.