### PR TITLE
fix: bind keyed-collection keys into the SSZ state root

### DIFF
--- a/docs/ssz-merklization.md
+++ b/docs/ssz-merklization.md
@@ -74,7 +74,7 @@ Each collection leaf in the top-level tree holds `mix_in_length(subtree.root(), 
 
 #### Validator Accounts
 
-Each validator occupies 8 contiguous leaves (depth-3 per-validator subtree):
+Each validator occupies 16 contiguous leaves (depth-4 per-validator subtree): 9 fields padded to the next power of two. `node_pubkey` is the `BTreeMap` key (the validator's identity) — committing it as a leaf binds the key into the root and into validator proofs. Leaves 9–15 are zero padding.
 
 | Field Index | Field |
 |-------------|-------|
@@ -86,6 +86,8 @@ Each validator occupies 8 contiguous leaves (depth-3 per-validator subtree):
 | 5 | `has_pending_withdrawal` |
 | 6 | `joining_epoch` |
 | 7 | `last_deposit_index` |
+| 8 | `node_pubkey` (map key) |
+| 9–15 | (zero padding) |
 
 Slot assignment is positional: the i-th entry in `BTreeMap` iteration order occupies leaves `[i*8 .. i*8+7]`. The subtree capacity is always a power of 2, growing/shrinking as validators are added/removed.
 
@@ -141,7 +143,7 @@ A `HashMap<pubkey, (epoch_slot, item_slot)>` index enables O(1) proof lookup by 
 
 #### Added Validators
 
-2 leaves per item (node_key + consensus_key), flattened across all epochs.
+4 leaves per item (depth-2 subtree): 3 fields — `node_key` (0), `consensus_key` (1), `epoch` (2) — padded to 4 (leaf 3 is zero). Items are flattened across all epochs, so the `epoch` field commits each item's activation epoch (the `BTreeMap` key), which would otherwise be lost by the flattening.
 
 #### Removed Validators
 

--- a/docs/ssz-merklization.md
+++ b/docs/ssz-merklization.md
@@ -89,7 +89,7 @@ Each validator occupies 16 contiguous leaves (depth-4 per-validator subtree): 9 
 | 8 | `node_pubkey` (map key) |
 | 9–15 | (zero padding) |
 
-Slot assignment is positional: the i-th entry in `BTreeMap` iteration order occupies leaves `[i*8 .. i*8+7]`. The subtree capacity is always a power of 2, growing/shrinking as validators are added/removed.
+Slot assignment is positional: the i-th entry in `BTreeMap` iteration order occupies leaves `[i*16 .. i*16+15]`. The subtree capacity is always a power of 2, growing/shrinking as validators are added/removed.
 
 #### Deposit Queue
 
@@ -333,7 +333,7 @@ The proof branch concatenates sibling hashes from multiple tree levels:
 
 Proofs can target different levels of the tree:
 
-- **Whole-account proof**: The leaf is the per-validator subtree root (internal node 3 levels above field leaves). Shorter branch.
+- **Whole-account proof**: The leaf is the per-validator subtree root (internal node 4 levels above field leaves). Shorter branch.
 - **Field-level proof**: The leaf is an individual field (e.g., just the balance). Longer branch but proves a single field.
 
 The same applies to deposits and withdrawals — both whole-item and field-level proofs are supported.

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -5056,6 +5056,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-types-engine",
+ "alloy-transport",
  "alloy-transport-ipc",
  "anyhow",
  "bytes",

--- a/types/src/consensus_state.rs
+++ b/types/src/consensus_state.rs
@@ -595,7 +595,8 @@ impl ConsensusState {
                 .keys()
                 .position(|k| k == &pubkey)
                 .expect("key was just inserted");
-            self.ssz_tree.update_validator_at_slot(slot, &account);
+            self.ssz_tree
+                .update_validator_at_slot(slot, &pubkey, &account);
         } else {
             // Insert into BTreeMap first to determine positional slot
             self.validator_accounts.insert(pubkey, account.clone());
@@ -604,7 +605,8 @@ impl ConsensusState {
                 .keys()
                 .position(|k| k == &pubkey)
                 .expect("key was just inserted");
-            self.ssz_tree.insert_validator_at_slot(slot, &account);
+            self.ssz_tree
+                .insert_validator_at_slot(slot, &pubkey, &account);
         }
 
         #[cfg(feature = "prom")]
@@ -1999,6 +2001,63 @@ mod tests {
             before,
             state.get_state_root(),
             "an epoch-schedule change must change the captured state root"
+        );
+    }
+
+    /// Changing only a validator-account map key (the node
+    /// pubkey) must change the SSZ state root. The tree commits account values
+    /// positionally without the key, so two states with the same account value
+    /// under different keys must not share a root.
+    #[test]
+    fn validator_account_key_binds_into_state_root() {
+        let account = ValidatorAccount {
+            consensus_public_key: bls12381::PrivateKey::from_seed(1).public_key(),
+            withdrawal_credentials: Address::from([7u8; 20]),
+            balance: 32_000_000_000,
+            status: ValidatorStatus::Active,
+            has_pending_deposit: false,
+            has_pending_withdrawal: false,
+            joining_epoch: 0,
+            last_deposit_index: 0,
+        };
+
+        let root_for_key = |key: [u8; 32]| {
+            let mut state = ConsensusState::default();
+            state.validator_accounts.insert(key, account.clone());
+            state.rebuild_ssz_tree();
+            state.capture_state_root(0);
+            state.get_state_root()
+        };
+
+        assert_ne!(
+            root_for_key([1u8; 32]),
+            root_for_key([2u8; 32]),
+            "changing only the validator-account map key must change the state root"
+        );
+    }
+
+    /// Changing only the scheduled-activation epoch key must
+    /// change the SSZ state root. added_validators is flattened to its values, so
+    /// the same activation under a different epoch must not share a root.
+    #[test]
+    fn added_validator_epoch_key_binds_into_state_root() {
+        let av = AddedValidator {
+            node_key: ed25519::PrivateKey::from_seed(1).public_key(),
+            consensus_key: bls12381::PrivateKey::from_seed(1).public_key(),
+        };
+
+        let root_for_epoch = |epoch: u64| {
+            let mut state = ConsensusState::default();
+            state.add_validator(epoch, av.clone());
+            state.rebuild_ssz_tree();
+            state.capture_state_root(0);
+            state.get_state_root()
+        };
+
+        assert_ne!(
+            root_for_epoch(5),
+            root_for_epoch(6),
+            "changing only the added-validator epoch key must change the state root"
         );
     }
 

--- a/types/src/ssz_state_tree.rs
+++ b/types/src/ssz_state_tree.rs
@@ -8,14 +8,15 @@
 //! `mix_in_length(subtree_root, count)`.
 //!
 //! The validator accounts collection uses a dedicated subtree (`SszTree`)
-//! where each validator occupies 8 contiguous leaves (one per field),
-//! forming a depth-3 per-validator sub-subtree. This enables field-level
-//! Merkle proofs (e.g., proving just the balance) in addition to whole-
-//! account proofs.
+//! where each validator occupies 16 contiguous leaves (9 fields incl. the node
+//! pubkey/map key, padded to a depth-4 per-validator sub-subtree). This enables
+//! field-level Merkle proofs (e.g., proving just the balance) in addition to
+//! whole-account proofs, and binds the validator's identity (node pubkey) into
+//! the root and its proofs.
 //!
 //! Validator slot assignment is purely positional: the i-th entry in
 //! `BTreeMap<[u8; 32], ValidatorAccount>` iteration order occupies
-//! leaves `[i*8 .. i*8+7]`. The subtree is rebuilt from scratch on
+//! leaves `[i*16 .. i*16+15]`. The subtree is rebuilt from scratch on
 //! every mutation for determinism.
 
 use crate::PublicKey;
@@ -74,9 +75,13 @@ pub const VALIDATOR_FIELD_HAS_PENDING_DEPOSIT: usize = 4;
 pub const VALIDATOR_FIELD_HAS_PENDING_WITHDRAWAL: usize = 5;
 pub const VALIDATOR_FIELD_JOINING_EPOCH: usize = 6;
 pub const VALIDATOR_FIELD_LAST_DEPOSIT_INDEX: usize = 7;
+/// The node public key — the `BTreeMap` key the account belongs to. Committed as
+/// a leaf so the validator's identity is bound into the root and its proofs.
+pub const VALIDATOR_FIELD_NODE_PUBKEY: usize = 8;
 
-/// Number of SSZ fields per ValidatorAccount (8 fields = depth-3 subtree).
-pub const VALIDATOR_FIELDS_PER_ACCOUNT: usize = 8;
+/// Leaves per validator: 9 fields padded to the next power of two (16 leaves,
+/// depth-4 subtree). Leaves 9–15 are zero padding.
+pub const VALIDATOR_FIELDS_PER_ACCOUNT: usize = 16;
 
 // --- Deposit field indices (within each deposit's 8-leaf subtree) ---
 
@@ -118,9 +123,13 @@ pub const PROTOCOL_PARAM_FIELDS_PER_ITEM: usize = 2;
 
 pub const ADDED_VALIDATOR_FIELD_NODE_KEY: usize = 0;
 pub const ADDED_VALIDATOR_FIELD_CONSENSUS_KEY: usize = 1;
+/// The activation epoch — the `BTreeMap` key this scheduled addition belongs to.
+/// Committed per item so the epoch is bound even though the value list is flattened.
+pub const ADDED_VALIDATOR_FIELD_EPOCH: usize = 2;
 
-/// Number of SSZ leaves per AddedValidator (2 fields = depth-1 subtree).
-pub const ADDED_VALIDATOR_FIELDS_PER_ITEM: usize = 2;
+/// Number of SSZ leaves per AddedValidator: 3 fields padded to the next power of
+/// two (4 leaves, depth-2 subtree). Leaf 3 is zero padding.
+pub const ADDED_VALIDATOR_FIELDS_PER_ITEM: usize = 4;
 
 /// Two-level SSZ state tree mirroring ConsensusState.
 #[derive(Clone, Debug)]
@@ -313,8 +322,8 @@ impl SszStateTree {
         let count = accounts.len();
         let leaf_count = (count * VALIDATOR_FIELDS_PER_ACCOUNT).max(1);
         let mut tree = SszTree::new(leaf_count);
-        for (i, account) in accounts.values().enumerate() {
-            Self::set_validator_fields(&mut tree, i, account);
+        for (i, (node_pubkey, account)) in accounts.iter().enumerate() {
+            Self::set_validator_fields(&mut tree, i, node_pubkey, account);
         }
         self.validator_tree = tree;
         self.validator_count = count;
@@ -322,8 +331,14 @@ impl SszStateTree {
     }
 
     /// Set the 8 field leaves for validator at positional slot `i`.
-    fn set_validator_fields(tree: &mut SszTree, slot: usize, account: &ValidatorAccount) {
+    fn set_validator_fields(
+        tree: &mut SszTree,
+        slot: usize,
+        node_pubkey: &[u8; 32],
+        account: &ValidatorAccount,
+    ) {
         let base = slot * VALIDATOR_FIELDS_PER_ACCOUNT;
+        tree.set_leaf(base + VALIDATOR_FIELD_NODE_PUBKEY, *node_pubkey);
         tree.set_leaf(
             base + VALIDATOR_FIELD_CONSENSUS_PUBKEY,
             account.consensus_public_key.hash_tree_root(),
@@ -362,8 +377,13 @@ impl SszStateTree {
     ///
     /// The validator must already exist at the given `slot`. Only the changed
     /// leaves are rehashed — O(8 · log n) instead of O(N · 8) for a full rebuild.
-    pub fn update_validator_at_slot(&mut self, slot: usize, account: &ValidatorAccount) {
-        Self::set_validator_fields(&mut self.validator_tree, slot, account);
+    pub fn update_validator_at_slot(
+        &mut self,
+        slot: usize,
+        node_pubkey: &[u8; 32],
+        account: &ValidatorAccount,
+    ) {
+        Self::set_validator_fields(&mut self.validator_tree, slot, node_pubkey, account);
         self.update_validator_collection_root();
     }
 
@@ -372,7 +392,12 @@ impl SszStateTree {
     /// Grows the tree if needed. Copies shifted validators' subtree nodes via memmove
     /// (no rehash), then writes the new validator's 8 field leaves and rehashes only
     /// the new slot's subtree plus upper ancestors. O(N) memcpy + O(N/8) SHA256.
-    pub fn insert_validator_at_slot(&mut self, slot: usize, account: &ValidatorAccount) {
+    pub fn insert_validator_at_slot(
+        &mut self,
+        slot: usize,
+        node_pubkey: &[u8; 32],
+        account: &ValidatorAccount,
+    ) {
         let new_count = self.validator_count + 1;
         let needed = new_count * VALIDATOR_FIELDS_PER_ACCOUNT;
         self.validator_tree.grow(needed);
@@ -382,8 +407,8 @@ impl SszStateTree {
         self.validator_tree
             .shift_blocks_right(slot, to_shift, VALIDATOR_FIELDS_PER_ACCOUNT);
 
-        // Write new validator's 8 field leaves (no per-leaf rehash)
-        Self::set_validator_fields_no_rehash(&mut self.validator_tree, slot, account);
+        // Write new validator's field leaves (no per-leaf rehash)
+        Self::set_validator_fields_no_rehash(&mut self.validator_tree, slot, node_pubkey, account);
 
         // Rehash only the new validator's subtree (3 internal levels above its 8 leaves)
         self.validator_tree
@@ -452,8 +477,14 @@ impl SszStateTree {
     }
 
     /// Set the 8 field leaves without triggering per-leaf rehash.
-    fn set_validator_fields_no_rehash(tree: &mut SszTree, slot: usize, account: &ValidatorAccount) {
+    fn set_validator_fields_no_rehash(
+        tree: &mut SszTree,
+        slot: usize,
+        node_pubkey: &[u8; 32],
+        account: &ValidatorAccount,
+    ) {
         let base = slot * VALIDATOR_FIELDS_PER_ACCOUNT;
+        tree.set_leaf_no_rehash(base + VALIDATOR_FIELD_NODE_PUBKEY, *node_pubkey);
         tree.set_leaf_no_rehash(
             base + VALIDATOR_FIELD_CONSENSUS_PUBKEY,
             account.consensus_public_key.hash_tree_root(),
@@ -855,12 +886,15 @@ impl SszStateTree {
     /// Each added validator occupies 2 contiguous leaves (node_key, consensus_key),
     /// forming a depth-1 per-item sub-subtree, enabling field-level proofs.
     pub fn rebuild_added_validators(&mut self, validators: &BTreeMap<u64, Vec<AddedValidator>>) {
-        let items: Vec<&AddedValidator> = validators.values().flat_map(|v| v.iter()).collect();
+        let items: Vec<(u64, &AddedValidator)> = validators
+            .iter()
+            .flat_map(|(epoch, v)| v.iter().map(move |av| (*epoch, av)))
+            .collect();
         let count = items.len();
         let leaf_count = (count * ADDED_VALIDATOR_FIELDS_PER_ITEM).max(1);
         let mut tree = SszTree::new(leaf_count);
-        for (i, av) in items.iter().enumerate() {
-            Self::set_added_validator_fields(&mut tree, i, av);
+        for (i, (epoch, av)) in items.iter().enumerate() {
+            Self::set_added_validator_fields(&mut tree, i, *epoch, av);
         }
         self.added_validator_tree = tree;
         self.added_validator_count = count;
@@ -868,7 +902,12 @@ impl SszStateTree {
     }
 
     /// Set the 2 field leaves for added validator at positional slot `i`.
-    fn set_added_validator_fields(tree: &mut SszTree, slot: usize, av: &AddedValidator) {
+    fn set_added_validator_fields(
+        tree: &mut SszTree,
+        slot: usize,
+        epoch: u64,
+        av: &AddedValidator,
+    ) {
         let base = slot * ADDED_VALIDATOR_FIELDS_PER_ITEM;
         tree.set_leaf(
             base + ADDED_VALIDATOR_FIELD_NODE_KEY,
@@ -878,6 +917,7 @@ impl SszStateTree {
             base + ADDED_VALIDATOR_FIELD_CONSENSUS_KEY,
             av.consensus_key.hash_tree_root(),
         );
+        tree.set_leaf(base + ADDED_VALIDATOR_FIELD_EPOCH, epoch.hash_tree_root());
     }
 
     fn update_added_validator_collection_root(&mut self) {
@@ -1123,11 +1163,13 @@ impl SszStateTree {
         let node_index = self.validator_tree.capacity() / VALIDATOR_FIELDS_PER_ACCOUNT + slot;
         let node_value = self.validator_tree.get_node(node_index);
 
-        // Generalized index: top_gindex << (sd - 2) | slot
-        // (sd - 2 = (sd - 3) levels in subtree + 1 for mix_in_length)
+        // Generalized index: descend from the top leaf to the per-validator subtree
+        // root, which sits `log_block` levels above the field leaves. That is
+        // `(sd - log_block)` subtree levels + 1 for the mix_in_length node.
+        let log_block = VALIDATOR_FIELDS_PER_ACCOUNT.ilog2() as usize;
         let td = self.top.depth();
         let top_gindex = (1u64 << td) + VALIDATOR_ACCOUNTS_ROOT as u64;
-        let gindex = (top_gindex << (sd - 2)) | (slot as u64);
+        let gindex = (top_gindex << (sd - log_block + 1)) | (slot as u64);
 
         // Branch: subtree proof from internal node + mix_in_length sibling + top proof
         let mut branch = self.validator_tree.generate_proof_from_node(node_index);
@@ -1561,9 +1603,12 @@ impl SszStateTree {
             self.added_validator_tree.capacity() / ADDED_VALIDATOR_FIELDS_PER_ITEM + slot;
         let node_value = self.added_validator_tree.get_node(node_index);
 
+        // Descend to the per-item subtree root, `log_block` levels above the field
+        // leaves: `(sd - log_block)` subtree levels + 1 for the mix_in_length node.
+        let log_block = ADDED_VALIDATOR_FIELDS_PER_ITEM.ilog2() as usize;
         let td = self.top.depth();
         let top_gindex = (1u64 << td) + ADDED_VALIDATORS_ROOT as u64;
-        let gindex = (top_gindex << sd) | (slot as u64);
+        let gindex = (top_gindex << (sd - log_block + 1)) | (slot as u64);
 
         let mut branch = self
             .added_validator_tree
@@ -2822,11 +2867,12 @@ mod tests {
         let account_proof = tree.generate_validator_proof(&pk, &keys).unwrap();
         let field_proof = tree.generate_validator_field_proof(&pk, 0, &keys).unwrap();
 
-        // Field proof branch is 3 elements longer (depth-3 per-validator subtree)
+        // Field proof branch is 4 elements longer (depth-4 per-validator subtree:
+        // 9 fields incl. node pubkey, padded to 16 leaves)
         assert_eq!(
             field_proof.branch.len(),
-            account_proof.branch.len() + 3,
-            "field branch should be 3 longer than account branch"
+            account_proof.branch.len() + 4,
+            "field branch should be 4 longer than account branch"
         );
     }
 
@@ -2841,9 +2887,21 @@ mod tests {
         let keys: Vec<[u8; 32]> = accounts.keys().copied().collect();
         let proof = tree.generate_validator_proof(&pk, &keys).unwrap();
 
-        // The proof leaf should be hash_tree_root(account), computed from the
-        // internal node which is the root of the 8-field subtree
-        assert_eq!(proof.leaf, acc.hash_tree_root());
+        // The whole-account proof leaf is the per-validator subtree root: the 8
+        // account fields plus the node pubkey (field 8), merkleized over 16 leaves.
+        // (No longer equal to ValidatorAccount::hash_tree_root, which omits the key.)
+        let expected = crate::ssz_tree::merkleize(&[
+            acc.consensus_public_key.hash_tree_root(),
+            acc.withdrawal_credentials.hash_tree_root(),
+            acc.balance.hash_tree_root(),
+            acc.status.hash_tree_root(),
+            acc.has_pending_deposit.hash_tree_root(),
+            acc.has_pending_withdrawal.hash_tree_root(),
+            acc.joining_epoch.hash_tree_root(),
+            acc.last_deposit_index.hash_tree_root(),
+            pk,
+        ]);
+        assert_eq!(proof.leaf, expected);
     }
 
     #[test]
@@ -2881,6 +2939,16 @@ mod tests {
         tree
     }
 
+    /// Expected per-item leaf for an added validator: node key, consensus key, and
+    /// the activation epoch, merkleized over 4 leaves (matches the SSZ subtree root).
+    fn added_validator_entry_root(epoch: u64, av: &AddedValidator) -> [u8; 32] {
+        crate::ssz_tree::merkleize(&[
+            av.node_key.hash_tree_root(),
+            av.consensus_key.hash_tree_root(),
+            epoch.hash_tree_root(),
+        ])
+    }
+
     // ── Insert / remove tests ──────────────────────────────────────────
 
     /// Insert N validators one-by-one and compare against full rebuild.
@@ -2893,7 +2961,7 @@ mod tests {
         for (pk, acc) in &validators {
             accounts.insert(*pk, acc.clone());
             let slot = accounts.keys().position(|k| k == pk).unwrap();
-            inc_tree.insert_validator_at_slot(slot, acc);
+            inc_tree.insert_validator_at_slot(slot, pk, acc);
         }
 
         let ref_tree = rebuild_tree(&accounts);
@@ -2962,7 +3030,7 @@ mod tests {
             let slot = accounts.keys().position(|k| k == &new_pk).unwrap();
 
             let mut tree = rebuild_tree(&base_accounts);
-            tree.insert_validator_at_slot(slot, &new_acc);
+            tree.insert_validator_at_slot(slot, &new_pk, &new_acc);
 
             let ref_tree = rebuild_tree(&accounts);
             assert_eq!(
@@ -3098,7 +3166,7 @@ mod tests {
             let mut modified_accounts = accounts.clone();
             modified_accounts.insert(new_pk, new_acc.clone());
             let slot = modified_accounts.keys().position(|k| k == &new_pk).unwrap();
-            modified.insert_validator_at_slot(slot, &new_acc);
+            modified.insert_validator_at_slot(slot, &new_pk, &new_acc);
 
             assert_ne!(
                 modified.root(),
@@ -3134,7 +3202,7 @@ mod tests {
 
             let mut modified = tree.clone();
             modified.remove_validator_at_slot(slot);
-            modified.insert_validator_at_slot(slot, &acc);
+            modified.insert_validator_at_slot(slot, &pk, &acc);
 
             assert_eq!(
                 modified.root(),
@@ -3162,12 +3230,12 @@ mod tests {
         // Insert A
         modified_accounts.insert(pk_a, acc_a.clone());
         let slot_a = modified_accounts.keys().position(|k| k == &pk_a).unwrap();
-        modified.insert_validator_at_slot(slot_a, &acc_a);
+        modified.insert_validator_at_slot(slot_a, &pk_a, &acc_a);
 
         // Insert B
         modified_accounts.insert(pk_b, acc_b.clone());
         let slot_b = modified_accounts.keys().position(|k| k == &pk_b).unwrap();
-        modified.insert_validator_at_slot(slot_b, &acc_b);
+        modified.insert_validator_at_slot(slot_b, &pk_b, &acc_b);
 
         // Verify intermediate state matches rebuild
         let ref_tree = rebuild_tree(&modified_accounts);
@@ -3206,12 +3274,12 @@ mod tests {
         let (new_pk, mut new_acc) = make_validator(42);
         accounts.insert(new_pk, new_acc.clone());
         let slot = accounts.keys().position(|k| k == &new_pk).unwrap();
-        tree.insert_validator_at_slot(slot, &new_acc);
+        tree.insert_validator_at_slot(slot, &new_pk, &new_acc);
 
         // Update its balance
         new_acc.balance = 64_000_000_000;
         accounts.insert(new_pk, new_acc.clone());
-        tree.update_validator_at_slot(slot, &new_acc);
+        tree.update_validator_at_slot(slot, &new_pk, &new_acc);
 
         let ref_tree = rebuild_tree(&accounts);
         assert_eq!(
@@ -3232,7 +3300,7 @@ mod tests {
             let (pk, acc) = make_validator(i);
             accounts.insert(pk, acc.clone());
             let slot = accounts.keys().position(|k| k == &pk).unwrap();
-            inc_tree.insert_validator_at_slot(slot, &acc);
+            inc_tree.insert_validator_at_slot(slot, &pk, &acc);
 
             let ref_tree = rebuild_tree(&accounts);
             assert_eq!(
@@ -3254,7 +3322,7 @@ mod tests {
             let (pk, acc) = make_validator(i);
             accounts.insert(pk, acc.clone());
             let slot = accounts.keys().position(|k| k == &pk).unwrap();
-            tree.insert_validator_at_slot(slot, &acc);
+            tree.insert_validator_at_slot(slot, &pk, &acc);
         }
 
         // Remove 2nd
@@ -3270,7 +3338,7 @@ mod tests {
             let (pk, acc) = make_validator(i);
             accounts.insert(pk, acc.clone());
             let slot = accounts.keys().position(|k| k == &pk).unwrap();
-            tree.insert_validator_at_slot(slot, &acc);
+            tree.insert_validator_at_slot(slot, &pk, &acc);
         }
 
         // Remove first
@@ -3289,7 +3357,7 @@ mod tests {
             let (pk, acc) = make_validator(i);
             accounts.insert(pk, acc.clone());
             let slot = accounts.keys().position(|k| k == &pk).unwrap();
-            tree.insert_validator_at_slot(slot, &acc);
+            tree.insert_validator_at_slot(slot, &pk, &acc);
         }
 
         let ref_tree = rebuild_tree(&accounts);
@@ -3314,7 +3382,7 @@ mod tests {
         let (new_pk, new_acc) = make_validator(42);
         accounts.insert(new_pk, new_acc.clone());
         let slot = accounts.keys().position(|k| k == &new_pk).unwrap();
-        tree.insert_validator_at_slot(slot, &new_acc);
+        tree.insert_validator_at_slot(slot, &new_pk, &new_acc);
 
         let root = tree.root();
         let keys: Vec<[u8; 32]> = accounts.keys().copied().collect();
@@ -3377,12 +3445,15 @@ mod tests {
         tree.rebuild_added_validators(&added);
         let root = tree.root();
 
-        // Flattened items
-        let items: Vec<AddedValidator> = added.values().flat_map(|v| v.iter().cloned()).collect();
+        // Flattened items, carrying each item's activation epoch.
+        let items: Vec<(u64, AddedValidator)> = added
+            .iter()
+            .flat_map(|(epoch, v)| v.iter().cloned().map(move |av| (*epoch, av)))
+            .collect();
 
-        for i in 0..items.len() {
+        for (i, (epoch, av)) in items.iter().enumerate() {
             let proof = tree.generate_added_validator_proof(i).unwrap();
-            assert_eq!(proof.leaf, items[i].hash_tree_root());
+            assert_eq!(proof.leaf, added_validator_entry_root(*epoch, av));
             assert!(proof.verify(&root), "added validator proof {i} failed");
         }
 
@@ -3437,7 +3508,7 @@ mod tests {
         let proof = tree
             .generate_added_validator_proof_by_key(target_key, &added)
             .unwrap();
-        assert_eq!(proof.leaf, added[&3][1].hash_tree_root());
+        assert_eq!(proof.leaf, added_validator_entry_root(3, &added[&3][1]));
         assert!(proof.verify(&root));
 
         // Unknown key returns None
@@ -3563,19 +3634,20 @@ mod tests {
             }
         }
 
-        // Field proof branch is 1 element longer than whole-item proof
+        // Field proof branch is 2 elements longer than whole-item proof
+        // (depth-2 per-item subtree: 3 fields incl. epoch, padded to 4 leaves)
         let item_proof = tree.generate_added_validator_proof(0).unwrap();
         let field_proof = tree
             .generate_added_validator_field_proof(0, ADDED_VALIDATOR_FIELD_NODE_KEY)
             .unwrap();
         assert_eq!(
             field_proof.branch.len(),
-            item_proof.branch.len() + 1,
-            "field branch should be 1 longer than item branch"
+            item_proof.branch.len() + 2,
+            "field branch should be 2 longer than item branch"
         );
 
-        // Out of bounds
-        assert!(tree.generate_added_validator_field_proof(0, 2).is_none());
+        // Out of bounds (fields 0..=2 are valid: node_key, consensus_key, epoch)
+        assert!(tree.generate_added_validator_field_proof(0, 4).is_none());
         assert!(
             tree.generate_added_validator_field_proof(count, 0)
                 .is_none()
@@ -3595,7 +3667,7 @@ mod tests {
         tree.rebuild_added_validators(&added);
 
         let proof = tree.generate_added_validator_proof(0).unwrap();
-        assert_eq!(proof.leaf, av.hash_tree_root());
+        assert_eq!(proof.leaf, added_validator_entry_root(1, &av));
     }
 
     #[test]

--- a/types/src/ssz_state_tree.rs
+++ b/types/src/ssz_state_tree.rs
@@ -314,10 +314,11 @@ impl SszStateTree {
 
     /// Rebuild the validator subtree from the full validator accounts map.
     ///
-    /// Each validator occupies 8 contiguous leaves (one per field) in the subtree,
-    /// forming a depth-3 per-validator sub-subtree. Slot assignment is purely
-    /// positional: the i-th entry in BTreeMap iteration order occupies leaves
-    /// `[i*8 .. i*8+7]`.
+    /// Each validator occupies 16 contiguous leaves (8 fields incl. the
+    /// `node_pubkey` map key, plus zero padding) in the subtree, forming a
+    /// depth-4 per-validator sub-subtree. Slot assignment is purely positional:
+    /// the i-th entry in BTreeMap iteration order occupies leaves
+    /// `[i*16 .. i*16+15]`.
     pub fn rebuild_validators(&mut self, accounts: &BTreeMap<[u8; 32], ValidatorAccount>) {
         let count = accounts.len();
         let leaf_count = (count * VALIDATOR_FIELDS_PER_ACCOUNT).max(1);
@@ -885,8 +886,9 @@ impl SszStateTree {
 
     /// Rebuild added validators subtree (flattened across all epochs).
     ///
-    /// Each added validator occupies 2 contiguous leaves (node_key, consensus_key),
-    /// forming a depth-1 per-item sub-subtree, enabling field-level proofs.
+    /// Each added validator occupies 4 contiguous leaves (node_key, consensus_key,
+    /// epoch map key, and zero padding), forming a depth-2 per-item sub-subtree,
+    /// enabling field-level proofs.
     pub fn rebuild_added_validators(&mut self, validators: &BTreeMap<u64, Vec<AddedValidator>>) {
         let items: Vec<(u64, &AddedValidator)> = validators
             .iter()
@@ -1157,11 +1159,11 @@ impl SszStateTree {
     /// Build a proof for the whole validator at positional `slot`.
     ///
     /// Returns (gindex, node_value, branch) where the node is the
-    /// per-validator subtree root (3 levels above the field leaves).
+    /// per-validator subtree root (4 levels above the field leaves).
     fn validator_account_proof(&self, slot: usize) -> (u64, [u8; 32], Vec<[u8; 32]>) {
         let sd = self.validator_tree.depth();
-        // Per-validator root is at depth (sd - 3) in the subtree.
-        // Its 1-based tree index is: capacity / 8 + slot
+        // Per-validator root is at depth (sd - 4) in the subtree (16 leaves/item).
+        // Its 1-based tree index is: capacity / VALIDATOR_FIELDS_PER_ACCOUNT + slot
         let node_index = self.validator_tree.capacity() / VALIDATOR_FIELDS_PER_ACCOUNT + slot;
         let node_value = self.validator_tree.get_node(node_index);
 
@@ -1543,9 +1545,9 @@ impl SszStateTree {
 
     /// Generate a proof for an added validator at a given flattened index (whole item).
     ///
-    /// The proof leaf is the per-item subtree root (internal node 1 level
-    /// above the field leaves). The branch is 1 element shorter than a
-    /// field-level proof.
+    /// The proof leaf is the per-item subtree root (internal node 2 levels
+    /// above the field leaves, since each item is a depth-2 / 4-leaf subtree).
+    /// The branch is 2 elements shorter than a field-level proof.
     pub fn generate_added_validator_proof(&self, index: usize) -> Option<SszProof> {
         if index >= self.added_validator_count {
             return None;

--- a/types/src/ssz_state_tree.rs
+++ b/types/src/ssz_state_tree.rs
@@ -330,7 +330,8 @@ impl SszStateTree {
         self.update_validator_collection_root();
     }
 
-    /// Set the 8 field leaves for validator at positional slot `i`.
+    /// Set the validator's 9 field leaves (node-pubkey key + 8 account fields,
+    /// padded to a 16-leaf depth-4 subtree) at positional slot `i`.
     fn set_validator_fields(
         tree: &mut SszTree,
         slot: usize,
@@ -390,7 +391,7 @@ impl SszStateTree {
     /// Insert a new validator at positional `slot`, shifting existing validators right.
     ///
     /// Grows the tree if needed. Copies shifted validators' subtree nodes via memmove
-    /// (no rehash), then writes the new validator's 8 field leaves and rehashes only
+    /// (no rehash), then writes the new validator's 9 field leaves and rehashes only
     /// the new slot's subtree plus upper ancestors. O(N) memcpy + O(N/8) SHA256.
     pub fn insert_validator_at_slot(
         &mut self,
@@ -410,7 +411,7 @@ impl SszStateTree {
         // Write new validator's field leaves (no per-leaf rehash)
         Self::set_validator_fields_no_rehash(&mut self.validator_tree, slot, node_pubkey, account);
 
-        // Rehash only the new validator's subtree (3 internal levels above its 8 leaves)
+        // Rehash only the new validator's subtree (4 internal levels above its 16 leaves)
         self.validator_tree
             .rehash_block(slot, VALIDATOR_FIELDS_PER_ACCOUNT);
 
@@ -476,7 +477,8 @@ impl SszStateTree {
         self.update_validator_collection_root();
     }
 
-    /// Set the 8 field leaves without triggering per-leaf rehash.
+    /// Set the validator's 9 field leaves (node-pubkey key + 8 account fields)
+    /// without triggering per-leaf rehash.
     fn set_validator_fields_no_rehash(
         tree: &mut SszTree,
         slot: usize,

--- a/types/src/ssz_tree_key.rs
+++ b/types/src/ssz_tree_key.rs
@@ -168,6 +168,9 @@ pub fn parse_key(descriptor: &str) -> Result<SszStateKey, String> {
 
 fn parse_validator_field_name(name: &str) -> Result<usize, String> {
     match name {
+        // The account's map key (node ed25519 pubkey), committed as a leaf so a
+        // proof binds the account value to the pubkey it belongs to.
+        "node_pubkey" | "node_public_key" => Ok(ssz_state_tree::VALIDATOR_FIELD_NODE_PUBKEY),
         "consensus_pubkey" | "consensus_public_key" => {
             Ok(ssz_state_tree::VALIDATOR_FIELD_CONSENSUS_PUBKEY)
         }
@@ -222,6 +225,9 @@ fn parse_added_validator_field_name(name: &str) -> Result<usize, String> {
     match name {
         "node_key" => Ok(ssz_state_tree::ADDED_VALIDATOR_FIELD_NODE_KEY),
         "consensus_key" => Ok(ssz_state_tree::ADDED_VALIDATOR_FIELD_CONSENSUS_KEY),
+        // The scheduled-activation map key (target epoch), committed as a leaf so
+        // a proof binds the addition to the epoch it activates in.
+        "epoch" => Ok(ssz_state_tree::ADDED_VALIDATOR_FIELD_EPOCH),
         _ => Err(format!("unknown added_validator field: {name}")),
     }
 }
@@ -539,6 +545,28 @@ mod tests {
     #[test]
     fn parse_added_validator_field_unknown_errors() {
         assert!(parse_key("added_validator_field:0:nonexistent").is_err());
+    }
+
+    #[test]
+    fn parse_added_validator_epoch_key_field() {
+        // The activation-epoch map key is now committed and addressable.
+        let key = parse_key("added_validator_field:2:epoch").unwrap();
+        assert_eq!(
+            key,
+            SszStateKey::AddedValidatorField(2, ssz_state_tree::ADDED_VALIDATOR_FIELD_EPOCH)
+        );
+    }
+
+    #[test]
+    fn parse_validator_node_pubkey_key_field() {
+        // The node-pubkey map key is now committed and addressable as a field, so
+        // a consumer can prove the account value is bound to the pubkey it keyed.
+        let hex_key = "validator_field:0x0101010101010101010101010101010101010101010101010101010101010101:node_pubkey";
+        let SszStateKey::ValidatorField(pubkey, field_index) = parse_key(hex_key).unwrap() else {
+            panic!("expected ValidatorField");
+        };
+        assert_eq!(pubkey, [1u8; 32]);
+        assert_eq!(field_index, ssz_state_tree::VALIDATOR_FIELD_NODE_PUBKEY);
     }
 
     #[test]


### PR DESCRIPTION
Builds on https://github.com/SeismicSystems/summit/pull/293 (which builds on https://github.com/SeismicSystems/summit/pull/292 and https://github.com/SeismicSystems/summit/pull/291).

Addresses https://github.com/SeismicSystems/summit/issues/257.

The SSZ tree committed validator_accounts and added_validators as value-only positional lists, so the BTreeMap keys were not bound by the state root. Two states differing only in a map key produced the same root, and validator-account proofs bound a value without binding the pubkey it belongs to.

Changes:
- validator_accounts: add `node_pubkey` as a 9th field; per-validator subtree grows 8 → 16 leaves (depth 3 → 4). Threaded the map key through set_validator_fields and update_/insert_validator_at_slot; rebuild_validators iterates by (key, account); set_account passes the pubkey.
- added_validators: add `epoch` as a 3rd per-item field; subtree grows 2 → 4 leaves (depth 1 → 2). rebuild_added_validators carries the epoch through the flatten.
- Generalized the whole-item proof gindex from a hardcoded subtree depth to `top_gindex << (sd - log_block + 1)` (`log_block = fields_per_item.ilog2()`), so it adapts to the new depths.

A field/whole-item proof's branch now includes the key, so the proof self-binds identity. ValidatorAccount::hash_tree_root no longer equals the per-validator subtree root (the root now includes the node pubkey).