### PR TITLE
chore: add consensus-key guard when processing deposits

### DIFF
--- a/finalizer/src/actor.rs
+++ b/finalizer/src/actor.rs
@@ -2316,15 +2316,24 @@ impl<
                 .canonical_state
                 .validator_accounts_iter()
                 .filter_map(|(key, acc)| {
-                    if !acc.has_pending_deposit
-                        && !pending_exit_pubkeys.contains(key)
-                        && (acc.balance < self.canonical_state.get_minimum_stake()
-                            || acc.balance > self.canonical_state.get_maximum_stake())
+                    let min_stake = self.canonical_state.get_minimum_stake();
+                    let max_stake = self.canonical_state.get_maximum_stake();
+                    if pending_exit_pubkeys.contains(key)
+                        || !(acc.balance < min_stake || acc.balance > max_stake)
                     {
-                        Some((*key, acc.balance, acc.withdrawal_credentials))
-                    } else {
-                        None
+                        return None;
                     }
+                    // Defer to deposit processing only if a queued deposit could bring this
+                    // validator back into range; otherwise enforce now, so a too-small (or
+                    // never-processed) deposit can't let an out-of-bounds validator linger.
+                    if acc.has_pending_deposit {
+                        let prospective =
+                            acc.balance + self.canonical_state.pending_deposit_amount(key);
+                        if (min_stake..=max_stake).contains(&prospective) {
+                            return None;
+                        }
+                    }
+                    Some((*key, acc.balance, acc.withdrawal_credentials))
                 })
                 .collect();
 
@@ -3197,11 +3206,21 @@ async fn process_execution_requests<
             let candidates: Vec<([u8; 32], u64, ValidatorStatus)> = state
                 .validator_accounts_iter()
                 .filter_map(|(key, account)| {
-                    if !account.has_pending_deposit && account.balance < prospective_min {
-                        Some((*key, account.joining_epoch, account.status.clone()))
-                    } else {
-                        None
+                    // Real, funded validators only — a zero-balance account is a new-validator
+                    // placeholder whose deposit is still pending (handled at deposit processing,
+                    // not via the committee removed_validators delta).
+                    if account.balance == 0 || account.balance >= prospective_min {
+                        return None;
                     }
+                    // Defer removal only if a queued deposit could lift this validator to the
+                    // prospective minimum; a too-small (or never-processed) deposit must not let
+                    // a below-minimum validator escape removal.
+                    if account.has_pending_deposit
+                        && account.balance + state.pending_deposit_amount(key) >= prospective_min
+                    {
+                        return None;
+                    }
+                    Some((*key, account.joining_epoch, account.status.clone()))
                 })
                 .collect();
             let already_removed: HashSet<PublicKey> =

--- a/finalizer/src/actor.rs
+++ b/finalizer/src/actor.rs
@@ -2983,6 +2983,25 @@ async fn process_execution_requests<
                     continue;
                 };
 
+                // Guard against a stale deposit binding to a replacement validator that reused
+                // this node pubkey: if the stored consensus key differs from the one the deposit
+                // was accepted with, the account is a different identity — refund the deposit
+                // rather than crediting the wrong validator's lifecycle.
+                if account.consensus_public_key != request.consensus_pubkey {
+                    warn!(
+                        "Deposit request consensus key does not match the current account, refunding: {request:?}"
+                    );
+                    queue_deposit_refund(
+                        state,
+                        request.withdrawal_credentials,
+                        request.amount,
+                        request.index,
+                        DepositRejectionReason::Refund,
+                        consts,
+                    );
+                    continue;
+                }
+
                 // Clear the pending deposit flag since we're processing it now
                 account.has_pending_deposit = false;
 

--- a/finalizer/src/actor.rs
+++ b/finalizer/src/actor.rs
@@ -3100,18 +3100,22 @@ async fn process_execution_requests<
                             state.get_minimum_stake(),
                             state.get_maximum_stake()
                         );
