### PR TITLE
fix: adds weak-subjectivity anchoring for verified checkpoint imports

### DIFF
--- a/docs/checkpointing.md
+++ b/docs/checkpointing.md
@@ -110,7 +110,7 @@ Checkpoints and headers are stored in a single QMDB store using prefixed keys an
 
 ## Checkpoint Verification
 
-Checkpoint verification allows a node to trustlessly validate a checkpoint received from an untrusted source. This is essential for secure bootstrapping without replaying the entire chain.
+Checkpoint verification allows a node to validate that a checkpoint is internally signed, contiguous from local genesis, fresh, and passes through an independently trusted weak-subjectivity anchor. The finalized-header chain by itself is not enough to bootstrap from an untrusted source: operators must supply a recent trusted finalized-header digest and epoch from outside the checkpoint bundle.
 
 ### Verification Scheme
 
@@ -119,20 +119,27 @@ To verify a checkpoint for epoch `n`, a verifier needs:
 1. **Genesis state**: The initial validator set and their BLS public keys
 2. **Finalized headers**: Headers for epochs `0` through `n`
 3. **Checkpoint**: The checkpoint for epoch `n`
+4. **Weak-subjectivity anchor**: A trusted finalized-header `epoch` and `digest` obtained independently of the checkpoint bundle
 
 ### Verification Steps
 
 1. **Verify Header Chain**:
    - For each epoch `i` from `0` to `n`:
+     - Verify the header links to the previous epoch header (or genesis for epoch `0`)
      - Verify the BLS multi-signature using the known validator set for epoch `i`
      - Extract `added_validators` and `removed_validators` from the header
      - Update the validator set for epoch `i+1`
 
-2. **Verify Checkpoint Hash**:
+2. **Verify Weak-Subjectivity Anchor**:
+   - Check `finalized_headers[trusted_epoch].header.digest == trusted_digest`
+   - Reject if the trusted epoch is not included in the supplied header chain
+   - Reject if the terminal checkpoint epoch is more than 5 epochs after the trusted epoch
+
+3. **Verify Checkpoint Hash**:
    - Compute the checkpoint digest
    - Verify it matches `checkpoint_hash` in header `n`
 
-3. **Verify Validator Set Consistency**:
+4. **Verify Validator Set Consistency**:
    - The checkpoint's `validator_accounts` should match the accumulated validator set changes
 
 ### Header Fields for Verification
@@ -186,7 +193,17 @@ checkpoint_dir/
 
 ### Checkpoint Verification on Startup
 
-When the `finalized_headers/` directory is present, the node loads the checkpoint artifacts from disk first, then verifies the checkpoint during startup after loading genesis by calling `verify_checkpoint_chain` with the genesis state, the loaded headers, and the checkpoint. This allows the node to trustlessly validate a checkpoint received from an untrusted source.
+When the `finalized_headers/` directory is present, the node loads the checkpoint artifacts from disk first, then verifies the checkpoint during startup after loading genesis. Verified checkpoint imports require an independently configured weak-subjectivity anchor:
+
+```
+--checkpoint-path ./checkpoint_dir \
+--weak-subjectivity-epoch 7421 \
+--weak-subjectivity-header-digest 0x8f4c...
+```
+
+The header digest is the finalized header's `header.digest` for the trusted epoch. It can be queried from a trusted node with `getFinalizedHeaderDigest(epoch)`.
+
+The checkpoint's terminal epoch must be within 5 epochs of `--weak-subjectivity-epoch`.
 
 If the `finalized_headers/` directory is absent, verification is skipped and the node trusts the checkpoint as-is.
 

--- a/node/src/args.rs
+++ b/node/src/args.rs
@@ -154,6 +154,22 @@ pub struct RunFlags {
     #[arg(long)]
     pub checkpoint_or_default: bool,
 
+    /// Trusted finalized-header epoch used as the weak-subjectivity anchor for checkpoint verification
+    #[arg(
+        long,
+        requires = "checkpoint_path",
+        requires = "weak_subjectivity_header_digest"
+    )]
+    pub weak_subjectivity_epoch: Option<u64>,
+
+    /// Trusted finalized-header digest used as the weak-subjectivity anchor for checkpoint verification
+    #[arg(
+        long,
+        requires = "checkpoint_path",
+        requires = "weak_subjectivity_epoch"
+    )]
+    pub weak_subjectivity_header_digest: Option<String>,
+
     /// IP address for this node (optional, will use genesis if not provided)
     #[arg(long)]
     pub ip: Option<String>,
