### PR TITLE
fix: conserve staged-removal validator balance on deferred top-up

### DIFF
--- a/finalizer/src/actor.rs
+++ b/finalizer/src/actor.rs
@@ -3018,17 +3018,26 @@ async fn process_execution_requests<
                             bonded_balance,
                         );
 
-                        // Refund the top-up, which was never credited to the balance
-                        // (taxed like any other invalid-deposit refund).
+                        // Refund the top-up in full, untaxed. Unlike the
+                        // invalid-deposit refund paths, this top-up was valid in
+                        // shape, signature, and resulting balance (it passed
+                        // admission and would have landed in range) — it is refunded
+                        // only because the independent stake-bound removal wins. The
+                        // depositor is blameless, the bonded balance above is also
+                        // returned untaxed, and the canonical stake-bound exit applies
+                        // no tax, so `invalid_deposit_tax` must not apply here. The
+                        // top-up was never credited to the balance, so
+                        // balance_deduction = 0.
                         let refund_pubkey =
                             refunded_deposit_key(withdrawal_credentials, request.index);
-                        push_invalid_deposit_withdrawals(
-                            state,
-                            withdrawal_credentials,
-                            refund_pubkey,
-                            request.index,
-                            request.amount,
+                        state.push_refund_withdrawal_request(
+                            WithdrawalRequest {
+                                source_address: withdrawal_credentials,
+                                validator_pubkey: refund_pubkey,
+                                amount: request.amount,
+                            },
                             withdrawal_epoch,
+                            0,
                         );
 
                         continue;

--- a/finalizer/src/actor.rs
+++ b/finalizer/src/actor.rs
@@ -2976,6 +2976,64 @@ async fn process_execution_requests<
                 account.has_pending_deposit = false;
 
                 if account.status == ValidatorStatus::Inactive {
+                    // A nonzero balance means this is not a fresh new-validator
+                    // placeholder. Placeholders are created with balance 0 at parse
+                    // time (see `parse_execution_requests`); an Inactive account that
+                    // still holds a balance is a validator that was staged for
+                    // stake-bound removal and marked Inactive at the epoch boundary,
+                    // with this top-up left queued behind it. The boundary stake-bound
+                    // withdrawal scan skips accounts with `has_pending_deposit`, so the
+                    // bonded balance was never withdrawn there. Honor the removal
+                    // exactly as that scan would have: withdraw the full bonded balance
+                    // and refund the top-up separately, so the original stake is never
+                    // silently dropped.
+                    if account.balance > 0 {
+                        let bonded_balance = account.balance;
+                        let withdrawal_credentials = account.withdrawal_credentials;
+                        let withdrawal_epoch =
+                            state.get_epoch() + consts.validator_withdrawal_num_epochs;
+
+                        info!(
+                            validator = hex::encode(node_pubkey_bytes),
+                            balance = bonded_balance,
+                            deposit_amount = request.amount,
+                            "queued top-up resolved against staged-removal validator: withdrawing bonded balance and refunding top-up"
+                        );
+
+                        // Withdraw the full pre-existing bonded balance. This stake was
+                        // credited on the EL, so balance_deduction = balance. Mirrors
+                        // the stake-bound full-exit path; the account is removed by the
+                        // withdrawal-completion path once its balance reaches 0.
+                        account.balance = 0;
+                        account.has_pending_withdrawal = true;
+                        state.set_account(node_pubkey_bytes, account);
+
+                        state.push_withdrawal_request(
+                            WithdrawalRequest {
+                                source_address: withdrawal_credentials,
+                                validator_pubkey: node_pubkey_bytes,
+                                amount: bonded_balance,
+                            },
+                            withdrawal_epoch,
+                            bonded_balance,
+                        );
+
+                        // Refund the top-up, which was never credited to the balance
+                        // (taxed like any other invalid-deposit refund).
+                        let refund_pubkey =
+                            refunded_deposit_key(withdrawal_credentials, request.index);
+                        push_invalid_deposit_withdrawals(
+                            state,
+                            withdrawal_credentials,
+                            refund_pubkey,
+                            request.index,
+                            request.amount,
+                            withdrawal_epoch,
+                        );
+
+                        continue;
+                    }
+
                     // New validator: account was created early with Inactive status
                     let new_balance = request.amount;
 

--- a/node/src/tests/execution_requests/deposit_withdrawal_combined.rs
+++ b/node/src/tests/execution_requests/deposit_withdrawal_combined.rs
@@ -1700,6 +1700,256 @@ fn test_withdrawal_blocked_by_pending_deposit() {
 }
 
 #[test_traced("INFO")]
+fn test_last_block_topup_does_not_drop_staged_removal_balance() {
+    // Regression test for the stake-bound staged-removal + last-block top-up balance drop.
+    //
+    // Scenario (audit issue):
+    //   1. A MinimumStake increase (32 -> 33 ETH) is submitted early in epoch 0.
+    //   2. The victim validator (validators[0], 32 ETH) will fall below the new minimum. The
+    //      other validators are at 40 ETH, so only the victim is a removal candidate (and the
+    //      minimum-validator-count floor of 3 still permits staging one of the five).
+    //   3. At the penultimate block of epoch 0 the victim is staged into removed_validators.
+    //   4. At the last block of epoch 0 the victim submits a 1 ETH top-up. This sets
+    //      has_pending_deposit = true and queues the deposit: 32 + 1 = 33 still passes the
+    //      parse-time bounds check because the raised minimum has not been applied yet.
+    //   5. At the epoch boundary the staged removal marks the victim Inactive (balance 32 kept),
+    //      and the stake-bound withdrawal scan SKIPS the victim because has_pending_deposit.
+    //   6. At the next penultimate block (epoch 1) the queued top-up is processed against the
+    //      now-Inactive account. The buggy code treats it as a new-validator deposit, uses
+    //      new_balance = request.amount (1 ETH), refunds only the 1 ETH and removes the account.
+    //
+    // Correct behavior (removal wins): the staged removal is honored. When the top-up is processed
+    // against the Inactive account, the victim's original 32 ETH bonded balance is withdrawn to its
+    // withdrawal address and the 1 ETH top-up is refunded (never credited). With no invalid-deposit
+    // tax configured, the full 33 ETH is returned to the victim's address and the account is
+    // removed. The original bonded balance is never silently dropped.
+    let n = 5;
+    let min_stake = 32_000_000_000; // 32 ETH (victim's balance)
+    let healthy_balance = 40_000_000_000; // 40 ETH (other validators, above the raised minimum)
+    let max_stake = 100_000_000_000; // 100 ETH
+    let new_min_stake = 33_000_000_000; // 33 ETH (raised minimum, above the victim's balance)
+    let topup_amount = 1_000_000_000; // 1 ETH last-block top-up
+    let link = Link {
+        latency: Duration::from_millis(80),
+        jitter: Duration::from_millis(10),
+        success_rate: 0.98,
+    };
+
+    let cfg = deterministic::Config::default().with_seed(0);
+    let executor = Runner::from(cfg);
+    executor.start(|context| async move {
+        let (network, mut oracle) = Network::new(
+            context.with_label("network"),
+            simulated::Config {
+                max_size: 1024 * 1024,
+                disconnect_on_block: false,
+                tracked_peer_sets: NZUsize!(n as usize * 10),
+            },
+        );
+
+        network.start();
+
+        let mut key_stores = Vec::new();
+        let mut validators = Vec::new();
+        for i in 0..n {
+            let mut rng = StdRng::seed_from_u64(i as u64);
+            let node_key = PrivateKey::random(&mut rng);
+            let node_public_key = node_key.public_key();
+            let consensus_key = bls12381::PrivateKey::random(&mut rng);
+            let consensus_public_key = consensus_key.public_key();
+            let key_store = KeyStore {
+                node_key,
+                consensus_key,
+            };
+            key_stores.push(key_store);
+            validators.push((node_public_key, consensus_public_key));
+        }
+        validators.sort_by(|lhs, rhs| lhs.0.cmp(&rhs.0));
+        key_stores.sort_by_key(|ks| ks.node_key.public_key());
+
+        // Withdrawal credentials per validator, created after sorting so they align.
+        let addresses: Vec<Address> = (0..n).map(|i| Address::from([i as u8; 20])).collect();
+
+        let node_public_keys: Vec<_> = validators.iter().map(|(pk, _)| pk.clone()).collect();
+        let mut registrations = common::register_validators(&oracle, &node_public_keys).await;
+
+        common::link_validators(&mut oracle, &node_public_keys, link, None).await;
+
+        let genesis_hash =
+            from_hex_formatted(common::GENESIS_HASH).expect("failed to decode genesis hash");
+        let genesis_hash: [u8; 32] = genesis_hash
+            .try_into()
+            .expect("failed to convert genesis hash");
+
+        // The victim is validators[0] (smallest pubkey after sorting).
+        let victim_idx = 0usize;
+        let victim_pubkey = validators[victim_idx].0.clone();
+        let victim_address = addresses[victim_idx];
+
+        // The victim's last-block top-up reuses the victim's node + consensus keys so it is
+        // recognized as an existing-validator top-up rather than a new validator.
+        let mut victim_withdrawal_credentials = [0u8; 32];
+        victim_withdrawal_credentials[0] = 0x01;
+        victim_withdrawal_credentials[12..32].copy_from_slice(victim_address.as_ref());
+        let (topup_deposit, _, _) = common::create_deposit_request(
+            50, // deposit index distinct from the genesis validators
+            topup_amount,
+            common::get_domain(),
+            Some(key_stores[victim_idx].node_key.clone()),
+            Some(key_stores[victim_idx].consensus_key.clone()),
+            Some(victim_withdrawal_credentials),
+        );
+
+        // MinimumStake increase (param_id 0x00).
+        let min_stake_update = common::create_protocol_param_request(0x00, new_min_stake);
+
+        // Block schedule (DEFAULT_BLOCKS_PER_EPOCH = 10):
+        //   - param update early in epoch 0 (pending through the epoch, applied at its last block)
+        //   - victim staged at the penultimate block of epoch 0
+        //   - victim top-up at the LAST block of epoch 0 (after staging)
+        let param_block = 3;
+        let topup_block = last_block_in_epoch(DEFAULT_BLOCKS_PER_EPOCH, 0);
+        // The queued top-up is processed at the penultimate block of epoch 1, where the resulting
+        // refund/withdrawal is scheduled `VALIDATOR_WITHDRAWAL_NUM_EPOCHS` epochs out.
+        let resolution_epoch = 1 + VALIDATOR_WITHDRAWAL_NUM_EPOCHS;
+        let resolution_height = last_block_in_epoch(DEFAULT_BLOCKS_PER_EPOCH, resolution_epoch);
+        let stop_height = resolution_height + 1;
+
+        let mut execution_requests_map = HashMap::new();
+        execution_requests_map.insert(
+            param_block,
+            common::execution_requests_to_requests(vec![ExecutionRequest::ProtocolParam(
+                min_stake_update,
+            )]),
+        );
+        execution_requests_map.insert(
+            topup_block,
+            common::execution_requests_to_requests(vec![ExecutionRequest::Deposit(
+                topup_deposit.clone(),
+            )]),
+        );
+
+        let engine_client_network = MockEngineNetworkBuilder::new(genesis_hash)
+            .with_execution_requests(execution_requests_map)
+            .with_stop_at(stop_height)
+            .build();
+
+        // Genesis: victim at 32 ETH, every other validator at 40 ETH (above the raised minimum),
+        // maximum stake raised to 100 ETH so the healthy validators stay in range.
+        let mut initial_state =
+            get_initial_state(genesis_hash, &validators, Some(&addresses), None, min_stake);
+        initial_state.set_maximum_stake(max_stake);
+        for idx in 0..n as usize {
+            if idx == victim_idx {
+                continue;
+            }
+            let pk_bytes: [u8; 32] = validators[idx].0.as_ref().try_into().unwrap();
+            let mut account = initial_state.get_account(&pk_bytes).unwrap().clone();
+            account.balance = healthy_balance;
+            initial_state.set_account(pk_bytes, account);
+        }
+
+        let mut consensus_state_queries = HashMap::new();
+        for (idx, key_store) in key_stores.into_iter().enumerate() {
+            let public_key = key_store.node_key.public_key();
+            let uid = format!("validator_{public_key}");
+            let namespace = String::from("_SUMMIT");
+
+            let engine_client = engine_client_network.create_client(uid.clone());
+            let config = get_default_engine_config(
+                engine_client,
+                SimulatedOracle::new(oracle.clone()),
+                uid.clone(),
+                genesis_hash,
+                namespace,
+                key_store,
+                validators.clone(),
+                initial_state.clone(),
+            );
+            let engine = Engine::new(context.with_label(&uid), config).await;
+            consensus_state_queries.insert(idx, engine.finalizer_mailbox.clone());
+
+            let (pending, recovered, resolver, orchestrator, broadcast) =
+                registrations.remove(&public_key).unwrap();
+            engine.start(pending, recovered, resolver, orchestrator, broadcast);
+        }
+
+        // The victim exits the validator set, so only n-1 validators keep finalizing.
+        let mut height_reached = HashSet::new();
+        loop {
+            let metrics = context.encode();
+            let mut success = false;
+            for line in metrics.lines() {
+                if !line.starts_with("validator_") {
+                    continue;
+                }
+
+                let mut parts = line.split_whitespace();
+                let metric = parts.next().unwrap();
+                let value = parts.next().unwrap();
+
+                if metric.ends_with("finalizer_height") {
+                    let height = value.parse::<u64>().unwrap();
+                    if height >= stop_height {
+                        height_reached.insert(metric.to_string());
+                    }
+                }
+
+                if height_reached.len() as u32 == n - 1 {
+                    success = true;
+                    break;
+                }
+            }
+            if success {
+                break;
+            }
+            context.sleep(Duration::from_secs(1)).await;
+        }
+
+        // Query a surviving validator's view of the canonical state.
+        let state_query = consensus_state_queries.get(&1).unwrap();
+
+        // Sanity: the MinimumStake increase was applied.
+        assert_eq!(state_query.get_minimum_stake().await, new_min_stake);
+
+        // The staged removal is honored: the victim account no longer exists.
+        let victim_account = state_query.get_validator_account(victim_pubkey).await;
+        assert!(
+            victim_account.is_none(),
+            "staged-removal validator should be removed once its top-up is resolved, got {victim_account:?}"
+        );
+
+        // The victim's original bonded balance is returned to the EL rather than silently dropped:
+        // the full 32 ETH is withdrawn and the 1 ETH top-up is refunded (no invalid-deposit tax),
+        // so 33 ETH total reaches the victim's withdrawal address.
+        let withdrawals = engine_client_network.get_withdrawals();
+        let total_withdrawn_to_victim: u64 = withdrawals
+            .values()
+            .flatten()
+            .filter(|withdrawal| withdrawal.address == victim_address)
+            .map(|withdrawal| withdrawal.amount)
+            .sum();
+        assert_eq!(
+            total_withdrawn_to_victim,
+            min_stake + topup_amount,
+            "expected the original bonded balance ({min_stake}) plus the refunded top-up \
+             ({topup_amount}) to be returned to the victim's address, got {total_withdrawn_to_victim}"
+        );
+
+        // The network stays consistent across the validators that remain.
+        let victim_client_id = format!("validator_{}", validators[victim_idx].0);
+        assert!(
+            engine_client_network
+                .verify_consensus_skip(None, Some(stop_height), &[&victim_client_id])
+                .is_ok()
+        );
+        common::assert_state_root_consensus_skip(&consensus_state_queries, &[victim_idx]).await;
+
+        context.auditor().state()
+    })
+}
+
+#[test_traced("INFO")]
 fn test_deposit_and_withdrawal_same_block() {
     // Tests that when a deposit and withdrawal for the same validator are in the same block,
     // the second request is blocked by the first one's pending flag.

--- a/node/src/tests/execution_requests/deposit_withdrawal_combined.rs
+++ b/node/src/tests/execution_requests/deposit_withdrawal_combined.rs
@@ -1701,34 +1701,55 @@ fn test_withdrawal_blocked_by_pending_deposit() {
 
 #[test_traced("INFO")]
 fn test_last_block_topup_does_not_drop_staged_removal_balance() {
-    // Regression test for the stake-bound staged-removal + last-block top-up balance drop.
-    //
-    // Scenario (audit issue):
-    //   1. A MinimumStake increase (32 -> 33 ETH) is submitted early in epoch 0.
-    //   2. The victim validator (validators[0], 32 ETH) will fall below the new minimum. The
-    //      other validators are at 40 ETH, so only the victim is a removal candidate (and the
-    //      minimum-validator-count floor of 3 still permits staging one of the five).
-    //   3. At the penultimate block of epoch 0 the victim is staged into removed_validators.
-    //   4. At the last block of epoch 0 the victim submits a 1 ETH top-up. This sets
-    //      has_pending_deposit = true and queues the deposit: 32 + 1 = 33 still passes the
-    //      parse-time bounds check because the raised minimum has not been applied yet.
-    //   5. At the epoch boundary the staged removal marks the victim Inactive (balance 32 kept),
-    //      and the stake-bound withdrawal scan SKIPS the victim because has_pending_deposit.
-    //   6. At the next penultimate block (epoch 1) the queued top-up is processed against the
-    //      now-Inactive account. The buggy code treats it as a new-validator deposit, uses
-    //      new_balance = request.amount (1 ETH), refunds only the 1 ETH and removes the account.
-    //
-    // Correct behavior (removal wins): the staged removal is honored. When the top-up is processed
-    // against the Inactive account, the victim's original 32 ETH bonded balance is withdrawn to its
-    // withdrawal address and the 1 ETH top-up is refunded (never credited). With no invalid-deposit
-    // tax configured, the full 33 ETH is returned to the victim's address and the account is
-    // removed. The original bonded balance is never silently dropped.
+    // No invalid-deposit tax configured: the full 33 ETH (32 bonded + 1 top-up) is
+    // returned to the victim's address.
+    run_staged_removal_topup_scenario(0);
+}
+
+#[test_traced("INFO")]
+fn test_last_block_topup_staged_removal_refund_is_untaxed() {
+    // A nonzero invalid_deposit_tax must NOT skim the refunded top-up. The top-up was
+    // a valid deposit (valid shape, signature, and resulting balance) refunded only
+    // because the independent stake-bound removal wins — the depositor is blameless,
+    // the bonded balance is returned untaxed, and the canonical stake-bound exit
+    // applies no tax. So with a 25% tax configured the victim must still receive the
+    // full 33 ETH and the treasury must receive nothing.
+    run_staged_removal_topup_scenario(25);
+}
+
+// Shared scenario for the stake-bound staged-removal + last-block top-up balance drop.
+//
+// Scenario (audit issue):
+//   1. A MinimumStake increase (32 -> 33 ETH) is submitted early in epoch 0.
+//   2. The victim validator (validators[0], 32 ETH) will fall below the new minimum. The
+//      other validators are at 40 ETH, so only the victim is a removal candidate (and the
+//      minimum-validator-count floor of 3 still permits staging one of the five).
+//   3. At the penultimate block of epoch 0 the victim is staged into removed_validators.
+//   4. At the last block of epoch 0 the victim submits a 1 ETH top-up. This sets
+//      has_pending_deposit = true and queues the deposit: 32 + 1 = 33 still passes the
+//      parse-time bounds check because the raised minimum has not been applied yet.
+//   5. At the epoch boundary the staged removal marks the victim Inactive (balance 32 kept),
+//      and the stake-bound withdrawal scan SKIPS the victim because has_pending_deposit.
+//   6. At the next penultimate block (epoch 1) the queued top-up is processed against the
+//      now-Inactive account. The buggy code treats it as a new-validator deposit, uses
+//      new_balance = request.amount (1 ETH), refunds only the 1 ETH and removes the account.
+//
+// Correct behavior (removal wins): the staged removal is honored. When the top-up is processed
+// against the Inactive account, the victim's original 32 ETH bonded balance is withdrawn to its
+// withdrawal address and the 1 ETH top-up is refunded in full (never credited, never taxed),
+// so the full 33 ETH is returned to the victim's address and the account is removed. The
+// original bonded balance is never silently dropped, and the treasury never receives a cut of
+// the valid top-up regardless of `invalid_deposit_tax`.
+fn run_staged_removal_topup_scenario(invalid_deposit_tax: u64) {
     let n = 5;
     let min_stake = 32_000_000_000; // 32 ETH (victim's balance)
     let healthy_balance = 40_000_000_000; // 40 ETH (other validators, above the raised minimum)
     let max_stake = 100_000_000_000; // 100 ETH
     let new_min_stake = 33_000_000_000; // 33 ETH (raised minimum, above the victim's balance)
     let topup_amount = 1_000_000_000; // 1 ETH last-block top-up
+    // Distinct from every validator address ([0x00..0x04]) so a taxed cut, if one
+    // were (wrongly) taken, would land here and be observable.
+    let treasury_address = Address::from([0xEE; 20]);
     let link = Link {
         latency: Duration::from_millis(80),
         jitter: Duration::from_millis(10),
@@ -1839,6 +1860,8 @@ fn test_last_block_topup_does_not_drop_staged_removal_balance() {
         let mut initial_state =
             get_initial_state(genesis_hash, &validators, Some(&addresses), None, min_stake);
         initial_state.set_maximum_stake(max_stake);
+        initial_state.set_treasury_address(treasury_address);
+        initial_state.set_invalid_deposit_tax(invalid_deposit_tax);
         for idx in 0..n as usize {
             if idx == victim_idx {
                 continue;
@@ -1920,8 +1943,8 @@ fn test_last_block_topup_does_not_drop_staged_removal_balance() {
         );
 
         // The victim's original bonded balance is returned to the EL rather than silently dropped:
-        // the full 32 ETH is withdrawn and the 1 ETH top-up is refunded (no invalid-deposit tax),
-        // so 33 ETH total reaches the victim's withdrawal address.
+        // the full 32 ETH is withdrawn and the 1 ETH top-up is refunded in full, so 33 ETH total
+        // reaches the victim's withdrawal address regardless of the configured tax.
         let withdrawals = engine_client_network.get_withdrawals();
         let total_withdrawn_to_victim: u64 = withdrawals
             .values()
@@ -1936,6 +1959,20 @@ fn test_last_block_topup_does_not_drop_staged_removal_balance() {
              ({topup_amount}) to be returned to the victim's address, got {total_withdrawn_to_victim}"
         );
 
+        // The refunded top-up is a valid deposit returned only because the removal wins, so it
+        // must never be taxed: the treasury receives nothing even with a nonzero tax configured.
+        let total_to_treasury: u64 = withdrawals
+            .values()
+            .flatten()
+            .filter(|withdrawal| withdrawal.address == treasury_address)
+            .map(|withdrawal| withdrawal.amount)
+            .sum();
+        assert_eq!(
+            total_to_treasury, 0,
+            "the valid top-up refund must not be taxed (tax = {invalid_deposit_tax}), \
+             but the treasury received {total_to_treasury}"
+        );
+
         // The network stays consistent across the validators that remain.
         let victim_client_id = format!("validator_{}", validators[victim_idx].0);
         assert!(
@@ -1946,7 +1983,7 @@ fn test_last_block_topup_does_not_drop_staged_removal_balance() {
         common::assert_state_root_consensus_skip(&consensus_state_queries, &[victim_idx]).await;
 
         context.auditor().state()
-    })
+    });
 }
 
 #[test_traced("INFO")]


### PR DESCRIPTION
Builds on https://github.com/SeismicSystems/summit/pull/276 (which builds on https://github.com/SeismicSystems/summit/pull/275).

Addresses https://github.com/SeismicSystems/summit/issues/374.

Changes:

- Guard the Inactive deposit branch on `account.balance > 0` to distinguish a staged-removal validator (still holds a credited balance) from a new-validator placeholder (balance 0). For the former, withdraw the full credited balance (`balance_deduction = balance`), refund the top-up separately, and let the completion path remove the account. Placeholders and active top-ups are unaffected.
- Add regression test `test_last_block_topup_does_not_drop_staged_removal_balance`.