-                        let refund_pubkey =
-                            refunded_deposit_key(account.withdrawal_credentials, request.index);
-                        let withdrawal_epoch =
-                            state.get_epoch() + consts.validator_withdrawal_num_epochs;
-
-                        push_invalid_deposit_withdrawals(
+                        // Refund to the DEPOSIT's own withdrawal credentials, not the
+                        // account's. A stale queued deposit can bind to a replacement
+                        // account that reused the same (node, consensus) key but has
+                        // different credentials; its funds must go back to the original
+                        // depositor (request.withdrawal_credentials), never the
+                        // replacement account's credentials. For a genuine new-validator
+                        // placeholder these are identical (the placeholder's credentials
+                        // were parsed from this same deposit), so honest flows are
+                        // unchanged.
+                        queue_deposit_refund(
                             state,
-                            account.withdrawal_credentials,
-                            refund_pubkey,
-                            request.index,
+                            request.withdrawal_credentials,
                             request.amount,
-                            withdrawal_epoch,
+                            request.index,
+                            DepositRejectionReason::Refund,
+                            consts,
                         );
                         // Remove the inactive account since validator won't be joining
                         state.remove_account(&node_pubkey_bytes);
@@ -3184,18 +3188,18 @@ async fn process_execution_requests<
                             state.get_minimum_stake(),
                             state.get_maximum_stake()
                         );
-                        let refund_pubkey =
-                            refunded_deposit_key(account.withdrawal_credentials, request.index);
-                        let withdrawal_epoch =
-                            state.get_epoch() + consts.validator_withdrawal_num_epochs;
-
-                        push_invalid_deposit_withdrawals(
+                        // Refund to the DEPOSIT's own withdrawal credentials, not the
+                        // account's, for the same reason as the new-validator path above:
+                        // a stale queued deposit can bind to a same-key replacement with
+                        // different credentials, and its funds must return to the original
+                        // depositor. For an honest top-up the two are identical.
+                        queue_deposit_refund(
                             state,
-                            account.withdrawal_credentials,
-                            refund_pubkey,
-                            request.index,
+                            request.withdrawal_credentials,
                             request.amount,
-                            withdrawal_epoch,
+                            request.index,
+                            DepositRejectionReason::Refund,
+                            consts,
                         );
                         // Persist the has_pending_deposit = false change
                         state.set_account(node_pubkey_bytes, account);

--- a/finalizer/src/actor.rs
+++ b/finalizer/src/actor.rs
@@ -2977,9 +2977,23 @@ async fn process_execution_requests<
                 drained_any_deposit = true;
                 let node_pubkey_bytes: [u8; 32] = request.node_pubkey.as_ref().try_into().unwrap();
 
-                // Account should always exist (created early in parse_execution_requests)
+                // The account is normally created early in parse_execution_requests, but a
+                // queued deposit can outlive its account: e.g. a top-up stays queued (low or
+                // zero max_deposits_per_epoch) while the validator is force-removed and its
+                // account deleted, with no replacement deposit yet. Invariant: a queued
+                // deposit must either be processed against its original account lifecycle or
+                // refunded — never silently dropped (which would burn the depositor's
+                // EL-locked funds). With no account to bind, refund it to its own credentials.
                 let Some(mut account) = state.get_account(&node_pubkey_bytes).cloned() else {
-                    warn!("Deposit request has no corresponding account, skipping: {request:?}");
+                    warn!("Deposit request has no corresponding account, refunding: {request:?}");
+                    queue_deposit_refund(
+                        state,
+                        request.withdrawal_credentials,
+                        request.amount,
+                        request.index,
+                        DepositRejectionReason::Refund,
+                        consts,
+                    );
                     continue;
                 };
 

--- a/node/src/tests/execution_requests/deposit_withdrawal_combined.rs
+++ b/node/src/tests/execution_requests/deposit_withdrawal_combined.rs
@@ -2569,3 +2569,201 @@ fn test_deposit_and_withdrawal_same_block() {
         context.auditor().state()
     })
 }
