### PR TITLE
fix: bind dynamic epoch schedule into the SSZ state root

### DIFF
--- a/docs/ssz-merklization.md
+++ b/docs/ssz-merklization.md
@@ -36,7 +36,7 @@ The state tree is a two-level design: a fixed top-level tree containing scalar f
 
 ### Top-Level Tree
 
-32 leaf slots (depth 5), 24 used. Each leaf is a 32-byte `hash_tree_root` value. Leaves 24–31 are unused (zero-filled).
+32 leaf slots (depth 5), 25 used. Each leaf is a 32-byte `hash_tree_root` value. Leaves 25–31 are unused (zero-filled).
 
 | Leaf Index | Field | Type |
 |------------|-------|------|
@@ -64,6 +64,7 @@ The state tree is a two-level design: a fixed top-level tree containing scalar f
 | 21 | `observers_per_validator` | Scalar |
 | 22 | `pending_execution_requests` | Collection root |
 | 23 | `pending_checkpoint` | Scalar (checkpoint digest, or zero when absent) |
+| 24 | `dynamic_epoch_schedule` | Scalar (SSZ byte-list root of the encoded `DynamicEpocher`) |
 
 ### Collection Subtrees
 
@@ -151,6 +152,14 @@ byte list: packed into 32-byte chunks (final chunk zero-padded), merkleized, the
 `mix_in_length(chunks_root, byte_len)`. The collection root is
 `mix_in_length(subtree.root(), request_count)`, like the other collections.
 
+#### Dynamic Epoch Schedule
+
+A single scalar leaf, not a collection. The leaf is the SSZ byte-list root of the
+encoded `DynamicEpocher` (same `hash_byte_list` encoding as a pending execution
+request). Because the epocher uses interior mutability and can change without a
+`ConsensusState` setter, this leaf is refreshed at `capture_state_root` (and in
+`rebuild`) rather than maintained incrementally.
+
 ## Leaf Encoding
 
 All leaf values are 32 bytes, produced by SSZ `hash_tree_root`:
@@ -169,6 +178,8 @@ All leaf values are 32 bytes, produced by SSZ `hash_tree_root`:
 ## Tree Updates
 
 Every mutation to `ConsensusState` has a corresponding SSZ tree update. Updates are organized into tiers by optimization strategy.
+
+One exception: the `dynamic_epoch_schedule` leaf is not driven by a `ConsensusState` setter. The `DynamicEpocher` uses interior mutability and can change (epoch advance, length update) without a `&mut ConsensusState` call, so its leaf is recomputed in `capture_state_root` (and `rebuild`) instead.
 
 ### Tier 1: Scalar Fields — O(1)
 

--- a/types/src/consensus_state.rs
+++ b/types/src/consensus_state.rs
@@ -10,7 +10,7 @@ use crate::{Digest, PublicKey};
 use alloy_primitives::Address;
 use alloy_rpc_types_engine::ForkchoiceState;
 use bytes::{Buf, BufMut};
-use commonware_codec::{DecodeExt, EncodeSize, Error, Read, ReadExt, Write};
+use commonware_codec::{DecodeExt, Encode, EncodeSize, Error, Read, ReadExt, Write};
 use commonware_cryptography::{bls12381, sha256};
 #[cfg(feature = "prom")]
 use metrics::histogram;
@@ -588,6 +588,13 @@ impl ConsensusState {
         #[cfg(feature = "prom")]
         let start = std::time::Instant::now();
 
+        // Refresh the dynamic-epoch-schedule leaf here: the epocher uses interior
+        // mutability and can change (epoch advance, length update) without going
+        // through a ConsensusState setter, so this commit point is the reliable
+        // place to bind its current value into the root.
+        self.ssz_tree
+            .set_dynamic_epoch_schedule(&self.epocher.encode());
+
         self.state_root = self.ssz_tree.root();
         self.proof_tree = self.ssz_tree.clone();
         self.proof_validator_keys = self.validator_accounts.keys().copied().collect();
@@ -905,6 +912,7 @@ impl ConsensusState {
             self.observers_per_validator,
             &self.pending_execution_requests,
             self.pending_checkpoint.as_ref().map(|cp| cp.digest.0),
+            &self.epocher.encode(),
         );
 
         // Capture root and freeze proof tree so get_state_root() / proof_tree() are valid
@@ -1648,6 +1656,31 @@ mod tests {
             state.get_state_root(),
             before,
             "taking the pending checkpoint must restore the prior state root"
+        );
+    }
+
+    #[test]
+    fn dynamic_epoch_schedule_binds_into_captured_state_root() {
+        use std::num::NonZeroU64;
+
+        let mut state = ConsensusState::default();
+        state.rebuild_ssz_tree();
+        state.capture_state_root(0);
+        let before = state.get_state_root();
+
+        // Mutate the epoch schedule through interior mutability — no `&mut
+        // ConsensusState` setter is involved — and confirm the captured root still
+        // changes, via the refresh in `capture_state_root`.
+        state
+            .get_epocher()
+            .update_length(NonZeroU64::new(20).unwrap())
+            .expect("update_length should succeed");
+        state.capture_state_root(0);
+
+        assert_ne!(
+            before,
+            state.get_state_root(),
+            "an epoch-schedule change must change the captured state root"
         );
     }
 

--- a/types/src/ssz_state_tree.rs
+++ b/types/src/ssz_state_tree.rs
@@ -1,6 +1,6 @@
 //! Two-level SSZ binary Merkle tree for ConsensusState.
 //!
-//! The top-level tree has 32 leaf slots (24 used, depth 5). Scalar fields and
+//! The top-level tree has 32 leaf slots (25 used, depth 5). Scalar fields and
 //! collection roots are assigned to fixed leaf indices — see the field-index
 //! and `*_ROOT` constants below for the authoritative layout. Each collection
 //! root (validator accounts, deposit/withdrawal queues, protocol-param changes,
