### PR TITLE
fix: gate execution-layer forkchoice status during block execution

### DIFF
--- a/finalizer/src/actor.rs
+++ b/finalizer/src/actor.rs
@@ -912,6 +912,8 @@ impl<
                 &mut self.canonical_state,
                 &self.protocol_consts,
                 self.deposit_signature_domain,
+                // canonical path: instant finality (safe = finalized = head)
+                None,
             )
             .await
             {
@@ -1000,17 +1002,8 @@ impl<
             );
         }
 
-        if let Err(e) = self
-            .engine_client
-            .commit_hash(*self.canonical_state.get_forkchoice())
-            .await
-        {
-            error!(target: "critical", "engine client error on canonical commit_hash after finalization: {e}");
-            #[cfg(feature = "prom")]
-            counter!("critical_errors_total", "reason" => "engine_client_error", "severity" => "critical")
-                .increment(1);
-            return Err(anyhow!("engine client error on canonical commit_hash: {e}"));
-        }
+        // Forkchoice was already committed (and its status gated) inside
+        // `execute_block` before any state mutation.
 
         #[cfg(feature = "prom")]
         {
@@ -1406,6 +1399,9 @@ impl<
             // discard the block: certify will reject it on every honest validator, no
             // certify quorum will form, and no descendant can build on it (find_parent
             // gates on certified). The fork is dead; skip fork-state creation.
+            // Fork path: head is this block, but safe/finalized stay at the
+            // canonical finalized hash so the EL never finalizes a speculative fork.
+            let fork_finalized = self.canonical_state.get_forkchoice().finalized_block_hash;
             let exec_outcome = match execute_block(
                 &mut self.engine_client,
                 &self.context,
@@ -1413,6 +1409,7 @@ impl<
                 &mut fork_state,
                 &self.protocol_consts,
                 self.deposit_signature_domain,
+                Some(fork_finalized),
             )
             .await
             {
@@ -1494,22 +1491,8 @@ impl<
                 },
             );
 
-            // Commit this fork to reth so validators can build/verify blocks on top of it
-            // Keep the canonical finalized chain unchanged by using canonical finalized hash
-            let fork_forkchoice = ForkchoiceState {
-                head_block_hash: fork_state.get_forkchoice().head_block_hash,
-                safe_block_hash: self.canonical_state.get_forkchoice().finalized_block_hash,
-                finalized_block_hash: self.canonical_state.get_forkchoice().finalized_block_hash,
-            };
-            if let Err(e) = self.engine_client.commit_hash(fork_forkchoice).await {
-                error!(target: "critical", height, ?block_digest, "engine client error on fork commit_hash after notarization: {e}");
-                #[cfg(feature = "prom")]
-                counter!("critical_errors_total", "reason" => "engine_client_error", "severity" => "critical")
-                    .increment(1);
-                return Err(anyhow!(
-                    "engine client error on fork commit_hash at height {height}: {e}"
-                ));
-            }
+            // The fork forkchoice was already committed to reth (and its status
+            // gated) inside `execute_block`, so validators can build/verify on it.
 
             let total_fork_count: usize = self.fork_states.values().map(|f| f.len()).sum();
             info!(
@@ -2152,6 +2135,10 @@ async fn execute_block<
     state: &mut ConsensusState,
     consts: &ProtocolConsts,
     deposit_signature_domain: Digest,
+    // forkchoice safe/finalized hash for this block's EL commit: `None` on the
+    // canonical path (instant finality → safe = finalized = head), or the
+    // canonical finalized hash for a speculative notarized fork.
+    fork_finalized: Option<alloy_primitives::B256>,
 ) -> Result<ExecuteOutcome, summit_types::EngineClientError> {
     #[cfg(feature = "prom")]
     let block_processing_start = Instant::now();
@@ -2194,6 +2181,41 @@ async fn execute_block<
         eth_hash = hex(&eth_hash),
         "committing block to execution layer"
     );