+
+/// A stale queued deposit can outlive its account and then bind to a
+/// *replacement* account that reuses the same node AND consensus key but has
+/// different withdrawal credentials. The no-account branch does not fire (the
+/// replacement placeholder exists) and the consensus-key guard passes (same
+/// key), so the stale deposit is consumed against the replacement lifecycle and
+/// refunds to the replacement account's credentials (W2) instead of its own
+/// (W1).
+///
+/// We reproduce the resulting state directly: a replacement Inactive placeholder
+/// for node key X (consensus key A, credentials W2) plus a stale queued deposit
+/// for X (same A, credentials W1, amount below the minimum so it is refunded).
+/// The invariant is that the stale deposit refunds to its OWN W1
+/// (request.withdrawal_credentials), never the replacement account's W2.
+#[test_traced("INFO")]
+fn test_stale_deposit_binds_to_same_key_replacement_with_wrong_credentials() {
+    use summit_types::account::ValidatorAccount;
+
+    let n = 5;
+    let min_stake = 32_000_000_000;
+    let stale_deposit_amount = 1_000_000_000; // 1 ETH, below min_stake → refunded
+    let link = Link {
+        latency: Duration::from_millis(80),
+        jitter: Duration::from_millis(10),
+        success_rate: 0.98,
+    };
+
+    let cfg = deterministic::Config::default().with_seed(0);
+    let executor = Runner::from(cfg);
+    executor.start(|context| async move {
+        let (network, mut oracle) = Network::new(
+            context.with_label("network"),
+            simulated::Config {
+                max_size: 1024 * 1024,
+                disconnect_on_block: false,
+                tracked_peer_sets: NZUsize!(n as usize * 10),
+            },
+        );
+        network.start();
+
+        let mut key_stores = Vec::new();
+        let mut validators = Vec::new();
+        for i in 0..n {
+            let mut rng = StdRng::seed_from_u64(i as u64);
+            let node_key = PrivateKey::random(&mut rng);
+            let node_public_key = node_key.public_key();
+            let consensus_key = bls12381::PrivateKey::random(&mut rng);
+            let consensus_public_key = consensus_key.public_key();
+            key_stores.push(KeyStore {
+                node_key,
+                consensus_key,
+            });
+            validators.push((node_public_key, consensus_public_key));
+        }
+        validators.sort_by(|lhs, rhs| lhs.0.cmp(&rhs.0));
+        key_stores.sort_by_key(|ks| ks.node_key.public_key());
+
+        let node_public_keys: Vec<_> = validators.iter().map(|(pk, _)| pk.clone()).collect();
+        let mut registrations = common::register_validators(&oracle, &node_public_keys).await;
+        common::link_validators(&mut oracle, &node_public_keys, link, None).await;
+
+        let genesis_hash =
+            from_hex_formatted(common::GENESIS_HASH).expect("failed to decode genesis hash");
+        let genesis_hash: [u8; 32] = genesis_hash
+            .try_into()
+            .expect("failed to convert genesis hash");
+
+        // The stale deposit's own withdrawal address (W1) and the replacement
+        // account's withdrawal address (W2) differ.
+        let stale_refund_address = Address::from([0xAA; 20]); // W1
+        let replacement_address = Address::from([0xBB; 20]); // W2
+        let mut stale_credentials = [0u8; 32];
+        stale_credentials[0] = 0x01;
+        stale_credentials[12..32].copy_from_slice(stale_refund_address.as_slice());
+
+        // Stale queued deposit for node key X, consensus key A, credentials W1.
+        let (stale_deposit, _node_key, stale_consensus_key) = common::create_deposit_request(
+            99,
+            stale_deposit_amount,
+            common::get_domain(),
+            None,
+            None,
+            Some(stale_credentials),
+        );
+        let node_pubkey: [u8; 32] = stale_deposit.node_pubkey.as_ref().try_into().unwrap();
+
+        let refund_epoch = VALIDATOR_WITHDRAWAL_NUM_EPOCHS;
+        let refund_height = last_block_in_epoch(DEFAULT_BLOCKS_PER_EPOCH, refund_epoch);
+        let stop_height = refund_height + 1;
+
+        let engine_client_network = MockEngineNetworkBuilder::new(genesis_hash)
+            .with_execution_requests(HashMap::new())
+            .with_stop_at(stop_height)
+            .build();
+
+        let mut initial_state = get_initial_state(genesis_hash, &validators, None, None, min_stake);
+
+        // Replacement Inactive placeholder for X: same consensus key A as the
+        // stale deposit, but different withdrawal credentials (W2). This is the
+        // state left after the original (X, A) validator was deleted and a
+        // same-key replacement deposit recreated a placeholder, while the stale
+        // top-up is still queued.
+        let replacement_account = ValidatorAccount {
+            consensus_public_key: stale_consensus_key.public_key(),
+            withdrawal_credentials: replacement_address,
+            balance: 0,
+            status: ValidatorStatus::Inactive,
+            has_pending_deposit: true,
+            has_pending_withdrawal: false,
+            joining_epoch: 0,
+            last_deposit_index: 0,
+        };
+        initial_state.set_account(node_pubkey, replacement_account);
+        initial_state.push_deposit(stale_deposit.clone());
+
+        let mut consensus_state_queries = HashMap::new();
+        for (idx, key_store) in key_stores.into_iter().enumerate() {
+            let public_key = key_store.node_key.public_key();
+            let uid = format!("validator_{public_key}");
+            let namespace = String::from("_SUMMIT");
+            let engine_client = engine_client_network.create_client(uid.clone());
+            let config = get_default_engine_config(
+                engine_client,
+                SimulatedOracle::new(oracle.clone()),
+                uid.clone(),
+                genesis_hash,
+                namespace,
+                key_store,
+                validators.clone(),
+                initial_state.clone(),
+            );
+            let engine = Engine::new(context.with_label(&uid), config).await;
+            consensus_state_queries.insert(idx, engine.finalizer_mailbox.clone());
+            let (pending, recovered, resolver, orchestrator, broadcast) =
+                registrations.remove(&public_key).unwrap();
+            engine.start(pending, recovered, resolver, orchestrator, broadcast);
+        }
+
+        let mut height_reached = HashSet::new();
+        loop {
+            let metrics = context.encode();
+            let mut success = false;
+            for line in metrics.lines() {
+                if !line.starts_with("validator_") {
+                    continue;
+                }
+                let mut parts = line.split_whitespace();
+                let metric = parts.next().unwrap();
+                let value = parts.next().unwrap();
+                if metric.ends_with("finalizer_height") {
+                    let height = value.parse::<u64>().unwrap();
+                    if height >= stop_height {
+                        height_reached.insert(metric.to_string());
+                    }
+                }
+                if height_reached.len() as u32 == n {
+                    success = true;
+                    break;
+                }
+            }
+            if success {
+                break;
+            }
+            context.sleep(Duration::from_secs(1)).await;
+        }
+
+        let withdrawals = engine_client_network.get_withdrawals();
+        let refund_withdrawals = withdrawals
+            .get(&refund_height)
+            .expect("missing refund for the stale queued deposit");
+
+        // INVARIANT: the stale deposit must refund to its OWN credentials (W1),
+        // never to the replacement account's credentials (W2).
+        assert!(
+            refund_withdrawals
+                .iter()
+                .any(|w| w.address == stale_refund_address && w.amount == stale_deposit_amount),
+            "stale deposit must refund to its own W1 ({stale_refund_address:?}), not the \
+             replacement account's W2; got withdrawals = {refund_withdrawals:?}"
+        );
+        assert!(
+            !refund_withdrawals
+                .iter()
+                .any(|w| w.address == replacement_address),
+            "stale deposit must NOT refund to the replacement account's W2 \
+             ({replacement_address:?}); got withdrawals = {refund_withdrawals:?}"
+        );
+
+        assert!(
+            engine_client_network
+                .verify_consensus(None, Some(stop_height))
+                .is_ok()
+        );
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[]).await;
+
+        context.auditor().state()
+    })
+}

