### PR TITLE
fix: fence epoch-boundary side effects on fatal persistence failure

### DIFF
--- a/finalizer/src/actor.rs
+++ b/finalizer/src/actor.rs
@@ -916,7 +916,7 @@ impl<
             let header_start = Instant::now();
             self.db
                 .store_finalized_header(self.canonical_state.get_epoch(), &finalized_header)
-                .await;
+                .await?;
             #[cfg(feature = "prom")]
             {
                 let header_duration = header_start.elapsed().as_micros() as f64;
@@ -989,7 +989,7 @@ impl<
                         checkpoint,
                         block.clone(),
                     )
-                    .await;
+                    .await?;
                 #[cfg(feature = "prom")]
                 {
                     let checkpoint_duration = checkpoint_start.elapsed().as_micros() as f64;
@@ -1025,7 +1025,7 @@ impl<
             let consensus_state_start = Instant::now();
             self.db
                 .store_consensus_state(self.canonical_state.get_epoch(), &self.canonical_state)
-                .await;
+                .await?;
             #[cfg(feature = "prom")]
             {
                 let consensus_state_duration = consensus_state_start.elapsed().as_micros() as f64;
@@ -1038,7 +1038,7 @@ impl<
             // This will commit all changes to the state db
             #[cfg(feature = "prom")]
             let commit_start = Instant::now();
-            self.db.commit().await;
+            self.db.commit().await?;
             #[cfg(feature = "prom")]
             {
                 let commit_duration = commit_start.elapsed().as_micros() as f64;

--- a/finalizer/src/db.rs
+++ b/finalizer/src/db.rs
@@ -47,12 +47,15 @@ impl<E: Clock + Storage + Metrics, V: Variant> FinalizerState<E, V> {
         }
     }
 
-    /// Log a database error and initiate graceful shutdown.
-    fn handle_db_error(&self, e: impl std::fmt::Display, op: &str) {
+    /// Log a database error, initiate graceful shutdown, and return the error so callers
+    /// can propagate it and fence any consensus-critical side effects that must not run on
+    /// state that failed to persist.
+    fn handle_db_error(&self, e: impl std::fmt::Display, op: &str) -> anyhow::Error {
         error!(target: "critical", %e, op, "fatal database error, initiating shutdown");
         #[cfg(feature = "prom")]
         metrics::counter!("critical_errors_total", "reason" => "fatal_db_error", "severity" => "critical").increment(1);
         self.cancellation_token.cancel();
+        anyhow::anyhow!("fatal database error in {op}: {e}")
     }
 
     fn pad_key(key: &[u8]) -> FixedBytes<64> {
@@ -99,15 +102,16 @@ impl<E: Clock + Storage + Metrics, V: Variant> FinalizerState<E, V> {
         }
     }
 
-    async fn set_latest_consensus_state_epoch(&mut self, epoch: u64) {
+    async fn set_latest_consensus_state_epoch(&mut self, epoch: u64) -> anyhow::Result<()> {
         let key = Self::pad_key(&LATEST_CONSENSUS_STATE_EPOCH_KEY);
         if let Err(e) = self
             .store
             .apply_batch([(key, Some(Value::U64(epoch)))].into())
             .await
         {
-            self.handle_db_error(e, "set_latest_consensus_state_epoch");
+            return Err(self.handle_db_error(e, "set_latest_consensus_state_epoch"));
         }
+        Ok(())
     }
 
     // FinalizedHeader epoch tracking operations
@@ -123,15 +127,16 @@ impl<E: Clock + Storage + Metrics, V: Variant> FinalizerState<E, V> {
         }
     }
 
-    async fn set_latest_finalized_header_epoch(&mut self, epoch: u64) {
+    async fn set_latest_finalized_header_epoch(&mut self, epoch: u64) -> anyhow::Result<()> {
         let key = Self::pad_key(&LATEST_FINALIZED_HEADER_EPOCH_KEY);
         if let Err(e) = self
             .store
             .apply_batch([(key, Some(Value::U64(epoch)))].into())
             .await
         {
-            self.handle_db_error(e, "set_latest_finalized_header_epoch");
+            return Err(self.handle_db_error(e, "set_latest_finalized_header_epoch"));
         }
+        Ok(())
     }
 
     // Checkpoint epoch tracking operations
@@ -147,34 +152,39 @@ impl<E: Clock + Storage + Metrics, V: Variant> FinalizerState<E, V> {
         }
     }
 
-    async fn set_latest_checkpoint_epoch(&mut self, epoch: u64) {
+    async fn set_latest_checkpoint_epoch(&mut self, epoch: u64) -> anyhow::Result<()> {
         let key = Self::pad_key(&LATEST_CHECKPOINT_EPOCH_KEY);
         if let Err(e) = self
             .store
             .apply_batch([(key, Some(Value::U64(epoch)))].into())
             .await
         {
-            self.handle_db_error(e, "set_latest_checkpoint_epoch");
+            return Err(self.handle_db_error(e, "set_latest_checkpoint_epoch"));
         }
+        Ok(())
     }
 
     // ConsensusState blob operations
-    pub async fn store_consensus_state(&mut self, epoch: u64, state: &ConsensusState) {
+    pub async fn store_consensus_state(
+        &mut self,
+        epoch: u64,
+        state: &ConsensusState,
+    ) -> anyhow::Result<()> {
         let key = Self::make_consensus_state_key(epoch);
         if let Err(e) = self
             .store
             .apply_batch([(key, Some(Value::ConsensusState(Box::new(state.clone()))))].into())
             .await
         {
-            self.handle_db_error(e, "store_consensus_state");
-            return;
+            return Err(self.handle_db_error(e, "store_consensus_state"));
         }
 
         // Update the latest epoch tracker
         let current_latest = self.get_latest_consensus_state_epoch().await;
         if epoch >= current_latest {
-            self.set_latest_consensus_state_epoch(epoch).await;
+            self.set_latest_consensus_state_epoch(epoch).await?;
         }
+        Ok(())
     }
 
     pub async fn get_consensus_state(&self, epoch: u64) -> Option<ConsensusState> {
@@ -218,7 +228,7 @@ impl<E: Clock + Storage + Metrics, V: Variant> FinalizerState<E, V> {
         epoch: u64,
         checkpoint: &Checkpoint,
         last_block: Block,
-    ) {
+    ) -> anyhow::Result<()> {
         let key = Self::make_checkpoint_key(epoch);
         if let Err(e) = self
             .store
@@ -234,15 +244,15 @@ impl<E: Clock + Storage + Metrics, V: Variant> FinalizerState<E, V> {
             )
             .await
         {
-            self.handle_db_error(e, "store_finalized_checkpoint");
-            return;
+            return Err(self.handle_db_error(e, "store_finalized_checkpoint"));
         }
 
         // Update the latest checkpoint epoch tracker
         let current_latest = self.get_latest_checkpoint_epoch().await;
         if epoch >= current_latest {
-            self.set_latest_checkpoint_epoch(epoch).await;
+            self.set_latest_checkpoint_epoch(epoch).await?;
         }
+        Ok(())
     }
 
     #[allow(unused)]
@@ -269,22 +279,22 @@ impl<E: Clock + Storage + Metrics, V: Variant> FinalizerState<E, V> {
         &mut self,
         epoch: u64,
         header: &FinalizedHeader<bls12381_multisig::Scheme<PublicKey, V>>,
-    ) {
+    ) -> anyhow::Result<()> {
         let key = Self::make_finalized_header_key(epoch);
         if let Err(e) = self
             .store
             .apply_batch([(key, Some(Value::FinalizedHeader(Box::new(header.clone()))))].into())
             .await
         {
-            self.handle_db_error(e, "store_finalized_header");
-            return;
+            return Err(self.handle_db_error(e, "store_finalized_header"));
         }
 
         // Update the latest finalized header epoch tracker
         let current_latest = self.get_latest_finalized_header_epoch().await;
         if epoch >= current_latest {
-            self.set_latest_finalized_header_epoch(epoch).await;
+            self.set_latest_finalized_header_epoch(epoch).await?;
         }
+        Ok(())
     }
 
     #[allow(unused)]
@@ -311,10 +321,11 @@ impl<E: Clock + Storage + Metrics, V: Variant> FinalizerState<E, V> {
     }
 
     // Commit all pending changes to the database
-    pub async fn commit(&mut self) {
+    pub async fn commit(&mut self) -> anyhow::Result<()> {
         if let Err(e) = self.store.commit().await {
-            self.handle_db_error(e, "commit");
+            return Err(self.handle_db_error(e, "commit"));
         }
+        Ok(())
     }
 }
 
@@ -482,8 +493,10 @@ mod tests {
             assert!(db.get_latest_consensus_state().await.is_none());
 
             // Store the consensus state
-            db.store_consensus_state(42, &consensus_state).await;
-            db.commit().await;
+            db.store_consensus_state(42, &consensus_state)
+                .await
+                .unwrap();
+            db.commit().await.unwrap();
 
             // Retrieve the consensus state
             let retrieved = db.get_consensus_state(42).await;
@@ -500,8 +513,8 @@ mod tests {
             // Store a newer state
             let mut newer_state = ConsensusState::default();
             newer_state.set_latest_height(100);
-            db.store_consensus_state(100, &newer_state).await;
-            db.commit().await;
+            db.store_consensus_state(100, &newer_state).await.unwrap();
+            db.commit().await.unwrap();
 
             // Should return the most recent state
             let latest = db.get_latest_consensus_state().await;
@@ -560,8 +573,10 @@ mod tests {
             assert!(db.get_finalized_header(100).await.is_none());
 
             // Store the finalized header at height 100
-            db.store_finalized_header(100, &finalized_header).await;
-            db.commit().await;
+            db.store_finalized_header(100, &finalized_header)
+                .await
+                .unwrap();
+            db.commit().await.unwrap();
 
             // Retrieve the finalized header
             let retrieved = db.get_finalized_header(100).await;
@@ -603,8 +618,10 @@ mod tests {
             };
             let finalized_header2 =
                 summit_types::FinalizedHeader::new_unchecked(header2.clone(), finalized2, 3);
-            db.store_finalized_header(200, &finalized_header2).await;
-            db.commit().await;
+            db.store_finalized_header(200, &finalized_header2)
+                .await
+                .unwrap();
+            db.commit().await.unwrap();
 
             // Both headers should be accessible
             let h1 = db.get_finalized_header(100).await.unwrap();
@@ -728,8 +745,10 @@ mod tests {
                 summit_types::FinalizedHeader::new_unchecked(header2.clone(), finalized2, 3);
 
             // Store headers in non-sequential order: 100, 300, 200
-            db.store_finalized_header(100, &finalized_header1).await;
-            db.commit().await;
+            db.store_finalized_header(100, &finalized_header1)
+                .await
+                .unwrap();
+            db.commit().await.unwrap();
 
             // Most recent should be height 100
             let most_recent = db.get_most_recent_finalized_header().await.unwrap();
@@ -737,8 +756,10 @@ mod tests {
             assert_eq!(most_recent.header().get_digest(), header1.get_digest());
 
             // Store height 300
-            db.store_finalized_header(300, &finalized_header3).await;
-            db.commit().await;
+            db.store_finalized_header(300, &finalized_header3)
+                .await
+                .unwrap();
+            db.commit().await.unwrap();
 
             // Most recent should now be height 300
             let most_recent = db.get_most_recent_finalized_header().await.unwrap();
@@ -746,8 +767,10 @@ mod tests {
             assert_eq!(most_recent.header().get_digest(), header3.get_digest());
 
             // Store height 200 (lower than current max)
-            db.store_finalized_header(200, &finalized_header2).await;
-            db.commit().await;
+            db.store_finalized_header(200, &finalized_header2)
+                .await
+                .unwrap();
+            db.commit().await.unwrap();
 
             // Most recent should still be height 300
             let most_recent = db.get_most_recent_finalized_header().await.unwrap();
@@ -790,8 +813,9 @@ mod tests {
 
             // Store finalized checkpoint for epoch 0
             db.store_finalized_checkpoint(0, &finalized_checkpoint1, Block::genesis([0; 32]))
-                .await;
-            db.commit().await;
+                .await
+                .unwrap();
+            db.commit().await.unwrap();
 
             // Retrieve finalized checkpoint
             let retrieved_finalized = db.get_finalized_checkpoint(0).await;
@@ -806,8 +830,9 @@ mod tests {
 
             // Store checkpoint for epoch 1
             db.store_finalized_checkpoint(1, &finalized_checkpoint2, Block::genesis([0; 32]))
-                .await;
-            db.commit().await;
+                .await
+                .unwrap();
+            db.commit().await.unwrap();
 
             // Both checkpoints should be accessible
             let (checkpoint0, _) = db.get_finalized_checkpoint(0).await.unwrap();
@@ -846,8 +871,9 @@ mod tests {
 
             // Store checkpoints out of order: 5, then 3, then 7
             db.store_finalized_checkpoint(5, &checkpoint5, Block::genesis([0; 32]))
-                .await;
-            db.commit().await;
+                .await
+                .unwrap();
+            db.commit().await.unwrap();
 
             // Latest should be epoch 5
             let (latest, _) = db.get_latest_finalized_checkpoint().await.0.unwrap();
@@ -855,8 +881,9 @@ mod tests {
 
             // Store epoch 3 (older than current latest)
             db.store_finalized_checkpoint(3, &checkpoint3, Block::genesis([0; 32]))
-                .await;
-            db.commit().await;
+                .await
+                .unwrap();
+            db.commit().await.unwrap();
 
             // Latest should still be epoch 5, not 3
             let (latest, _) = db.get_latest_finalized_checkpoint().await.0.unwrap();
@@ -864,8 +891,9 @@ mod tests {
 
             // Store epoch 7 (newer than current latest)
             db.store_finalized_checkpoint(7, &checkpoint7, Block::genesis([0; 32]))
-                .await;
-            db.commit().await;
+                .await
+                .unwrap();
+            db.commit().await.unwrap();
 
             // Latest should now be epoch 7
             let (latest, _) = db.get_latest_finalized_checkpoint().await.0.unwrap();
@@ -901,16 +929,18 @@ mod tests {
 
             // Store first checkpoint for epoch 2
             db.store_finalized_checkpoint(2, &checkpoint1, Block::genesis([0; 32]))
-                .await;
-            db.commit().await;
+                .await
+                .unwrap();
+            db.commit().await.unwrap();
 
             let (retrieved, _) = db.get_finalized_checkpoint(2).await.unwrap();
             assert_eq!(retrieved.digest, checkpoint1.digest);
 
             // Overwrite with second checkpoint for the same epoch 2
             db.store_finalized_checkpoint(2, &checkpoint2, Block::genesis([0; 32]))
-                .await;
-            db.commit().await;
+                .await
+                .unwrap();
+            db.commit().await.unwrap();
 
             // Should now return the second checkpoint
             let (retrieved, _) = db.get_finalized_checkpoint(2).await.unwrap();
@@ -946,16 +976,19 @@ mod tests {
 
             // Store checkpoints for epochs 0, 2, and 5 (skipping 1, 3, 4)
             db.store_finalized_checkpoint(0, &checkpoint0, Block::genesis([0; 32]))
-                .await;
-            db.commit().await;
+                .await
+                .unwrap();
+            db.commit().await.unwrap();
 
             db.store_finalized_checkpoint(2, &checkpoint2, Block::genesis([0; 32]))
-                .await;
-            db.commit().await;
+                .await
+                .unwrap();
+            db.commit().await.unwrap();
 
             db.store_finalized_checkpoint(5, &checkpoint5, Block::genesis([0; 32]))
-                .await;
-            db.commit().await;
+                .await
+                .unwrap();
+            db.commit().await.unwrap();
 
             // All stored checkpoints should be retrievable
             let (cp0, _) = db.get_finalized_checkpoint(0).await.unwrap();


### PR DESCRIPTION
Addresses https://github.com/SeismicSystems/summit/issues/326.

Changes
- `handle_db_error` now returns the error; the four boundary write/commit methods (and the internal `set_latest_*_epoch` tracker writes) return `anyhow::Result<()>` and propagate it. Tests updated.
- In the finalizer actor, `fatal persistence errors return `Err` before any oracle/orchestrator side effect and the existing `Err => cancel(); break` arm shuts down cleanly.