+
+    // EL forkchoice handoff, gated as part of block execution and BEFORE the
+    // in-state forkchoice update and request processing below. Placing it here
+    // means a SYNCING/INVALID forkchoice reuses the same buffer/abort handling as
+    // check_payload, and a SYNCING retry replays cleanly because `state` is still
+    // untouched. Only the head varies per block; safe/finalized follow the path.
+    let safe_finalized = match fork_finalized {
+        Some(finalized) => finalized, // notarized fork: keep the canonical finalized
+        None => eth_hash.into(),      // canonical: instant finality (safe = finalized = head)
+    };
+    let forkchoice_status = engine_client
+        .commit_hash(ForkchoiceState {
+            head_block_hash: eth_hash.into(),
+            safe_block_hash: safe_finalized,
+            finalized_block_hash: safe_finalized,
+        })
+        .await?;
+    if forkchoice_status.is_syncing() {
+        debug!(
+            height = new_height,
+            "execution client returned SYNCING on forkchoice update; deferring block for later retry"
+        );
+        return Ok(ExecuteOutcome::Syncing);
+    }
+    if !forkchoice_status.is_valid() {
+        // The EL accepted the payload as VALID but won't adopt the forkchoice for
+        // it: an EL/CL inconsistency, not a normal rejection. Surface it like an
+        // invalid payload (finalized path shuts down; fork path discards).
+        warn!(
+            height = new_height,
+            ?forkchoice_status,
+            "execution client returned non-valid forkchoice update"
+        );
+        return Ok(ExecuteOutcome::InvalidPayload);
+    }
 
     state.set_forkchoice_head(eth_hash.into());
 

--- a/finalizer/src/actor.rs
+++ b/finalizer/src/actor.rs
@@ -245,6 +245,35 @@ enum ExecuteOutcome {
     Syncing,
 }
 
+/// Send a forkchoice update to the execution client and map its response to an
+/// [`ExecuteOutcome`], so the SYNCING/INVALID/VALID gating is identical everywhere a
+/// forkchoice is committed (block execution and the notarized→finalized reuse path).
+/// `SYNCING` → `Syncing` (caller buffers and retries; nothing should be mutated before
+/// calling this), non-valid → `InvalidPayload`, `VALID` → `Applied`.
+async fn commit_forkchoice<C: EngineClient>(
+    engine_client: &mut C,
+    forkchoice: ForkchoiceState,
+    height: u64,
+) -> Result<ExecuteOutcome, summit_types::EngineClientError> {
+    let status = engine_client.commit_hash(forkchoice).await?;
+    if status.is_syncing() {
+        debug!(
+            height,
+            "execution client returned SYNCING on forkchoice update; deferring block for later retry"
+        );
+        return Ok(ExecuteOutcome::Syncing);
+    }
+    if !status.is_valid() {
+        warn!(
+            height,
+            ?status,
+            "execution client returned non-valid forkchoice update"
+        );
+        return Ok(ExecuteOutcome::InvalidPayload);
+    }
+    Ok(ExecuteOutcome::Applied)
+}
+
 /// Result of a single attempt to handle a notarized or finalized block.
 ///
 /// Critical errors that should shut the validator down are returned as
@@ -863,6 +892,73 @@ impl<
                 ?block_digest,
                 "reusing fork state for finalized block"
             );
+
+            // At notarization the EL accepted this block as head with
+            // safe=finalized=old_canonical_finalized. Now that it is finalized we must
+            // send and gate the canonical finalized forkchoice (head=safe=finalized=B)
+            // before promoting the fork state to canonical / notifying waiters — the
+            // direct path below does this inside `execute_block`, the reuse path must
+            // mirror it. Gate BEFORE mutating `canonical_state` so a SYNCING retry
+            // replays cleanly with state untouched.
+            let eth_hash = block.eth_block_hash();
+            match commit_forkchoice(
+                &mut self.engine_client,
+                ForkchoiceState {
+                    head_block_hash: eth_hash.into(),
+                    safe_block_hash: eth_hash.into(),
+                    finalized_block_hash: eth_hash.into(),
+                },
+                height,
+            )
+            .await
+            {
+                Ok(ExecuteOutcome::Applied) => {}
+                Ok(ExecuteOutcome::Syncing) => {
+                    debug!(
+                        height,
+                        ?block_digest,
+                        "deferring finalized block: execution layer is SYNCING on finalized forkchoice"
+                    );
+                    return Ok(HandleOutcome::Buffered(PendingFinalized {
+                        block,
+                        finalization,
+                        ack: ack_tx,
+                        first_attempt_at,
+                    }));
+                }
+                Ok(ExecuteOutcome::InvalidPayload) => {
+                    // The EL accepted the payload at notarization but won't adopt the
+                    // finalized forkchoice for it: an EL/CL inconsistency on a finalized
+                    // block. This validator cannot continue safely.
+                    error!(
+                        target: "critical",
+                        height,
+                        ?block_digest,
+                        "execution client returned non-valid finalized forkchoice for reused block"
+                    );
+                    #[cfg(feature = "prom")]
+                    counter!(
+                        "critical_errors_total",
+                        "reason" => "finalized_forkchoice_invalid",
+                        "severity" => "critical"
+                    )
+                    .increment(1);
+                    return Err(anyhow!(
+                        "non-valid finalized forkchoice for finalized block at height {height} \
+                         with digest {block_digest:?}"
+                    ));
+                }
+                Err(e) => {
+                    error!(target: "critical", height, "engine client error on finalized forkchoice for reused block: {e}");
+                    #[cfg(feature = "prom")]
+                    counter!("critical_errors_total", "reason" => "engine_client_error", "severity" => "critical")
+                        .increment(1);
+                    return Err(anyhow!(
+                        "engine client error on finalized forkchoice at height {height}: {e}"
+                    ));
+                }
+            }
+
             let live_epocher = self.canonical_state.get_epocher().clone();
             live_epocher.replace_with(fork_state.consensus_state.get_epocher());
             self.canonical_state = fork_state.consensus_state.clone_with_epocher(live_epocher);