--- a/node/src/tests/execution_requests/deposit_withdrawal_combined.rs
+++ b/node/src/tests/execution_requests/deposit_withdrawal_combined.rs
@@ -1317,6 +1317,181 @@ fn test_process_time_invalid_new_validator_refund_does_not_merge_with_reused_pub
 }
 
 #[test_traced("INFO")]
+fn test_queued_deposit_without_account_is_refunded_not_dropped() {
+    // Regression test for #339: a queued deposit can outlive its account. A top-up
+    // stays queued (low/zero max_deposits_per_epoch) while the validator is
+    // force-removed and its account deleted, with no replacement deposit yet. When
+    // the deposit is finally popped there is no account to bind it to.
+    //
+    // The invariant is that such a deposit must be refunded, not silently dropped
+    // (which would burn the depositor's EL-locked funds). We reproduce the resulting
+    // state directly — a deposit sitting in the queue whose node pubkey has no
+    // account — by pre-loading it into the initial consensus state, then assert the
+    // full amount is refunded to the deposit's own withdrawal address. Without the
+    // fix the no-account branch skips the deposit and no such withdrawal is ever
+    // emitted, so this test fails.
+    let n = 5;
+    let min_stake = 32_000_000_000;
+    let stale_deposit_amount = 32_000_000_000;
+    let link = Link {
+        latency: Duration::from_millis(80),
+        jitter: Duration::from_millis(10),
+        success_rate: 0.98,
+    };
+
+    let cfg = deterministic::Config::default().with_seed(0);
+    let executor = Runner::from(cfg);
+    executor.start(|context| async move {
+        let (network, mut oracle) = Network::new(
+            context.with_label("network"),
+            simulated::Config {
+                max_size: 1024 * 1024,
+                disconnect_on_block: false,
+                tracked_peer_sets: NZUsize!(n as usize * 10),
+            },
+        );
+
+        network.start();
+
+        let mut key_stores = Vec::new();
+        let mut validators = Vec::new();
+        for i in 0..n {
+            let mut rng = StdRng::seed_from_u64(i as u64);
+            let node_key = PrivateKey::random(&mut rng);
+            let node_public_key = node_key.public_key();
+            let consensus_key = bls12381::PrivateKey::random(&mut rng);
+            let consensus_public_key = consensus_key.public_key();
+            let key_store = KeyStore {
+                node_key,
+                consensus_key,
+            };
+            key_stores.push(key_store);
+            validators.push((node_public_key, consensus_public_key));
+        }
+        validators.sort_by(|lhs, rhs| lhs.0.cmp(&rhs.0));
+        key_stores.sort_by_key(|ks| ks.node_key.public_key());
+
+        let node_public_keys: Vec<_> = validators.iter().map(|(pk, _)| pk.clone()).collect();
+        let mut registrations = common::register_validators(&oracle, &node_public_keys).await;
+        common::link_validators(&mut oracle, &node_public_keys, link, None).await;
+
+        let genesis_hash =
+            from_hex_formatted(common::GENESIS_HASH).expect("failed to decode genesis hash");
+        let genesis_hash: [u8; 32] = genesis_hash
+            .try_into()
+            .expect("failed to convert genesis hash");
+
+        // The orphaned deposit's refund destination. Its node key is freshly generated
+        // by `create_deposit_request` and is not part of the committee, so no account
+        // exists for it — exactly the state left behind after account deletion.
+        let stale_refund_address = Address::from([0xAA; 20]);
+        let mut stale_withdrawal_credentials = [0u8; 32];
+        stale_withdrawal_credentials[0] = 0x01;
+        stale_withdrawal_credentials[12..32].copy_from_slice(stale_refund_address.as_slice());
+
+        let (stale_deposit, _, _) = common::create_deposit_request(
+            99,
+            stale_deposit_amount,
+            common::get_domain(),
+            None,
+            None,
+            Some(stale_withdrawal_credentials),
+        );
+
+        // The deposit is popped at the first penultimate block (epoch 0), so its refund
+        // is scheduled `VALIDATOR_WITHDRAWAL_NUM_EPOCHS` epochs out.
+        let refund_epoch = VALIDATOR_WITHDRAWAL_NUM_EPOCHS;
+        let refund_height = last_block_in_epoch(DEFAULT_BLOCKS_PER_EPOCH, refund_epoch);
+        let stop_height = refund_height + 1;
+
+        let engine_client_network = MockEngineNetworkBuilder::new(genesis_hash)
+            .with_execution_requests(HashMap::new())
+            .with_stop_at(stop_height)
+            .build();
+
+        let mut initial_state = get_initial_state(genesis_hash, &validators, None, None, min_stake);
+        // Seed the orphaned deposit directly into the queue (default max_deposits_per_epoch
+        // and invalid_deposit_tax of 0 mean it is popped and refunded in full).
+        initial_state.push_deposit(stale_deposit.clone());
+
+        let mut consensus_state_queries = HashMap::new();
+        for (idx, key_store) in key_stores.into_iter().enumerate() {
+            let public_key = key_store.node_key.public_key();
+            let uid = format!("validator_{public_key}");
+            let namespace = String::from("_SUMMIT");
+
+            let engine_client = engine_client_network.create_client(uid.clone());
+            let config = get_default_engine_config(
+                engine_client,
+                SimulatedOracle::new(oracle.clone()),
+                uid.clone(),
+                genesis_hash,
+                namespace,
+                key_store,
+                validators.clone(),
+                initial_state.clone(),
+            );
+            let engine = Engine::new(context.with_label(&uid), config).await;
+            consensus_state_queries.insert(idx, engine.finalizer_mailbox.clone());
+
+            let (pending, recovered, resolver, orchestrator, broadcast) =
+                registrations.remove(&public_key).unwrap();
+            engine.start(pending, recovered, resolver, orchestrator, broadcast);
+        }
+
+        let mut height_reached = HashSet::new();
+        loop {
+            let metrics = context.encode();
+            let mut success = false;
+            for line in metrics.lines() {
+                if !line.starts_with("validator_") {
+                    continue;
+                }
+                let mut parts = line.split_whitespace();
+                let metric = parts.next().unwrap();
+                let value = parts.next().unwrap();
+                if metric.ends_with("finalizer_height") {
+                    let height = value.parse::<u64>().unwrap();
+                    if height >= stop_height {
+                        height_reached.insert(metric.to_string());
+                    }
+                }
+                if height_reached.len() as u32 == n {
+                    success = true;
+                    break;
+                }
+            }
+            if success {
+                break;
+            }
+            context.sleep(Duration::from_secs(1)).await;
+        }
+
+        // The orphaned deposit must be refunded in full to its own withdrawal address.
+        let withdrawals = engine_client_network.get_withdrawals();
+        let refund_withdrawals = withdrawals
+            .get(&refund_height)
+            .expect("missing refund for the account-less queued deposit");
+        assert!(
+            refund_withdrawals.iter().any(|withdrawal| {
+                withdrawal.address == stale_refund_address
+                    && withdrawal.amount == stale_deposit_amount
+            }),
+            "a queued deposit with no account must be refunded in full, not dropped; got withdrawals = {refund_withdrawals:?}"
+        );
+
+        assert!(
+            engine_client_network
+                .verify_consensus(None, Some(stop_height))
+                .is_ok()
+        );
+        common::assert_state_root_consensus(&consensus_state_queries).await;
+
+        context.auditor().state()
+    })
+}
+
+#[test_traced("INFO")]
 fn test_invalid_deposit_refunds_do_not_delay_validator_exit_withdrawal() {
     // Invalid deposits that are rejected before deposit queue admission should not
     // consume the scarce withdrawal slot ahead of a legitimate validator exit.

--- a/node/src/tests/execution_requests/deposit_withdrawal_combined.rs
+++ b/node/src/tests/execution_requests/deposit_withdrawal_combined.rs
@@ -1987,6 +1987,211 @@ fn run_staged_removal_topup_scenario(invalid_deposit_tax: u64) {
 }
 
 #[test_traced("INFO")]
+fn test_pending_topup_does_not_evade_minimum_stake_increase() {
+    // A validator must not stay active below the minimum stake by having an insufficient top-up
+    // pending across a MinimumStake increase.
+    //
+    // Stake-bound enforcement is one-shot — it runs only at the boundary where a stake param
+    // actually changes (staging is gated by `has_pending_stake_bound_change()`, the scan by
+    // `stake_changed`). At that single boundary, #188 skips any account with a pending deposit.
+    // So if a top-up is still queued when the increase applies, the validator is skipped and is
+    // never re-checked: it remains active below the new minimum.
+    //
+    // This is reached through the real ingestion path (no state editing) with a zero
+    // deposit-processing cap — the "low/zero cap" trigger the finding describes — which keeps the
+    // top-up queued across the boundary. The victim's top-up (1 ETH) cannot cover the increase
+    // (32 -> 40), so even once processed it could never satisfy the new minimum.
+    let n = 5;
+    let min_stake = 32_000_000_000;
+    let max_stake = 100_000_000_000;
+    let new_min_stake = 40_000_000_000;
+    let topup_amount = 1_000_000_000; // 1 ETH — far short of the 8 ETH needed to reach the new min
+    let link = Link {
+        latency: Duration::from_millis(80),
+        jitter: Duration::from_millis(10),
+        success_rate: 0.98,
+    };
+
+    let cfg = deterministic::Config::default().with_seed(0);
+    let executor = Runner::from(cfg);
+    executor.start(|context| async move {
+        let (network, mut oracle) = Network::new(
+            context.with_label("network"),
+            simulated::Config {
+                max_size: 1024 * 1024,
+                disconnect_on_block: false,
+                tracked_peer_sets: NZUsize!(n as usize * 10),
+            },
+        );
+
+        network.start();
+
+        let mut key_stores = Vec::new();
+        let mut validators = Vec::new();
+        let mut addresses = Vec::new();
+        for i in 0..n {
+            let mut rng = StdRng::seed_from_u64(i as u64);
+            let node_key = PrivateKey::random(&mut rng);
+            let node_public_key = node_key.public_key();
+            let consensus_key = bls12381::PrivateKey::random(&mut rng);
+            let consensus_public_key = consensus_key.public_key();
+            let key_store = KeyStore {
+                node_key,
+                consensus_key,
+            };
+            key_stores.push(key_store);
+            validators.push((node_public_key, consensus_public_key));
+            addresses.push(Address::from([i as u8; 20]));
+        }
+        validators.sort_by(|lhs, rhs| lhs.0.cmp(&rhs.0));
+        key_stores.sort_by_key(|ks| ks.node_key.public_key());
+
+        let node_public_keys: Vec<_> = validators.iter().map(|(pk, _)| pk.clone()).collect();
+        let mut registrations = common::register_validators(&oracle, &node_public_keys).await;
+
+        common::link_validators(&mut oracle, &node_public_keys, link, None).await;
+
+        let genesis_hash =
+            from_hex_formatted(common::GENESIS_HASH).expect("failed to decode genesis hash");
+        let genesis_hash: [u8; 32] = genesis_hash
+            .try_into()
+            .expect("failed to convert genesis hash");
+
+        // Victim is validators[0]. Its top-up uses its own keys so it is a valid top-up.
+        let victim_idx = 0usize;
+        let victim_pubkey = validators[victim_idx].0.clone();
+        let victim_address = addresses[victim_idx];
+        let mut victim_credentials = [0u8; 32];
+        victim_credentials[0] = 0x01;
+        victim_credentials[12..32].copy_from_slice(victim_address.as_ref());
+        let (topup_deposit, _, _) = common::create_deposit_request(
+            50,
+            topup_amount,
+            common::get_domain(),
+            Some(key_stores[victim_idx].node_key.clone()),
+            Some(key_stores[victim_idx].consensus_key.clone()),
+            Some(victim_credentials),
+        );
+
+        // Submit the top-up and the MinimumStake increase early in epoch 0 (param applies at the
+        // epoch-0 boundary; the top-up is queued and — with the zero cap — stays queued across it).
+        let min_stake_update = common::create_protocol_param_request(0x00, new_min_stake);
+        let submit_block = 3;
+        let mut execution_requests_map = HashMap::new();
+        execution_requests_map.insert(
+            submit_block,
+            common::execution_requests_to_requests(vec![
+                ExecutionRequest::Deposit(topup_deposit.clone()),
+                ExecutionRequest::ProtocolParam(min_stake_update),
+            ]),
+        );
+
+        // Run well past the increase and any withdrawal window so a correctly-enforced removal
+        // would have completed.
+        let stop_height =
+            last_block_in_epoch(DEFAULT_BLOCKS_PER_EPOCH, VALIDATOR_WITHDRAWAL_NUM_EPOCHS + 2) + 1;
+
+        let engine_client_network = MockEngineNetworkBuilder::new(genesis_hash)
+            .with_execution_requests(execution_requests_map)
+            .with_stop_at(stop_height)
+            .build();
+
+        let mut initial_state =
+            get_initial_state(genesis_hash, &validators, Some(&addresses), None, min_stake);
+        initial_state.set_maximum_stake(max_stake);
+        // Zero deposit-processing cap keeps the top-up queued across the MinimumStake boundary.
+        initial_state.set_max_deposits_per_epoch(0);
+        // Only the victim should fall below the raised minimum. Give every other validator a
+        // balance comfortably above it so the increase doesn't force-remove the rest of the
+        // committee (which would collapse consensus and confound the test).
+        let healthy_balance = 50_000_000_000;
+        for idx in 0..n as usize {
+            if idx == victim_idx {
+                continue;
+            }
+            let pk_bytes: [u8; 32] = validators[idx].0.as_ref().try_into().unwrap();
+            let mut account = initial_state.get_account(&pk_bytes).unwrap().clone();
+            account.balance = healthy_balance;
+            initial_state.set_account(pk_bytes, account);
+        }
+
+        let mut consensus_state_queries = HashMap::new();
+        for (idx, key_store) in key_stores.into_iter().enumerate() {
+            let public_key = key_store.node_key.public_key();
+            let uid = format!("validator_{public_key}");
+            let namespace = String::from("_SUMMIT");
+
+            let engine_client = engine_client_network.create_client(uid.clone());
+            let config = get_default_engine_config(
+                engine_client,
+                SimulatedOracle::new(oracle.clone()),
+                uid.clone(),
+                genesis_hash,
+                namespace,
+                key_store,
+                validators.clone(),
+                initial_state.clone(),
+            );
+            let engine = Engine::new(context.with_label(&uid), config).await;
+            consensus_state_queries.insert(idx, engine.finalizer_mailbox.clone());
+
+            let (pending, recovered, resolver, orchestrator, broadcast) =
+                registrations.remove(&public_key).unwrap();
+            engine.start(pending, recovered, resolver, orchestrator, broadcast);
+        }
+
+        // The victim should be force-removed, so only n-1 validators keep finalizing once the fix
+        // is in place. Without the fix all n keep going, so wait for at least n-1.
+        let mut height_reached = HashSet::new();
+        loop {
+            let metrics = context.encode();
+            let mut success = false;
+            for line in metrics.lines() {
+                if !line.starts_with("validator_") {
+                    continue;
+                }
+
+                let mut parts = line.split_whitespace();
+                let metric = parts.next().unwrap();
+                let value = parts.next().unwrap();
+
+                if metric.ends_with("finalizer_height") {
+                    let height = value.parse::<u64>().unwrap();
+                    if height >= stop_height {
+                        height_reached.insert(metric.to_string());
+                    }
+                }
+
+                if height_reached.len() as u32 >= n - 1 {
+                    success = true;
+                    break;
+                }
+            }
+            if success {
+                break;
+            }
+            context.sleep(Duration::from_secs(1)).await;
+        }
+
+        // Sanity: the MinimumStake increase was applied.
+        let state_query = consensus_state_queries.get(&1).unwrap();
+        assert_eq!(state_query.get_minimum_stake().await, new_min_stake);
+
+        // The victim cannot satisfy the raised minimum, so it must not remain an active
+        // below-minimum validator — it should be force-removed (its stake withdrawn).
+        let account = state_query.get_validator_account(victim_pubkey).await;
+        assert!(
+            account
+                .as_ref()
+                .is_none_or(|account| account.balance >= new_min_stake),
+            "validator below the raised minimum must be force-removed, not left active below it: {account:?}"
+        );
+
+        context.auditor().state()
+    })
+}
+
+#[test_traced("INFO")]
 fn test_deposit_and_withdrawal_same_block() {
     // Tests that when a deposit and withdrawal for the same validator are in the same block,
     // the second request is blocked by the first one's pending flag.

--- a/types/src/consensus_state.rs
+++ b/types/src/consensus_state.rs
@@ -772,6 +772,15 @@ impl ConsensusState {
         self.deposit_queue.len()
     }
 
+    /// Total amount of queued (not-yet-processed) deposits for `node_pubkey`.
+    pub fn pending_deposit_amount(&self, node_pubkey: &[u8; 32]) -> u64 {
+        self.deposit_queue
+            .iter()
+            .filter(|deposit| deposit.node_pubkey.as_ref() == &node_pubkey[..])
+            .map(|deposit| deposit.amount)
+            .sum()
+    }
+
     pub fn pop_deposit(&mut self) -> Option<DepositRequest> {
         #[cfg(feature = "prom")]
         let start = std::time::Instant::now();


### PR DESCRIPTION
Builds on https://github.com/SeismicSystems/summit/pull/377 (which builds on https://github.com/SeismicSystems/summit/pull/276 and https://github.com/SeismicSystems/summit/pull/275).

Addresses https://github.com/SeismicSystems/summit/issues/339.

Changes:
- Adds consensus-key guard when processing deposits.
Note: This guard is purely defensive,
    - Parse already enforces the match. A top-up is only accepted into the queue if its consensus key equals the stored account's. For a new-validator deposit, the placeholder's consensus key is set from the deposit, so they match trivially.
    - The account can't change identity before consume. While the deposit is queued, has_pending_deposit = true, which blocks the account from being removed/replaced. So the account that's looked up at consume time is the same account, with the same consensus key, that was validated at parse.
- Stake-bound enforcement is one-shot (runs only at the boundary where a stake param changes) and #188 skips any account with a pending deposit there. So a validator with a too-small (or never-processed, e.g. low/zero deposit cap) top-up queued across a MinimumStake increase was skipped and never re-checke. It stayed active below the new
minimum indefinitely. This is fixed by:
    - At both the penultimate staging and the boundary scan, defer removal for a `has_pending_deposit` account only if its queued deposit could bring it back into `[min, max]`; otherwise enforce now. Zero-balance new-validator placeholders
  stay excluded.
    - Add regression test `test_pending_topup_does_not_evade_minimum_stake_increase`.