@@ -57,9 +57,10 @@ pub const MAX_WITHDRAWALS_PER_EPOCH: usize = 20;
 pub const OBSERVERS_PER_VALIDATOR: usize = 21;
 pub const PENDING_EXECUTION_REQUESTS_ROOT: usize = 22;
 pub const PENDING_CHECKPOINT: usize = 23;
+pub const DYNAMIC_EPOCH_SCHEDULE: usize = 24;
 
 /// Number of used leaf slots in the top-level tree.
-pub const NUM_TOP_LEAVES: usize = 24;
+pub const NUM_TOP_LEAVES: usize = 25;
 
 // --- Validator field indices (within each validator's 8-leaf subtree) ---
 
@@ -122,7 +123,7 @@ pub const ADDED_VALIDATOR_FIELDS_PER_ITEM: usize = 2;
 /// Two-level SSZ state tree mirroring ConsensusState.
 #[derive(Clone, Debug)]
 pub struct SszStateTree {
-    /// Top-level tree: 32 leaves (depth 5), 24 used.
+    /// Top-level tree: 32 leaves (depth 5), 25 used.
     top: SszTree,
 
     /// Validator accounts subtree. Rebuilt from BTreeMap on every mutation.
@@ -252,6 +253,18 @@ impl SszStateTree {
     pub fn set_pending_checkpoint_digest(&mut self, digest: Option<[u8; 32]>) {
         self.top
             .set_leaf(PENDING_CHECKPOINT, digest.unwrap_or([0u8; 32]));
+    }
+
+    /// Set the dynamic-epoch-schedule leaf to the SSZ byte-list root of the
+    /// encoded `DynamicEpocher`. A single scalar leaf — no subtree or proof
+    /// support, since the schedule only needs to be bound into the root, not
+    /// proven on-chain. Because the epocher uses interior mutability and can be
+    /// changed (epoch advance, length update) without going through a
+    /// `ConsensusState` setter, this is refreshed at `capture_state_root` (and in
+    /// `rebuild`) rather than maintained incrementally.
+    pub fn set_dynamic_epoch_schedule(&mut self, encoded_schedule: &[u8]) {
+        self.top
+            .set_leaf(DYNAMIC_EPOCH_SCHEDULE, hash_byte_list(encoded_schedule));
     }
 
     pub fn set_treasury_address(&mut self, address: &Address) {
@@ -941,6 +954,7 @@ impl SszStateTree {
         observers_per_validator: u32,
         pending_execution_requests: &[alloy_primitives::Bytes],
         pending_checkpoint_digest: Option<[u8; 32]>,
+        dynamic_epoch_schedule: &[u8],
     ) {
         *self = Self::new();
 
@@ -973,6 +987,7 @@ impl SszStateTree {
         self.rebuild_removed_validators(removed_validators);
         self.rebuild_pending_execution_requests(pending_execution_requests);
         self.set_pending_checkpoint_digest(pending_checkpoint_digest);
+        self.set_dynamic_epoch_schedule(dynamic_epoch_schedule);
     }
 
     // --- Proof generation ---
@@ -1849,6 +1864,7 @@ mod tests {
         inc.rebuild_removed_validators(&[]);
         inc.rebuild_pending_execution_requests(&[]);
         inc.set_pending_checkpoint_digest(None);
+        inc.set_dynamic_epoch_schedule(&[]);
 
         // Build via rebuild
         let mut rb = SszStateTree::new();
@@ -1877,6 +1893,7 @@ mod tests {
             5,
             &[],
             None,
+            &[],
         );
 
         assert_eq!(inc.root(), rb.root());
@@ -1937,6 +1954,25 @@ mod tests {
     }
 
     #[test]
+    fn dynamic_epoch_schedule_affects_root() {
+        let mut tree = SszStateTree::new();
+        tree.set_dynamic_epoch_schedule(&[1, 2, 3]);
+        let root_a = tree.root();
+
+        // A different encoded schedule must produce a different root.
+        tree.set_dynamic_epoch_schedule(&[1, 2, 4]);
+        assert_ne!(
+            root_a,
+            tree.root(),
+            "a different epoch schedule must produce a different root"
+        );
+
+        // The same encoded schedule reproduces the same root.
+        tree.set_dynamic_epoch_schedule(&[1, 2, 3]);
+        assert_eq!(root_a, tree.root());
+    }
+
+    #[test]
     fn rebuild_proof_still_valid() {
         let (pk1, acc1) = make_validator(1);
         let mut accounts = BTreeMap::new();
@@ -1968,6 +2004,7 @@ mod tests {
             0,
             &[],
             None,
+            &[],
         );
 
         let root = tree.root();


### PR DESCRIPTION
Builds on https://github.com/SeismicSystems/summit/pull/292 (which builds on https://github.com/SeismicSystems/summit/pull/291).

Addresses https://github.com/SeismicSystems/summit/issues/256.

Changes:
- Add `DYNAMIC_EPOCH_SCHEDULE` as a single scalar leaf: the SSZ byte-list root of the encoded epocher. No subtree/proof support, it only needs to be bound into the root, not proven on-chain.
- Set it in `rebuild` (decode/genesis) and refresh it in `capture_state_root`.
  The latter is the key bit: `DynamicEpocher` is `Arc<RwLock<…>>` with `&self` mutators (epoch advance, length update) invoked via `get_epocher()`, bypassing any `&mut ConsensusState` setter, so the commit point is the only reliable place to bind its current value. Both paths use the same hash, so decode-built and live-captured roots agree.