@@ -2191,30 +2287,22 @@ async fn execute_block<
         Some(finalized) => finalized, // notarized fork: keep the canonical finalized
         None => eth_hash.into(),      // canonical: instant finality (safe = finalized = head)
     };
-    let forkchoice_status = engine_client
-        .commit_hash(ForkchoiceState {
+    // A non-valid forkchoice here is an EL/CL inconsistency (the EL accepted the
+    // payload as VALID but won't adopt the forkchoice for it), surfaced like an
+    // invalid payload: the finalized path shuts down, the fork path discards.
+    match commit_forkchoice(
+        engine_client,
+        ForkchoiceState {
             head_block_hash: eth_hash.into(),
             safe_block_hash: safe_finalized,
             finalized_block_hash: safe_finalized,
-        })
-        .await?;
-    if forkchoice_status.is_syncing() {
-        debug!(
-            height = new_height,
-            "execution client returned SYNCING on forkchoice update; deferring block for later retry"
-        );
-        return Ok(ExecuteOutcome::Syncing);
-    }
-    if !forkchoice_status.is_valid() {
-        // The EL accepted the payload as VALID but won't adopt the forkchoice for
-        // it: an EL/CL inconsistency, not a normal rejection. Surface it like an
-        // invalid payload (finalized path shuts down; fork path discards).
-        warn!(
-            height = new_height,
-            ?forkchoice_status,
-            "execution client returned non-valid forkchoice update"
-        );
-        return Ok(ExecuteOutcome::InvalidPayload);
+        },
+        new_height,
+    )
+    .await?
+    {
+        ExecuteOutcome::Applied => {}
+        other => return Ok(other),
     }
 
     state.set_forkchoice_head(eth_hash.into());

--- a/finalizer/src/tests/mocks.rs
+++ b/finalizer/src/tests/mocks.rs
@@ -138,6 +138,37 @@ impl MockEngineClient {
             });
         }
     }
+
+    /// Queue VALID responses for commit_hash. Useful to satisfy the startup
+    /// forkchoice update before queuing a SYNCING/INVALID response for a block.
+    #[allow(unused)]
+    pub fn queue_commit_hash_valid(&self, count: usize) {
+        let mut overrides = self.commit_hash_overrides.lock().unwrap();
+        for _ in 0..count {
+            overrides.push_back(ForkchoiceUpdated {
+                payload_status: PayloadStatus::new(PayloadStatusEnum::Valid, None),
+                payload_id: None,
+            });
+        }
+    }
+
+    /// Queue INVALID responses for commit_hash. After these are consumed,
+    /// commit_hash falls back to returning VALID.
+    #[allow(unused)]
+    pub fn queue_commit_hash_invalid(&self, count: usize) {
+        let mut overrides = self.commit_hash_overrides.lock().unwrap();
+        for _ in 0..count {
+            overrides.push_back(ForkchoiceUpdated {
+                payload_status: PayloadStatus::new(
+                    PayloadStatusEnum::Invalid {
+                        validation_error: "mock invalid forkchoice".to_string(),
+                    },
+                    None,
+                ),
+                payload_id: None,
+            });
+        }
+    }
 }
 
 impl Default for MockEngineClient {

--- a/finalizer/src/tests/syncing.rs
+++ b/finalizer/src/tests/syncing.rs
@@ -1337,3 +1337,193 @@ fn test_notarized_commit_hash_invalid_discards_fork() {
         context.auditor().state()
     });
 }