@@ -301,16 +317,32 @@ async fn run_node_inner(
     );
 
     // Verify checkpoint if finalized headers chain was provided
+    let weak_subjectivity = weak_subjectivity_from_flags(&flags);
     if let (Some(raw_checkpoint), Some(headers_chain)) =
         (&loaded.raw_checkpoint, &loaded.finalized_headers_chain)
     {
-        checkpoint::verify_checkpoint_chain(&genesis, headers_chain, raw_checkpoint)
-            .expect("checkpoint verification failed");
+        let weak_subjectivity = weak_subjectivity.as_ref().expect(
+            "checkpoint verification requires --weak-subjectivity-epoch and \
+             --weak-subjectivity-header-digest when finalized_headers/ is present",
+        );
+        checkpoint::verify_checkpoint_chain_with_weak_subjectivity(
+            &genesis,
+            headers_chain,
+            raw_checkpoint,
+            Some(weak_subjectivity),
+        )
+        .expect("checkpoint verification failed");
         info!(
             epochs_verified = headers_chain.len(),
+            weak_subjectivity_epoch = weak_subjectivity.epoch,
             "checkpoint verified successfully"
         );
     } else if loaded.raw_checkpoint.is_some() {
+        if weak_subjectivity.is_some() {
+            panic!(
+                "weak-subjectivity checkpoint verification requires a checkpoint directory with finalized_headers/"
+            );
+        }
         warn!("checkpoint loaded without finalized headers chain - skipping verification");
     }
 
@@ -802,6 +834,33 @@ fn get_initial_state(
         }
         state
     })
