### PR TITLE
fix: make finalized block delivery idempotent in the finalizer

### DIFF
--- a/finalizer/src/actor.rs
+++ b/finalizer/src/actor.rs
@@ -685,6 +685,51 @@ impl<
         let height = block.height();
         let block_digest = block.digest();
 
+        // Idempotence guard. The syncer contract is at-least-once (see `summit-syncer`
+        // docs), so a finalized block may be re-delivered after it was already applied
+        // (restart/recovery/replay paths). The notarized path ignores blocks at or below
+        // canonical height; the finalized path must do the same. We must still ACK the
+        // duplicate so the syncer's pending-ack pipeline doesn't stall, and we must NOT
+        // re-execute it — re-execution would re-run the EL payload check, re-process
+        // deposits/withdrawals, regress the height, or trip the epoch assertion in
+        // `execute_block` when the canonical state has already advanced past an epoch
+        // boundary.
+        let latest_height = self.canonical_state.get_latest_height();
+        if height <= latest_height {
+            // At the canonical head the digest is known, so a mismatch here means two
+            // different blocks were finalized at the same height — a consensus safety
+            // violation we must surface rather than silently skip or re-execute.
+            if height == latest_height && block_digest != self.canonical_state.get_head_digest() {
+                error!(
+                    target: "critical",
+                    height,
+                    ?block_digest,
+                    head_digest = ?self.canonical_state.get_head_digest(),
+                    "received a conflicting finalized block at the canonical head height"
+                );
+                #[cfg(feature = "prom")]
+                counter!(
+                    "critical_errors_total",
+                    "reason" => "conflicting_finalization",
+                    "severity" => "critical"
+                )
+                .increment(1);
+                return Err(anyhow!(
+                    "conflicting finalized block at height {height}: got {block_digest:?}, \
+                     canonical head is {:?}",
+                    self.canonical_state.get_head_digest()
+                ));
+            }
+            debug!(
+                height,
+                ?block_digest,
+                latest_height,
+                "ignoring duplicate finalized block at or below canonical height"
+            );
+            ack_tx.acknowledge();
+            return Ok(HandleOutcome::Applied);
+        }
+
         // Try to find the fork state for this block (if it was notarized before finalization)
         if let Some(fork_state) = self
             .fork_states

--- a/finalizer/src/tests/mocks.rs
+++ b/finalizer/src/tests/mocks.rs
@@ -15,6 +15,7 @@ use commonware_math::algebra::Random;
 use commonware_parallel::Sequential;
 use commonware_utils::ordered::{BiMap, Map};
 use std::collections::VecDeque;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use summit_types::network_oracle::NetworkOracle;
 use summit_types::{Block, Digest, EngineClient, PublicKey};