+
+#[test]
+fn test_finalized_reuse_path_commits_finalized_forkchoice_and_shuts_down_on_invalid() {
+    // A block notarized before finalization is executed speculatively into a fork
+    // state with safe=finalized=old_canonical_finalized. When it later finalizes, the
+    // reuse path must still send and gate the canonical finalized forkchoice
+    // (head=safe=finalized=B). Here that finalized forkchoice is INVALID — an EL/CL
+    // inconsistency — so the validator must shut down rather than promote the fork.
+    //
+    // Regression guard: before the fix the reuse path skipped the finalized forkchoice
+    // entirely, so this INVALID would never be sent and the node would advance to
+    // height 1 instead of shutting down.
+    let cfg = deterministic::Config::default().with_seed(205);
+    let executor = Runner::from(cfg);
+    executor.start(|context| async move {
+        let genesis_hash = [0x42u8; 32];
+        let initial_state = create_test_initial_state(genesis_hash, NonZeroU64::new(10).unwrap());
+
+        let (orchestrator_tx, _orchestrator_rx) = futures_mpsc::channel(100);
+        let orchestrator_mailbox = summit_orchestrator::Mailbox::new(orchestrator_tx);
+        let node_key = ed25519::PrivateKey::from_seed(0);
+
+        let engine_client = MockEngineClient::new();
+        // commit_hash order: startup (VALID), notarized-fork execution (VALID),
+        // finalized reuse-path forkchoice (INVALID).
+        engine_client.queue_commit_hash_valid(2);
+        engine_client.queue_commit_hash_invalid(1);
+
+        let token = CancellationToken::new();
+        let finalizer_cfg = FinalizerConfig::<MockEngineClient, MockNetworkOracle, MinPk> {
+            mailbox_size: 100,
+            db_prefix: "test_finalized_reuse_fcu_invalid".to_string(),
+            engine_client,
+            oracle: MockNetworkOracle,
+            protocol_consts: default_protocol_consts(),
+            page_cache: CacheRef::from_pooler(
+                &context,
+                std::num::NonZero::new(4096).unwrap(),
+                NZUsize!(100),
+            ),
+            genesis_hash,
+            initial_state,
+            protocol_version: 1,
+            node_public_key: node_key.public_key(),
+            cancellation_token: token.clone(),
+            drain_interval: Duration::from_millis(100),
+            buffered_blocks_warn_threshold: 100,
+            pending_notarized_max: 1000,
+            namespace: Vec::new(),
+            _variant_marker: PhantomData,
+        };
+
+        let (finalizer, _state, mut mailbox, _state_query) =
+            Finalizer::<_, MockEngineClient, MockNetworkOracle, ed25519::PrivateKey, MinPk>::new(
+                context.with_label("finalizer"),
+                finalizer_cfg,
+            )
+            .await;
+        let _handle = finalizer.start(orchestrator_mailbox);
+        context.sleep(Duration::from_millis(100)).await;
+
+        let genesis_block = Block::genesis(genesis_hash);
+        let block1 = create_test_block(genesis_block.digest(), 1, 1, 4001);
+        let block1_digest = block1.digest();
+
+        // Notarize first → block lands in fork_states (forkchoice VALID).
+        mailbox.report(Update::NotarizedBlock(block1.clone())).await;
+        context.sleep(Duration::from_millis(200)).await;
+        let notify = mailbox.notify_at_height(1, block1_digest).await;
+        assert!(
+            notify.await.expect("notify channel closed"),
+            "notarized block must be in fork_states before finalization"
+        );
+        assert!(
+            !token.is_cancelled(),
+            "notarizing a valid block must not shut the validator down"
+        );
+
+        // Finalize the same block → reuse path sends the finalized forkchoice, which
+        // the EL rejects as INVALID → fatal shutdown.
+        let (ack, _waiter) = Exact::handle();
+        mailbox
+            .report(Update::FinalizedBlock((block1, None), ack))
+            .await;
+        context.sleep(Duration::from_millis(500)).await;
+
+        assert!(
+            token.is_cancelled(),
+            "a non-valid finalized forkchoice on the reuse path must shut the validator down"
+        );
+
+        context.auditor().state()
+    });
+}
+
+#[test]
+fn test_finalized_reuse_path_buffers_on_syncing() {
+    // When the finalized forkchoice on the reuse path returns SYNCING, the finalizer
+    // must NOT advance (canonical state stays untouched so the retry replays cleanly)
+    // and must apply the block only once the EL adopts the finalized forkchoice.
+    let cfg = deterministic::Config::default().with_seed(206);
+    let executor = Runner::from(cfg);
+    executor.start(|context| async move {
+        let genesis_hash = [0x42u8; 32];
+        let initial_state = create_test_initial_state(genesis_hash, NonZeroU64::new(10).unwrap());
+
+        let (orchestrator_tx, _orchestrator_rx) = futures_mpsc::channel(100);
+        let orchestrator_mailbox = summit_orchestrator::Mailbox::new(orchestrator_tx);
+        let node_key = ed25519::PrivateKey::from_seed(0);
+
+        let engine_client = MockEngineClient::new();
+        // commit_hash order: startup (VALID), notarized-fork execution (VALID), then
+        // the finalized reuse-path forkchoice returns SYNCING 3 times before VALID.
+        engine_client.queue_commit_hash_valid(2);
+        engine_client.queue_commit_hash_syncing(3);
+
+        let finalizer_cfg = FinalizerConfig::<MockEngineClient, MockNetworkOracle, MinPk> {
+            mailbox_size: 100,
+            db_prefix: "test_finalized_reuse_fcu_sync".to_string(),
+            engine_client,
+            oracle: MockNetworkOracle,
+            protocol_consts: default_protocol_consts(),
+            page_cache: CacheRef::from_pooler(
+                &context,
+                std::num::NonZero::new(4096).unwrap(),
+                NZUsize!(100),
+            ),
+            genesis_hash,
+            initial_state,
+            protocol_version: 1,
+            node_public_key: node_key.public_key(),
+            cancellation_token: CancellationToken::new(),
+            drain_interval: Duration::from_millis(100),
+            buffered_blocks_warn_threshold: 100,
+            pending_notarized_max: 1000,
+            namespace: Vec::new(),
+            _variant_marker: PhantomData,
+        };
+
+        let (finalizer, _state, mut mailbox, _state_query) =
+            Finalizer::<_, MockEngineClient, MockNetworkOracle, ed25519::PrivateKey, MinPk>::new(
+                context.with_label("finalizer"),
+                finalizer_cfg,
+            )
+            .await;
+        let _handle = finalizer.start(orchestrator_mailbox);
+        context.sleep(Duration::from_millis(100)).await;
+
+        let genesis_block = Block::genesis(genesis_hash);
+        let block1 = create_test_block(genesis_block.digest(), 1, 1, 4001);
+        let block1_digest = block1.digest();
+
+        // Notarize first → block lands in fork_states (forkchoice VALID). Notarization
+        // does not advance the finalized height.
+        mailbox.report(Update::NotarizedBlock(block1.clone())).await;
+        context.sleep(Duration::from_millis(200)).await;
+        let notify = mailbox.notify_at_height(1, block1_digest).await;
+        assert!(
+            notify.await.expect("notify channel closed"),
+            "notarized block must be in fork_states before finalization"
+        );
+        assert_eq!(
+            mailbox.get_latest_height().await,
+            0,
+            "notarization must not advance the finalized height"
+        );
+
+        // Finalize the same block → reuse path forkchoice is SYNCING: must buffer.
+        let (ack, _waiter) = Exact::handle();
+        mailbox
+            .report(Update::FinalizedBlock((block1, None), ack))
+            .await;
+        context.sleep(Duration::from_millis(50)).await;
+        assert_eq!(
+            mailbox.get_latest_height().await,
+            0,
+            "must not advance while the finalized forkchoice is SYNCING"
+        );
+
+        // Once the retries clear and the EL adopts the forkchoice, the block applies.
+        context.sleep(Duration::from_secs(20)).await;
+        assert_eq!(
+            mailbox.get_latest_height().await,
+            1,
+            "block must apply once the EL adopts the finalized forkchoice"
+        );
+
+        context.auditor().state()
+    });
+}