+}
+
+fn weak_subjectivity_from_flags(
+    flags: &RunFlags,
+) -> Option<checkpoint::WeakSubjectivityHeaderDigest> {
+    match (
+        flags.weak_subjectivity_epoch,
+        flags.weak_subjectivity_header_digest.as_ref(),
+    ) {
+        (Some(epoch), Some(header_digest)) => Some(checkpoint::WeakSubjectivityHeaderDigest {
+            epoch,
+            header_digest: parse_digest_arg(header_digest, "--weak-subjectivity-header-digest"),
+        }),
+        (None, None) => None,
+        _ => panic!(
+            "--weak-subjectivity-epoch and --weak-subjectivity-header-digest must be supplied together"
+        ),
+    }
+}
+
+fn parse_digest_arg(value: &str, arg_name: &str) -> summit_types::Digest {
+    let bytes = from_hex_formatted(value)
+        .unwrap_or_else(|| panic!("{arg_name} must be a 32-byte hex digest"));
+    let bytes: [u8; 32] = bytes
+        .try_into()
+        .unwrap_or_else(|_| panic!("{arg_name} must be a 32-byte hex digest"));
+    bytes.into()
 }
 
 async fn get_node_ip(

--- a/node/src/bin/observer.rs
+++ b/node/src/bin/observer.rs
@@ -513,6 +513,8 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         bench_block_dir: None,
         checkpoint_path: None,
         checkpoint_or_default: false,
+        weak_subjectivity_epoch: None,
+        weak_subjectivity_header_digest: None,
         ip: None,
         bootstrappers: None,
         critical_log_dir: None,

--- a/node/src/bin/protocol_params.rs
+++ b/node/src/bin/protocol_params.rs
@@ -412,6 +412,8 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         bench_block_dir: None,
         checkpoint_path: None,
         checkpoint_or_default: false,
+        weak_subjectivity_epoch: None,
+        weak_subjectivity_header_digest: None,
         ip: None,
         bootstrappers: None,
         critical_log_dir: None,

--- a/node/src/bin/stake_and_checkpoint.rs
+++ b/node/src/bin/stake_and_checkpoint.rs
@@ -703,6 +703,8 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         bench_block_dir: None,
         checkpoint_path: None,
         checkpoint_or_default: false,
+        weak_subjectivity_epoch: None,
+        weak_subjectivity_header_digest: None,
         ip: None,
         bootstrappers: None,
         critical_log_dir: None,

--- a/node/src/bin/stake_and_join_with_outdated_ckpt.rs
+++ b/node/src/bin/stake_and_join_with_outdated_ckpt.rs
@@ -821,6 +821,8 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         bench_block_dir: None,
         checkpoint_path: None,
         checkpoint_or_default: false,
+        weak_subjectivity_epoch: None,
+        weak_subjectivity_header_digest: None,
         ip: None,
         bootstrappers: None,
         critical_log_dir: None,

--- a/node/src/bin/sync_from_genesis.rs
+++ b/node/src/bin/sync_from_genesis.rs
@@ -685,6 +685,8 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         bench_block_dir: None,
         checkpoint_path: None,
         checkpoint_or_default: false,
+        weak_subjectivity_epoch: None,
+        weak_subjectivity_header_digest: None,
         ip: None,
         bootstrappers: None,
         critical_log_dir: None,

--- a/node/src/bin/testnet.rs
+++ b/node/src/bin/testnet.rs
@@ -199,6 +199,8 @@ fn get_node_flags(node: usize) -> RunFlags {
         bench_block_dir: None,
         checkpoint_path: None,
         checkpoint_or_default: false,
+        weak_subjectivity_epoch: None,
+        weak_subjectivity_header_digest: None,
         ip: None,
         bootstrappers: None,
         critical_log_dir: None,

--- a/node/src/bin/verify_consensus_state_proof.rs
+++ b/node/src/bin/verify_consensus_state_proof.rs
@@ -583,6 +583,8 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         bench_block_dir: None,
         checkpoint_path: None,
         checkpoint_or_default: false,
+        weak_subjectivity_epoch: None,
+        weak_subjectivity_header_digest: None,
         ip: None,
         bootstrappers: None,
         critical_log_dir: None,

--- a/node/src/bin/withdraw_and_exit.rs
+++ b/node/src/bin/withdraw_and_exit.rs
@@ -407,6 +407,8 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         bench_block_dir: None,
         checkpoint_path: None,
         checkpoint_or_default: false,
+        weak_subjectivity_epoch: None,
+        weak_subjectivity_header_digest: None,
         ip: None,
         bootstrappers: None,
         critical_log_dir: None,

--- a/node/src/tests/checkpointing/verification.rs
+++ b/node/src/tests/checkpointing/verification.rs
@@ -30,7 +30,7 @@ fn test_checkpoint_verification_fixed_committee() {
     // Runs a network for multiple epochs, then fetches all finalized headers
     // and verifies the checkpoint chain cryptographically.
     let n = 5;
-    let num_epochs = 3u64;
+    let num_epochs = checkpoint::WEAK_SUBJECTIVITY_MAX_AGE_EPOCHS + 2;
     let namespace = "_SUMMIT";
     let link = Link {
         latency: Duration::from_millis(80),
@@ -208,6 +208,88 @@ fn test_checkpoint_verification_fixed_committee() {
         // Verify the checkpoint chain
         checkpoint::verify_checkpoint_chain(&genesis, &finalized_headers, &raw_checkpoint)
             .expect("checkpoint verification failed");
+
+        assert!(
+            checkpoint_epoch > checkpoint::WEAK_SUBJECTIVITY_MAX_AGE_EPOCHS,
+            "test needs a checkpoint beyond the weak-subjectivity window"
+        );
+
+        let weak_subjectivity_epoch =
+            checkpoint_epoch - checkpoint::WEAK_SUBJECTIVITY_MAX_AGE_EPOCHS;
+        let weak_subjectivity = checkpoint::WeakSubjectivityHeaderDigest {
+            epoch: weak_subjectivity_epoch,
+            header_digest: finalized_headers[weak_subjectivity_epoch as usize]
+                .header
+                .digest,
+        };
+        checkpoint::verify_checkpoint_chain_with_weak_subjectivity(
+            &genesis,
+            &finalized_headers,
+            &raw_checkpoint,
+            Some(&weak_subjectivity),
+        )
+        .expect("checkpoint verification with weak-subjectivity anchor failed");
+
+        let wrong_weak_subjectivity = checkpoint::WeakSubjectivityHeaderDigest {
+            epoch: weak_subjectivity_epoch,
+            header_digest: [0xFF; 32].into(),
+        };
+        let err = checkpoint::verify_checkpoint_chain_with_weak_subjectivity(
+            &genesis,
+            &finalized_headers,
+            &raw_checkpoint,
+            Some(&wrong_weak_subjectivity),
+        )
+        .expect_err("verification should fail with a mismatched weak-subjectivity anchor");
+        assert!(
+            matches!(
+                err,
+                CheckpointVerificationError::WeakSubjectivityHeaderDigestMismatch { epoch, .. }
+                    if epoch == weak_subjectivity_epoch
+            ),
+            "expected WeakSubjectivityHeaderDigestMismatch for epoch {weak_subjectivity_epoch}, got: {err}"
+        );
+
+        let stale_weak_subjectivity = checkpoint::WeakSubjectivityHeaderDigest {
+            epoch: 0,
+            header_digest: finalized_headers[0].header.digest,
+        };
+        let err = checkpoint::verify_checkpoint_chain_with_weak_subjectivity(
+            &genesis,
+            &finalized_headers,
+            &raw_checkpoint,
+            Some(&stale_weak_subjectivity),
+        )
+        .expect_err("verification should fail with a stale weak-subjectivity anchor");
+        assert!(
+            matches!(
+                err,
+                CheckpointVerificationError::WeakSubjectivityCheckpointTooOld {
+                    weak_subjectivity_epoch: 0,
+                    ..
+                }
+            ),
+            "expected WeakSubjectivityCheckpointTooOld for epoch 0, got: {err}"
+        );
+
+        let unavailable_weak_subjectivity = checkpoint::WeakSubjectivityHeaderDigest {
+            epoch: checkpoint_epoch + 1,
+            header_digest: [0u8; 32].into(),
+        };
+        let err = checkpoint::verify_checkpoint_chain_with_weak_subjectivity(
+            &genesis,
+            &finalized_headers,
+            &raw_checkpoint,
+            Some(&unavailable_weak_subjectivity),
+        )
+        .expect_err("verification should fail when the weak-subjectivity epoch is unavailable");
+        assert!(
+            matches!(
+                err,
+                CheckpointVerificationError::WeakSubjectivityEpochUnavailable { .. }
+            ),
+            "expected WeakSubjectivityEpochUnavailable, got: {err}"
+        );
 
         // Verify that a tampered signature causes verification to fail
         let mut tampered_sig_headers = finalized_headers.clone();

--- a/rpc/src/api.rs
+++ b/rpc/src/api.rs
@@ -1,7 +1,7 @@
 use crate::types::{
     CheckpointInfoRes, CheckpointRes, DepositResponse, DepositTransactionResponse,
-    EpochBoundsResponse, FinalizedHeaderRes, PendingWithdrawalResponse, PublicKeysResponse,
-    StateProofResponse, StateRootResponse, ValidatorAccountResponse,
+    EpochBoundsResponse, FinalizedHeaderDigestRes, FinalizedHeaderRes, PendingWithdrawalResponse,
+    PublicKeysResponse, StateProofResponse, StateRootResponse, ValidatorAccountResponse,
 };
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::proc_macros::rpc;
@@ -25,6 +25,9 @@ pub trait SummitApi {
 
     #[method(name = "getFinalizedHeader")]
     async fn get_finalized_header(&self, epoch: u64) -> RpcResult<FinalizedHeaderRes>;
+
+    #[method(name = "getFinalizedHeaderDigest")]
+    async fn get_finalized_header_digest(&self, epoch: u64) -> RpcResult<FinalizedHeaderDigestRes>;
 
     #[method(name = "getLatestHeight")]
     async fn get_latest_height(&self) -> RpcResult<u64>;

--- a/rpc/src/server.rs
+++ b/rpc/src/server.rs
@@ -6,8 +6,9 @@ use crate::auth;
 use crate::error::RpcError;
 use crate::types::{
     CheckpointInfoRes, CheckpointRes, DepositResponse, DepositTransactionResponse,
-    EpochBoundsResponse, FinalizedHeaderRes, PendingWithdrawalResponse, PublicKeysResponse,
-    StateProofResponse, StateProofResult, StateRootResponse, ValidatorAccountResponse,
+    EpochBoundsResponse, FinalizedHeaderDigestRes, FinalizedHeaderRes, PendingWithdrawalResponse,
+    PublicKeysResponse, StateProofResponse, StateProofResult, StateRootResponse,
+    ValidatorAccountResponse,
 };
 use alloy_primitives::{Address, U256, hex::FromHex as _};
 use async_trait::async_trait;
@@ -156,6 +157,23 @@ impl SummitApiServer for SummitRpcServer {
         Ok(FinalizedHeaderRes {
             epoch,
             finalized_header: header.as_ssz_bytes(),
+        })
+    }
+
+    async fn get_finalized_header_digest(&self, epoch: u64) -> RpcResult<FinalizedHeaderDigestRes> {
+        let maybe_header = self
+            .finalizer_mailbox
+            .clone()
+            .get_finalized_header(epoch)
+            .await;
+
+        let Some(header) = maybe_header else {
+            return Err(RpcError::FinalizedHeaderNotFound.into());
+        };
+
+        Ok(FinalizedHeaderDigestRes {
+            epoch,
+            digest: header.header.digest.0,
         })
     }
 

--- a/rpc/src/types.rs
+++ b/rpc/src/types.rs
@@ -17,7 +17,7 @@ pub struct DepositTransactionResponse {
 }
 
 pub use summit_types::rpc::{
-    CheckpointInfoRes, CheckpointRes, DepositResponse, EpochBoundsResponse, FinalizedHeaderRes,
-    PendingWithdrawalResponse, StateProofResponse, StateProofResult, StateRootResponse,
-    ValidatorAccountResponse,
+    CheckpointInfoRes, CheckpointRes, DepositResponse, EpochBoundsResponse,
+    FinalizedHeaderDigestRes, FinalizedHeaderRes, PendingWithdrawalResponse, StateProofResponse,
+    StateProofResult, StateRootResponse, ValidatorAccountResponse,
 };

--- a/rpc/tests/integration_test.rs
+++ b/rpc/tests/integration_test.rs
@@ -9,7 +9,10 @@ use summit_rpc::{
     PathSender, start_rpc_server_for_genesis_with_handle, start_rpc_server_pair_with_handle,
     start_rpc_server_with_handle,
 };
-use utils::{MockFinalizerState, create_test_finalizer_mailbox, create_test_keystore};
+use utils::{
+    MockFinalizerState, create_test_finalized_header, create_test_finalizer_mailbox,
+    create_test_keystore,
+};
 
 const TEST_GENESIS_HASH: [u8; 32] = [7u8; 32];
 
@@ -107,6 +110,43 @@ async fn test_get_latest_epoch() {
     let response = client.get_latest_epoch().await;
     assert!(response.is_ok());
     assert_eq!(response.unwrap(), 10);
+
+    handle.stop().unwrap();
+}
+
+#[tokio::test]
+async fn test_get_finalized_header_digest() {
+    use summit_rpc::SummitApiClient;
+
+    let epoch = 3;
+    let finalized_header = create_test_finalized_header(epoch);
+    let expected_digest = finalized_header.header.digest.0;
+    let state = MockFinalizerState {
+        finalized_headers: [(epoch, Some(finalized_header))].into(),
+        ..Default::default()
+    };
+    let (mailbox, _finalizer_handle) = create_test_finalizer_mailbox(state);
+    let temp_dir = create_test_keystore().unwrap();
+    let key_store_path = temp_dir.path().to_str().unwrap().to_string();
+
+    let (handle, addr) = start_rpc_server_with_handle(
+        mailbox,
+        key_store_path,
+        TEST_GENESIS_HASH,
+        b"_SUMMIT".to_vec(),
+        0,
+        #[cfg(feature = "permissioned")]
+        Arc::new(AtomicBool::new(false)),
+    )
+    .await
+    .unwrap();
+
+    let url = format!("http://{}", addr);
+    let client = HttpClientBuilder::default().build(&url).unwrap();
+
+    let response = client.get_finalized_header_digest(epoch).await.unwrap();
+    assert_eq!(response.epoch, epoch);
+    assert_eq!(response.digest, expected_digest);
 
     handle.stop().unwrap();
 }

--- a/rpc/tests/utils.rs
+++ b/rpc/tests/utils.rs
@@ -1,5 +1,5 @@
 use alloy_primitives::Address;
-use commonware_codec::Encode as _;
+use commonware_codec::{DecodeExt as _, Encode as _};
 use commonware_cryptography::{bls12381, ed25519};
 use commonware_math::algebra::Random;
 use futures::{StreamExt, channel::mpsc};
@@ -27,6 +27,7 @@ pub struct MockFinalizerState {
     pub latest_epoch: u64,
     pub checkpoints: HashMap<u64, Option<summit_types::checkpoint::Checkpoint>>,
     pub latest_checkpoint: Option<(Option<summit_types::checkpoint::Checkpoint>, u64)>,
+    pub finalized_headers: HashMap<u64, Option<summit_types::FinalizedHeader<TestScheme>>>,
     pub validator_balances: HashMap<summit_types::PublicKey, Option<u64>>,
     pub validator_accounts: HashMap<summit_types::PublicKey, Option<ValidatorAccount>>,
     pub minimum_stake: u64,
@@ -40,6 +41,7 @@ impl Default for MockFinalizerState {
             latest_epoch: 0,
             checkpoints: HashMap::new(),
             latest_checkpoint: Some((None, 0)),
+            finalized_headers: HashMap::new(),
             validator_balances: HashMap::new(),
             validator_accounts: HashMap::new(),
             minimum_stake: 32_000_000_000, // 32 ETH in gwei
@@ -94,7 +96,10 @@ pub fn create_test_finalizer_mailbox(
                         let account = state.validator_accounts.get(&public_key).cloned().flatten();
                         let _ = response.send(ConsensusStateResponse::ValidatorAccount(account));
                     }
-                    ConsensusStateRequest::GetFinalizedHeader(_) => unimplemented!(),
+                    ConsensusStateRequest::GetFinalizedHeader(epoch) => {
+                        let header = state.finalized_headers.get(&epoch).cloned().flatten();
+                        let _ = response.send(ConsensusStateResponse::FinalizedHeader(header));
+                    }
                     ConsensusStateRequest::GetMinimumStake => {
                         let _ = response
                             .send(ConsensusStateResponse::MinimumStake(state.minimum_stake));
@@ -158,6 +163,60 @@ pub fn create_test_finalizer_mailbox(
     });
 
     (FinalizerMailbox::new(tx), handle)
+}
+
+pub fn create_test_finalized_header(epoch: u64) -> summit_types::FinalizedHeader<TestScheme> {
+    use commonware_consensus::simplex::types::{Finalization, Proposal};
+    use commonware_consensus::types::{Epoch, Round, View};
+    use commonware_cryptography::bls12381::{
+        certificate::multisig::Certificate as BlsCertificate,
+        primitives::{
+            group::Private,
+            ops::{aggregate::Signature, sign_message},
+            variant::MinPk,
+        },
+    };
+    use commonware_utils::Participant;
+
+    let header = summit_types::Header::compute_digest(
+        [1u8; 32].into(),
+        epoch * 10 + 9,
+        1234567890 + epoch,
+        epoch,
+        1,
+        [2u8; 32].into(),
+        [3u8; 32].into(),
+        [4u8; 32].into(),
+        [5u8; 32].into(),
+        Vec::new(),
+        Vec::new(),
+        [0u8; 32],
+    );
+
+    let proposal = Proposal {
+        round: Round::new(Epoch::new(header.epoch), View::new(header.view)),
+        parent: View::new(header.height),
+        payload: header.digest,
+    };
+
+    let mut rng = StdRng::seed_from_u64(42);
+    let private = Private::random(&mut rng);
+    let g2_signature = sign_message::<MinPk>(&private, b"", b"test message");
+    let encoded = g2_signature.encode();
+    let signature = Signature::<MinPk>::decode(encoded).expect("valid signature");
+
+    let finalized = Finalization {
+        proposal,
+        certificate: BlsCertificate::<MinPk> {
+            signers: commonware_cryptography::certificate::Signers::from(
+                3,
+                [0, 1, 2].map(Participant::new),
+            ),
+            signature: signature.into(),
+        },
+    };
+
+    summit_types::FinalizedHeader::new(header, finalized, 3)
 }
 
 /// Creates a temporary key store directory with test keys

--- a/types/src/checkpoint.rs
+++ b/types/src/checkpoint.rs
@@ -11,11 +11,14 @@ use commonware_cryptography::{Hasher, Sha256, ed25519};
 use commonware_parallel::Sequential;
 use commonware_utils::TryCollect;
 use commonware_utils::from_hex_formatted;
+use commonware_utils::hex;
 use commonware_utils::ordered::BiMap;
 use rand::rngs::OsRng;
 use ssz::{Decode, Encode as SszEncode};
 use std::collections::BTreeSet;
 use std::{error, fmt};
+
+pub const WEAK_SUBJECTIVITY_MAX_AGE_EPOCHS: u64 = 5;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Checkpoint {
@@ -143,13 +146,40 @@ impl TryFrom<&Checkpoint> for ConsensusState {
 #[derive(Debug)]
 pub enum CheckpointVerificationError {
     NoHeaders,
-    NonContiguousEpochs { expected: u64, found: u64 },
-    SignatureVerificationFailed { epoch: u64 },
+    NonContiguousEpochs {
+        expected: u64,
+        found: u64,
+    },
+    SignatureVerificationFailed {
+        epoch: u64,
+    },
     CheckpointHashMismatch,
-    PrevEpochHeaderHashMismatch { epoch: u64 },
+    PrevEpochHeaderHashMismatch {
+        epoch: u64,
+    },
     InvalidGenesisHash(String),
+    WeakSubjectivityEpochUnavailable {
+        epoch: u64,
+        highest: u64,
+    },
+    WeakSubjectivityHeaderDigestMismatch {
+        epoch: u64,
+        expected: Digest,
+        found: Digest,
+    },
+    WeakSubjectivityCheckpointTooOld {
+        checkpoint_epoch: u64,
+        weak_subjectivity_epoch: u64,
+        max_age_epochs: u64,
+    },
     ValidatorSetMismatch(String),
     ValidatorSetError(String),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WeakSubjectivityHeaderDigest {
+    pub epoch: u64,
+    pub header_digest: Digest,
 }
 
 impl fmt::Display for CheckpointVerificationError {
@@ -177,6 +207,34 @@ impl fmt::Display for CheckpointVerificationError {
             Self::InvalidGenesisHash(reason) => {
                 write!(f, "invalid genesis hash: {reason}")
             }
+            Self::WeakSubjectivityEpochUnavailable { epoch, highest } => {
+                write!(
+                    f,
+                    "weak-subjectivity epoch {epoch} is not present in finalized headers; highest available epoch is {highest}"
+                )
+            }
+            Self::WeakSubjectivityHeaderDigestMismatch {
+                epoch,
+                expected,
+                found,
+            } => {
+                write!(
+                    f,
+                    "weak-subjectivity header digest mismatch at epoch {epoch}: expected 0x{}, found 0x{}",
+                    hex(expected.as_ref()),
+                    hex(found.as_ref())
+                )
+            }
+            Self::WeakSubjectivityCheckpointTooOld {
+                checkpoint_epoch,
+                weak_subjectivity_epoch,
+                max_age_epochs,
+            } => {
+                write!(
+                    f,
+                    "checkpoint epoch {checkpoint_epoch} is more than {max_age_epochs} epochs after weak-subjectivity epoch {weak_subjectivity_epoch}"
+                )
+            }
             Self::ValidatorSetMismatch(reason) => {
                 write!(f, "validator set mismatch: {reason}")
             }
@@ -191,6 +249,10 @@ impl error::Error for CheckpointVerificationError {}
 
 /// Verifies a checkpoint by walking the chain of finalized headers from genesis.
 ///
+/// This checks internal chain consistency only. Checkpoint imports should call
+/// `verify_checkpoint_chain_with_weak_subjectivity` so the supplied history is
+/// tied to an independently trusted recent finalized-header digest.
+///
 /// For each epoch, the BLS aggregate signature is verified against the known
 /// validator set, and validator set changes (added/removed) are applied.
 /// Finally, the checkpoint hash in the last header is compared to the checkpoint digest.
@@ -198,6 +260,18 @@ pub fn verify_checkpoint_chain(
     genesis: &Genesis,
     finalized_headers: &[FinalizedHeader<MultisigScheme>],
     checkpoint: &Checkpoint,
+) -> Result<(), CheckpointVerificationError> {
+    verify_checkpoint_chain_with_weak_subjectivity(genesis, finalized_headers, checkpoint, None)
+}
+
+/// Verifies a checkpoint by walking the chain of finalized headers from genesis
+/// and requiring the chain to pass through an independently trusted finalized
+/// header digest.
+pub fn verify_checkpoint_chain_with_weak_subjectivity(
+    genesis: &Genesis,
+    finalized_headers: &[FinalizedHeader<MultisigScheme>],
+    checkpoint: &Checkpoint,
+    weak_subjectivity: Option<&WeakSubjectivityHeaderDigest>,
 ) -> Result<(), CheckpointVerificationError> {
     if finalized_headers.is_empty() {
         return Err(CheckpointVerificationError::NoHeaders);
@@ -294,6 +368,48 @@ pub fn verify_checkpoint_chain(
             participants.retain(|(pk, _)| pk != removed);
         }
         participants.sort_by(|a, b| a.0.cmp(&b.0));
+    }
+
+    if let Some(weak_subjectivity) = weak_subjectivity {
+        let Some(anchor_index) = usize::try_from(weak_subjectivity.epoch).ok() else {
+            let highest = finalized_headers.len() as u64 - 1;
+            return Err(
+                CheckpointVerificationError::WeakSubjectivityEpochUnavailable {
+                    epoch: weak_subjectivity.epoch,
+                    highest,
+                },
+            );
+        };
+        let Some(anchor_header) = finalized_headers.get(anchor_index) else {
+            let highest = finalized_headers.len() as u64 - 1;
+            return Err(
+                CheckpointVerificationError::WeakSubjectivityEpochUnavailable {
+                    epoch: weak_subjectivity.epoch,
+                    highest,
+                },
+            );
+        };
+
+        if anchor_header.header.digest != weak_subjectivity.header_digest {
+            return Err(
+                CheckpointVerificationError::WeakSubjectivityHeaderDigestMismatch {
+                    epoch: weak_subjectivity.epoch,
+                    expected: weak_subjectivity.header_digest,
+                    found: anchor_header.header.digest,
+                },
+            );
+        }
+
+        let checkpoint_epoch = finalized_headers.len() as u64 - 1;
+        if checkpoint_epoch - weak_subjectivity.epoch > WEAK_SUBJECTIVITY_MAX_AGE_EPOCHS {
+            return Err(
+                CheckpointVerificationError::WeakSubjectivityCheckpointTooOld {
+                    checkpoint_epoch,
+                    weak_subjectivity_epoch: weak_subjectivity.epoch,
+                    max_age_epochs: WEAK_SUBJECTIVITY_MAX_AGE_EPOCHS,
+                },
+            );
+        }
     }
 
     // Step 2: Compute the checkpoint digest and verify it matches the last header

--- a/types/src/rpc.rs
+++ b/types/src/rpc.rs
@@ -56,6 +56,12 @@ pub struct FinalizedHeaderRes {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct FinalizedHeaderDigestRes {
+    pub epoch: u64,
+    pub digest: [u8; 32],
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct StateRootResponse {
     pub root: [u8; 32],
     /// The EL block number at capture time. The root appears on-chain in EL block


### PR DESCRIPTION
Addresses https://github.com/SeismicSystems/summit/issues/297.

Changes:
  - Requires --weak-subjectivity-epoch and --weak-subjectivity-header-digest when importing checkpoint bundles with finalized_headers/
  - Verifies the supplied finalized-header chain passes through the trusted header digest
  - Rejects checkpoint bundles whose terminal epoch is more than 5 epochs after the trusted anchor
  - Adds getFinalizedHeaderDigest(epoch) RPC for fetching { epoch, digest } from a trusted node
  - Updates checkpointing docs to clarify that self-contained finalized-header bundles are not trustless without an external anchor