@@ -86,6 +87,7 @@ pub fn make_finalization(
 pub struct MockEngineClient {
     check_payload_overrides: Arc<Mutex<VecDeque<PayloadStatus>>>,
     commit_hash_overrides: Arc<Mutex<VecDeque<ForkchoiceUpdated>>>,
+    check_payload_calls: Arc<AtomicU64>,
 }
 
 impl MockEngineClient {
@@ -93,7 +95,15 @@ impl MockEngineClient {
         Self {
             check_payload_overrides: Arc::new(Mutex::new(VecDeque::new())),
             commit_hash_overrides: Arc::new(Mutex::new(VecDeque::new())),
+            check_payload_calls: Arc::new(AtomicU64::new(0)),
         }
+    }
+
+    /// Number of times `check_payload` has been invoked. Used to detect whether a
+    /// finalized block was (re-)executed against the execution layer.
+    #[allow(unused)]
+    pub fn check_payload_call_count(&self) -> u64 {
+        self.check_payload_calls.load(Ordering::SeqCst)
     }
 
     /// Queue SYNCING responses for check_payload. After these are consumed,
@@ -181,6 +191,7 @@ impl EngineClient for MockEngineClient {
         &mut self,
         _block: &Block,
     ) -> Result<PayloadStatus, summit_types::EngineClientError> {
+        self.check_payload_calls.fetch_add(1, Ordering::SeqCst);
         if let Some(override_status) = self.check_payload_overrides.lock().unwrap().pop_front() {
             return Ok(override_status);
         }

--- a/finalizer/src/tests/syncing.rs
+++ b/finalizer/src/tests/syncing.rs
@@ -993,3 +993,116 @@ fn test_finalizer_finalized_buffer_drains_in_order() {
         context.auditor().state()
     });
 }
+
+#[test]
+fn test_duplicate_finalized_delivery_is_idempotent() {
+    // The syncer documents at-least-once finalized delivery (syncer/src/lib.rs: "The actor
+    // will deliver a block to the reporter at-least-once. The reporter should be prepared to
+    // handle duplicate deliveries."). So the finalizer must tolerate a duplicate
+    // Update::FinalizedBlock for a block it has already applied: it must NOT re-execute the
+    // block against the execution layer or regress its canonical height, but it MUST still
+    // acknowledge the duplicate so the syncer's pending-ack pipeline does not stall.
+    //
+    // Regression guard for the missing idempotence guard in handle_finalized_block: the
+    // notarized path ignores blocks at or below canonical height, the finalized path does
+    // not. On the pre-fix code the duplicate is re-executed, so check_payload runs a second
+    // time (and execution requests would be re-processed / the height regressed).
+    let cfg = deterministic::Config::default().with_seed(77);
+    let executor = Runner::from(cfg);
+    executor.start(|context| async move {
+        let genesis_hash = [0u8; 32];
+        let initial_state = create_test_initial_state(genesis_hash, NonZeroU64::new(10).unwrap());
+
+        let (orchestrator_tx, _orchestrator_rx) = futures_mpsc::channel(100);
+        let orchestrator_mailbox = summit_orchestrator::Mailbox::new(orchestrator_tx);
+
+        let node_key = ed25519::PrivateKey::from_seed(0);
+
+        let engine_client = MockEngineClient::new();
+        // Shares the call counter with the client moved into the finalizer (Arc-backed).
+        let engine_client_probe = engine_client.clone();
+
+        let finalizer_cfg = FinalizerConfig::<MockEngineClient, MockNetworkOracle, MinPk> {
+            mailbox_size: 100,
+            db_prefix: "test_duplicate_finalized".to_string(),
+            engine_client,
+            oracle: MockNetworkOracle,
+            protocol_consts: default_protocol_consts(),
+            page_cache: CacheRef::from_pooler(
+                &context,
+                std::num::NonZero::new(4096).unwrap(),
+                NZUsize!(100),
+            ),
+            genesis_hash,
+            initial_state,
+            protocol_version: 1,
+            node_public_key: node_key.public_key(),
+            cancellation_token: CancellationToken::new(),
+            drain_interval: Duration::from_millis(50),
+            buffered_blocks_warn_threshold: 100,
+            pending_notarized_max: 1000,
+            namespace: Vec::new(),
+            _variant_marker: PhantomData,
+        };
+
+        let (finalizer, _state, mut mailbox) =
+            Finalizer::<_, MockEngineClient, MockNetworkOracle, ed25519::PrivateKey, MinPk>::new(
+                context.with_label("finalizer"),
+                finalizer_cfg,
+            )
+            .await;
+        let _handle = finalizer.start(orchestrator_mailbox);
+        context.sleep(Duration::from_millis(20)).await;
+
+        let genesis_block = Block::genesis(genesis_hash);
+        let block1 = create_test_block(genesis_block.digest(), 1, 1, 77001);
+
+        // First (legitimate) finalized delivery: the block is applied and executed once.
+        let (ack1, _waiter1) = Exact::handle();
+        mailbox
+            .report(Update::FinalizedBlock((block1.clone(), None), ack1))
+            .await;
+        context.sleep(Duration::from_millis(200)).await;
+        assert_eq!(
+            mailbox.get_latest_height().await,
+            1,
+            "first finalized block must apply"
+        );
+        let calls_after_first = engine_client_probe.check_payload_call_count();
+        assert_eq!(
+            calls_after_first, 1,
+            "first finalized delivery should execute the block exactly once"
+        );
+
+        // Duplicate finalized delivery of the SAME block (at-least-once contract).
+        let (ack2, waiter2) = Exact::handle();
+        mailbox
+            .report(Update::FinalizedBlock((block1.clone(), None), ack2))
+            .await;
+        context.sleep(Duration::from_millis(200)).await;
+
+        // The duplicate must be acknowledged so the syncer's pending-ack pipeline does not
+        // stall. (A guard that returns early without acking would drop the handle and the
+        // waiter would resolve Err(Canceled).)
+        assert!(
+            waiter2.await.is_ok(),
+            "duplicate finalized delivery must be acknowledged, not dropped"
+        );
+
+        // The duplicate must not change/regress canonical height.
+        assert_eq!(
+            mailbox.get_latest_height().await,
+            1,
+            "duplicate finalized block must not change canonical height"
+        );
+
+        // The duplicate must NOT be re-executed against the execution layer.
+        assert_eq!(
+            engine_client_probe.check_payload_call_count(),
+            calls_after_first,
+            "duplicate finalized block must not be re-executed (check_payload was called again)"
+        );
+
+        context.auditor().state()
+    });
+}


### PR DESCRIPTION
Addresses https://github.com/SeismicSystems/summit/issues/323.

Changes:
- Added the idempotence guard at the start of handle_finalized_block (before the fork-state/execute branch).
- Added regression test `test_duplicate_finalized_delivery_is_idempotent`.