--- a/finalizer/src/tests/syncing.rs
+++ b/finalizer/src/tests/syncing.rs
@@ -156,9 +156,9 @@ fn default_protocol_consts() -> ProtocolConsts {
 
 #[test]
 fn test_initial_startup_sync_waits_for_valid() {
-    // Test that the finalizer's initial forkchoice update loop retries
-    // when the execution client returns SYNCING, and proceeds once VALID.
-    // After the sync completes, finalized blocks should be processed normally.
+    // Test that the finalizer tolerates a SYNCING initial forkchoice update
+    // without blocking: it enters its main loop immediately, and finalized blocks
+    // are processed once the execution client returns VALID.
 
     let cfg = deterministic::Config::default().with_seed(100);
     let executor = Runner::from(cfg);
@@ -174,8 +174,10 @@ fn test_initial_startup_sync_waits_for_valid() {
         let node_key = ed25519::PrivateKey::from_seed(0);
 
         let engine_client = MockEngineClient::new();
-        // commit_hash returns SYNCING twice, then falls through to VALID
-        engine_client.queue_commit_hash_syncing(2);
+        // Startup forkchoice update returns SYNCING once (the finalizer enters its
+        // main loop without blocking); later commit_hash calls fall through to
+        // VALID so the block's own forkchoice update succeeds and it applies.
+        engine_client.queue_commit_hash_syncing(1);
 
         let finalizer_cfg = FinalizerConfig::<MockEngineClient, MockNetworkOracle, MinPk> {
             mailbox_size: 100,
@@ -210,10 +212,9 @@ fn test_initial_startup_sync_waits_for_valid() {
 
         let _handle = finalizer.start(orchestrator_mailbox);
 
-        // The initial forkchoice loop sleeps 5s per SYNCING retry.
-        // With 2 SYNCING responses, the finalizer needs ~10s before it starts
-        // processing messages. Wait long enough for it to complete.
-        context.sleep(Duration::from_secs(12)).await;
+        // Startup does not block on SYNCING — it enters the main loop right away.
+        // A short pause lets startup finish before we send the block.
+        context.sleep(Duration::from_millis(200)).await;
 
         // Now send a finalized block — it should be processed normally
         // Height 6, epoch = 6/10 = 0, matches state.epoch
@@ -1101,6 +1102,236 @@ fn test_duplicate_finalized_delivery_is_idempotent() {
             engine_client_probe.check_payload_call_count(),
             calls_after_first,
             "duplicate finalized block must not be re-executed (check_payload was called again)"
+        );
+
+        context.auditor().state()
+    });
+}
+
+#[test]
+fn test_finalized_commit_hash_syncing_buffers_and_retries() {
+    // When the forkchoice update (commit_hash) returns SYNCING during finalized
+    // block execution, the finalizer must NOT advance — it buffers and retries,
+    // applying the block only once the EL adopts the forkchoice.
+    let cfg = deterministic::Config::default().with_seed(202);
+    let executor = Runner::from(cfg);
+    executor.start(|context| async move {
+        let genesis_hash = [0x42u8; 32];
+        let initial_state = create_test_initial_state(genesis_hash, NonZeroU64::new(10).unwrap());
+
+        let (orchestrator_tx, _orchestrator_rx) = futures_mpsc::channel(100);
+        let orchestrator_mailbox = summit_orchestrator::Mailbox::new(orchestrator_tx);
+        let node_key = ed25519::PrivateKey::from_seed(0);
+
+        let engine_client = MockEngineClient::new();
+        // forkchoice update returns SYNCING 3 times for the first block, then VALID.
+        engine_client.queue_commit_hash_syncing(3);
+
+        let finalizer_cfg = FinalizerConfig::<MockEngineClient, MockNetworkOracle, MinPk> {
+            mailbox_size: 100,
+            db_prefix: "test_finalized_fcu_sync".to_string(),
+            engine_client,
+            oracle: MockNetworkOracle,
+            protocol_consts: default_protocol_consts(),
+            page_cache: CacheRef::from_pooler(
+                &context,
+                std::num::NonZero::new(4096).unwrap(),
+                NZUsize!(100),
+            ),
+            genesis_hash,
+            initial_state,
+            protocol_version: 1,
+            node_public_key: node_key.public_key(),
+            cancellation_token: CancellationToken::new(),
+            drain_interval: Duration::from_millis(100),
+            buffered_blocks_warn_threshold: 100,
+            pending_notarized_max: 1000,
+            namespace: Vec::new(),
+            _variant_marker: PhantomData,
+        };
+
+        let (finalizer, _state, mut mailbox, _state_query) =
+            Finalizer::<_, MockEngineClient, MockNetworkOracle, ed25519::PrivateKey, MinPk>::new(
+                context.with_label("finalizer"),
+                finalizer_cfg,
+            )
+            .await;
+        let _handle = finalizer.start(orchestrator_mailbox);
+        context.sleep(Duration::from_millis(100)).await;
+
+        let genesis_block = Block::genesis(genesis_hash);
+        let block1 = create_test_block(genesis_block.digest(), 1, 1, 4001);
+        let (ack, _waiter) = Exact::handle();
+        mailbox
+            .report(Update::FinalizedBlock((block1, None), ack))
+            .await;
+
+        // Must NOT advance while the forkchoice is still SYNCING.
+        context.sleep(Duration::from_millis(50)).await;
+        assert_eq!(
+            mailbox.get_latest_height().await,
+            0,
+            "must not advance while the EL forkchoice is SYNCING"
+        );
+
+        // Once the retries clear and the EL returns VALID, the block applies.
+        context.sleep(Duration::from_secs(20)).await;
+        assert_eq!(
+            mailbox.get_latest_height().await,
+            1,
+            "block must apply once the EL adopts the forkchoice"
+        );
+
+        context.auditor().state()
+    });
+}
+
+#[test]
+fn test_finalized_commit_hash_invalid_shuts_down() {
+    // A non-valid (INVALID) forkchoice update for a finalized block is an EL/CL
+    // inconsistency (the payload was already VALID): the validator must shut down
+    // rather than advance on a head the EL has not adopted.
+    let cfg = deterministic::Config::default().with_seed(203);
+    let executor = Runner::from(cfg);
+    executor.start(|context| async move {
+        let genesis_hash = [0x42u8; 32];
+        let initial_state = create_test_initial_state(genesis_hash, NonZeroU64::new(10).unwrap());
+
+        let (orchestrator_tx, _orchestrator_rx) = futures_mpsc::channel(100);
+        let orchestrator_mailbox = summit_orchestrator::Mailbox::new(orchestrator_tx);
+        let node_key = ed25519::PrivateKey::from_seed(0);
+
+        let engine_client = MockEngineClient::new();
+        // Startup forkchoice update consumes the first override; keep it VALID so
+        // only the finalized block's forkchoice update is INVALID.
+        engine_client.queue_commit_hash_valid(1);
+        engine_client.queue_commit_hash_invalid(1);
+
+        let token = CancellationToken::new();
+        let finalizer_cfg = FinalizerConfig::<MockEngineClient, MockNetworkOracle, MinPk> {
+            mailbox_size: 100,
+            db_prefix: "test_finalized_fcu_invalid".to_string(),
+            engine_client,
+            oracle: MockNetworkOracle,
+            protocol_consts: default_protocol_consts(),
+            page_cache: CacheRef::from_pooler(
+                &context,
+                std::num::NonZero::new(4096).unwrap(),
+                NZUsize!(100),
+            ),
+            genesis_hash,
+            initial_state,
+            protocol_version: 1,
+            node_public_key: node_key.public_key(),
+            cancellation_token: token.clone(),
+            drain_interval: Duration::from_millis(100),
+            buffered_blocks_warn_threshold: 100,
+            pending_notarized_max: 1000,
+            namespace: Vec::new(),
+            _variant_marker: PhantomData,
+        };
+
+        let (finalizer, _state, mut mailbox, _state_query) =
+            Finalizer::<_, MockEngineClient, MockNetworkOracle, ed25519::PrivateKey, MinPk>::new(
+                context.with_label("finalizer"),
+                finalizer_cfg,
+            )
+            .await;
+        let _handle = finalizer.start(orchestrator_mailbox);
+        context.sleep(Duration::from_millis(100)).await;
+
+        let genesis_block = Block::genesis(genesis_hash);
+        let block1 = create_test_block(genesis_block.digest(), 1, 1, 4001);
+        let (ack, _waiter) = Exact::handle();
+        mailbox
+            .report(Update::FinalizedBlock((block1, None), ack))
+            .await;
+        context.sleep(Duration::from_millis(500)).await;
+
+        assert!(
+            token.is_cancelled(),
+            "a non-valid finalized forkchoice update must shut the validator down"
+        );
+
+        context.auditor().state()
+    });
+}
+
+#[test]
+fn test_notarized_commit_hash_invalid_discards_fork() {
+    // A non-valid (INVALID) forkchoice update for a notarized fork is discarded,
+    // not fatal: the finalizer drops the fork and keeps running.
+    let cfg = deterministic::Config::default().with_seed(204);
+    let executor = Runner::from(cfg);
+    executor.start(|context| async move {
+        let genesis_hash = [0x42u8; 32];
+        let initial_state = create_test_initial_state(genesis_hash, NonZeroU64::new(10).unwrap());
+
+        let (orchestrator_tx, _orchestrator_rx) = futures_mpsc::channel(100);
+        let orchestrator_mailbox = summit_orchestrator::Mailbox::new(orchestrator_tx);
+        let node_key = ed25519::PrivateKey::from_seed(0);
+
+        let engine_client = MockEngineClient::new();
+        // Startup forkchoice update consumes the first override; keep it VALID so
+        // the notarized fork's forkchoice update is the INVALID one.
+        engine_client.queue_commit_hash_valid(1);
+        engine_client.queue_commit_hash_invalid(1);
+
+        let token = CancellationToken::new();
+        let finalizer_cfg = FinalizerConfig::<MockEngineClient, MockNetworkOracle, MinPk> {
+            mailbox_size: 100,
+            db_prefix: "test_notarized_fcu_invalid".to_string(),
+            engine_client,
+            oracle: MockNetworkOracle,
+            protocol_consts: default_protocol_consts(),
+            page_cache: CacheRef::from_pooler(
+                &context,
+                std::num::NonZero::new(4096).unwrap(),
+                NZUsize!(100),
+            ),
+            genesis_hash,
+            initial_state,
+            protocol_version: 1,
+            node_public_key: node_key.public_key(),
+            cancellation_token: token.clone(),
+            drain_interval: Duration::from_millis(100),
+            buffered_blocks_warn_threshold: 100,
+            pending_notarized_max: 1000,
+            namespace: Vec::new(),
+            _variant_marker: PhantomData,
+        };
+
+        let (finalizer, _state, mut mailbox, _state_query) =
+            Finalizer::<_, MockEngineClient, MockNetworkOracle, ed25519::PrivateKey, MinPk>::new(
+                context.with_label("finalizer"),
+                finalizer_cfg,
+            )
+            .await;
+        let _handle = finalizer.start(orchestrator_mailbox);
+        context.sleep(Duration::from_millis(100)).await;
+
+        let genesis_block = Block::genesis(genesis_hash);
+        let block1 = create_test_block(genesis_block.digest(), 1, 1, 4001);
+
+        // Notarized block whose forkchoice update is INVALID → fork discarded.
+        mailbox.report(Update::NotarizedBlock(block1.clone())).await;
+        context.sleep(Duration::from_millis(500)).await;
+        assert!(
+            !token.is_cancelled(),
+            "a non-valid notarized forkchoice must not shut the validator down"
+        );
+
+        // The finalizer must keep working: finalize the same block (commit_hash now
+        // VALID) and confirm it advances.
+        let (ack, _waiter) = Exact::handle();
+        mailbox
+            .report(Update::FinalizedBlock((block1, None), ack))
+            .await;
+        context.sleep(Duration::from_millis(500)).await;
+        assert_eq!(
+            mailbox.get_latest_height().await,
+            1,
+            "finalizer must recover and apply a valid block after discarding the fork"
         );
 
         context.auditor().state()


### PR DESCRIPTION
Addresses https://github.com/SeismicSystems/summit/issues/328.

Changes:
- Move the forkchoice commit into `execute_block`, right after the `newPayload`-VALID check and before any consensus-state mutation, and classify the status:
`VALID`   -> proceed
`SYNCING` -> `ExecuteOutcome::Syncing` (reuses the existing non-blocking buffer +
             drain retry; safe because nothing is mutated yet)
`INVALID` -> `ExecuteOutcome::InvalidPayload` (finalized: shut down; notarized:
             discard the fork)
transport error -> fatal (unchanged)
