### PR TITLE
fix: namespace-separate observer child-key derivation

### DIFF
--- a/finalizer/src/actor.rs
+++ b/finalizer/src/actor.rs
@@ -288,6 +288,10 @@ pub struct Finalizer<
     deposit_signature_domain: Digest,
     oracle: O,
     node_public_key: PublicKey,
+
+    /// Chain namespace (genesis), mixed into observer child-key derivation for
+    /// domain separation across deployments.
+    namespace: Vec<u8>,
     validator_exit: bool,
     cancellation_token: CancellationToken,
     _signer_marker: PhantomData<S>,
@@ -401,6 +405,7 @@ impl<
                     &cfg.namespace,
                 ),
                 node_public_key: cfg.node_public_key,
+                namespace: cfg.namespace,
                 validator_exit: false,
                 cancellation_token: cfg.cancellation_token,
                 _signer_marker: PhantomData,
@@ -433,6 +438,7 @@ impl<
             .collect();
         let observer_keys = derive_observer_keys(
             &network_keys,
+            &self.namespace,
             self.canonical_state.get_observers_per_validator(),
         );
         self.oracle
@@ -1009,6 +1015,7 @@ impl<
                 .collect();
             let observer_keys = derive_observer_keys(
                 &network_keys,
+                &self.namespace,
                 self.canonical_state.get_observers_per_validator(),
             );
             self.oracle

--- a/node/src/args.rs
+++ b/node/src/args.rs
@@ -507,7 +507,7 @@ async fn run_node_inner(
     let max_message_size = genesis.max_message_size_bytes as u32;
 
     let (engine, p2p, rpc_handle) = if let Some(index) = flags.observer {
-        let signer = ExtPrivateKey::derive_child_signer(&key_store.node_key, index);
+        let signer = ExtPrivateKey::derive_child_signer(&key_store.node_key, namespace, index);
         let mut p2p_cfg = authenticated::discovery::Config::recommended(
             signer,
             namespace,
@@ -657,7 +657,7 @@ async fn run_node_local_inner(
     let max_message_size = genesis.max_message_size_bytes as u32;
 
     let (engine, p2p, rpc_handle) = if let Some(index) = flags.observer {
-        let signer = ExtPrivateKey::derive_child_signer(&key_store.node_key, index);
+        let signer = ExtPrivateKey::derive_child_signer(&key_store.node_key, namespace, index);
         let mut p2p_cfg = authenticated::discovery::Config::local(
             signer,
             namespace,

--- a/node/src/bin/observer.rs
+++ b/node/src/bin/observer.rs
@@ -383,8 +383,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 from_hex_formatted(&master_key_hex).expect("invalid hex in master node key");
             let master_priv_key = PrivateKey::decode(&master_key_bytes[..])
                 .expect("failed to decode master private key");
-            let observer_pubkey =
-                derive_child_public(master_priv_key.public_key(), OBSERVER_DERIVE_IDX);
+            // Observer child keys are namespace-separated (#335); use the same genesis
+            // namespace the validators authorize against so this matches their derived set.
+            let observer_namespace = Genesis::load_from_file(&e2e_genesis_path_str)
+                .expect("failed to load genesis for observer namespace")
+                .namespace;
+            let observer_pubkey = derive_child_public(
+                master_priv_key.public_key(),
+                observer_namespace.as_bytes(),
+                OBSERVER_DERIVE_IDX,
+            );
 
             let val_rpc_port = get_node_flags(0, &e2e_genesis_path_str).rpc_port;
             let checkpoint_res = fetch_latest_checkpoint(val_rpc_port)

--- a/node/src/tests/observer.rs
+++ b/node/src/tests/observer.rs
@@ -71,11 +71,18 @@ fn test_observer_reaches_end_height() {
         let master_priv_key = validator_key_stores[0].node_key.clone();
         let master_consensus_key = validator_key_stores[0].consensus_key.clone();
         let master_pub_key = master_priv_key.public_key();
-        let observer_signer = ExtPrivateKey::derive_child_signer(&master_priv_key, observer_index);
+        // Must match the namespace the nodes run with (below), so the derived observer
+        // identity matches the finalizer's authorized observer set (#335).
+        let observer_namespace = b"_SUMMIT";
+        let observer_signer = ExtPrivateKey::derive_child_signer(
+            &master_priv_key,
+            observer_namespace,
+            observer_index,
+        );
         let observer_pubkey = observer_signer.public_key();
         assert_eq!(
             observer_pubkey,
-            derive_child_public(master_pub_key.clone(), observer_index),
+            derive_child_public(master_pub_key.clone(), observer_namespace, observer_index),
             "signer and public-only derivation must agree"
         );
 

--- a/types/src/ext_private_key.rs
+++ b/types/src/ext_private_key.rs
@@ -28,7 +28,11 @@ pub struct ExtPrivateKey {
 }
 
 impl ExtPrivateKey {
-    pub fn derive_child_signer(private_key: &PrivateKey, index: u32) -> Self {
+    /// Derive an observer child signer from the validator `private_key`, the chain
+    /// `namespace` (genesis namespace), and the observer `index`. The namespace is mixed
+    /// into the derivation so the same node key and index produce different observer
+    /// identities on different deployments.
+    pub fn derive_child_signer(private_key: &PrivateKey, namespace: &[u8], index: u32) -> Self {
         let path = format!("m/seismic/observer/{}", index).into_bytes();
         let seed_vec = private_key.encode();
         let master_pk = private_key.public_key();
@@ -36,7 +40,7 @@ impl ExtPrivateKey {
 
         let master_seed: [u8; 32] = seed_vec.as_ref().try_into().unwrap();
         let (scalar, master_prefix) = expand_seed(&master_seed);
-        let t = compute_tweak(&master_pub, &path);
+        let t = compute_tweak(&master_pub, namespace, &path);
         let scalar_child = scalar + t;
 
         let mut h = Sha512::new();
@@ -60,7 +64,8 @@ impl ExtPrivateKey {
 impl Random for ExtPrivateKey {
     fn random(rng: impl CryptoRngCore) -> Self {
         let master = PrivateKey::random(rng);
-        ExtPrivateKey::derive_child_signer(&master, 0)
+        // Random master => no cross-deployment collision concern; empty namespace.
+        ExtPrivateKey::derive_child_signer(&master, b"", 0)
     }
 }
 
@@ -106,24 +111,30 @@ impl Signer for ExtPrivateKey {
     }
 }
 
-pub fn derive_child_public(master_pk: PublicKey, index: u32) -> PublicKey {
+/// Public counterpart of [`ExtPrivateKey::derive_child_signer`]: must mix in the same
+/// `namespace` so the derived observer pubkey matches the signer the observer holds.
+pub fn derive_child_public(master_pk: PublicKey, namespace: &[u8], index: u32) -> PublicKey {
     let path = format!("m/seismic/observer/{}", index).into_bytes();
     let master_pub: [u8; 32] = master_pk.as_ref().try_into().unwrap();
     let a_point = CompressedEdwardsY(master_pub)
         .decompress()
         .expect("pubkey is y-coordinate of curve point");
-    let t = compute_tweak(&master_pub, &path);
+    let t = compute_tweak(&master_pub, namespace, &path);
     let t_point = t * ED25519_BASEPOINT_POINT;
     let bytes = (a_point + t_point).compress().0;
     PublicKey::decode(bytes.as_ref()).expect("child pubkey is a valid Ed25519 point")
 }
 
 /// For each validator master pubkey, derive the first `n` child pubkeys via
-/// [`derive_child_public`] and flatten into a single list.
-pub fn derive_observer_keys(validator_pks: &[PublicKey], n: u32) -> Vec<PublicKey> {
+/// [`derive_child_public`] (mixing in `namespace`) and flatten into a single list.
+pub fn derive_observer_keys(
+    validator_pks: &[PublicKey],
+    namespace: &[u8],
+    n: u32,
+) -> Vec<PublicKey> {
     validator_pks
         .iter()
-        .flat_map(|pk| (0..n).map(move |i| derive_child_public(pk.clone(), i)))
+        .flat_map(|pk| (0..n).map(move |i| derive_child_public(pk.clone(), namespace, i)))
         .collect()
 }
 
@@ -140,10 +151,14 @@ fn expand_seed(seed: &[u8; 32]) -> (Scalar, [u8; 32]) {
     (a, prefix)
 }
 
-fn compute_tweak(master_pub: &[u8; 32], path: &[u8]) -> Scalar {
+fn compute_tweak(master_pub: &[u8; 32], namespace: &[u8], path: &[u8]) -> Scalar {
     let mut h = Sha512::new();
     h.update(DERIVE_TAG);
     h.update(master_pub);
+    // Length-prefix the namespace so it can't be confused with the trailing path
+    // (e.g. namespace="ab",path="cd" must not collide with namespace="a",path="bcd").
+    h.update((namespace.len() as u64).to_le_bytes());
+    h.update(namespace);
     h.update(path);
     let out: [u8; 64] = h.finalize().into();
     Scalar::from_bytes_mod_order_wide(&out)
@@ -163,11 +178,11 @@ mod tests {
 
         // Derive first child
         let child_index = 0;
-        let child_sk = ExtPrivateKey::derive_child_signer(&master_sk, child_index);
+        let child_sk = ExtPrivateKey::derive_child_signer(&master_sk, b"test-ns", child_index);
         let child_pk = child_sk.public_key();
 
         // Verify child is derived from master
-        let pub_derived_child = derive_child_public(master_pk, child_index);
+        let pub_derived_child = derive_child_public(master_pk, b"test-ns", child_index);
 
         assert_eq!(pub_derived_child, child_pk);
     }
@@ -183,14 +198,14 @@ mod tests {
 
         // Derive first child
         let child_index = 0;
-        let child_sk = ExtPrivateKey::derive_child_signer(&master_sk, child_index);
+        let child_sk = ExtPrivateKey::derive_child_signer(&master_sk, b"test-ns", child_index);
         let child_pk = child_sk.public_key();
 
         // Sign message with child key
         let sig = child_sk.sign(namespace, msg);
 
         // Verify signature with both pubkeys
-        let pub_derived_child = derive_child_public(master_pk, child_index);
+        let pub_derived_child = derive_child_public(master_pk, b"test-ns", child_index);
         assert!(child_pk.verify(namespace, msg, &sig));
         assert!(pub_derived_child.verify(namespace, msg, &sig));
     }
@@ -202,12 +217,14 @@ mod tests {
 
         // Derive first child
         let child_index = 0;
-        let first_child_sk = ExtPrivateKey::derive_child_signer(&master_sk, child_index);
+        let first_child_sk =
+            ExtPrivateKey::derive_child_signer(&master_sk, b"test-ns", child_index);
         let first_child_pk = first_child_sk.public_key();
 
         // Derive the second child
         let child_index = 1;
-        let second_child_sk = ExtPrivateKey::derive_child_signer(&master_sk, child_index);
+        let second_child_sk =
+            ExtPrivateKey::derive_child_signer(&master_sk, b"test-ns", child_index);
         let second_child_pk = second_child_sk.public_key();
 
         // Verify that different indices lead to different derived child keys
@@ -217,8 +234,8 @@ mod tests {
     #[test]
     fn test_derivation_deterministic() {
         let master_sk = PrivateKey::random(&mut OsRng);
-        let child_a = ExtPrivateKey::derive_child_signer(&master_sk, 42);
-        let child_b = ExtPrivateKey::derive_child_signer(&master_sk, 42);
+        let child_a = ExtPrivateKey::derive_child_signer(&master_sk, b"test-ns", 42);
+        let child_b = ExtPrivateKey::derive_child_signer(&master_sk, b"test-ns", 42);
 
         assert_eq!(child_a.public_key(), child_b.public_key());
 
@@ -233,8 +250,8 @@ mod tests {
         let master_b = PrivateKey::random(&mut OsRng);
         let index = 0;
 
-        let child_a = ExtPrivateKey::derive_child_signer(&master_a, index);
-        let child_b = ExtPrivateKey::derive_child_signer(&master_b, index);
+        let child_a = ExtPrivateKey::derive_child_signer(&master_a, b"test-ns", index);
+        let child_b = ExtPrivateKey::derive_child_signer(&master_b, b"test-ns", index);
 
         assert_ne!(child_a.public_key(), child_b.public_key());
     }
@@ -243,10 +260,10 @@ mod tests {
     fn test_wrong_index_verify_fails() {
         let master_sk = PrivateKey::random(&mut OsRng);
         let master_pk = master_sk.public_key();
-        let signer = ExtPrivateKey::derive_child_signer(&master_sk, 5);
+        let signer = ExtPrivateKey::derive_child_signer(&master_sk, b"test-ns", 5);
         let sig = signer.sign(b"ns", b"msg");
 
-        let wrong_pk = derive_child_public(master_pk, 6);
+        let wrong_pk = derive_child_public(master_pk, b"test-ns", 6);
         assert!(!wrong_pk.verify(b"ns", b"msg", &sig));
     }
 
@@ -256,17 +273,17 @@ mod tests {
         let master_b = PrivateKey::random(&mut OsRng);
         let index = 0;
 
-        let signer = ExtPrivateKey::derive_child_signer(&master_a, index);
+        let signer = ExtPrivateKey::derive_child_signer(&master_a, b"test-ns", index);
         let sig = signer.sign(b"ns", b"msg");
 
-        let wrong_pk = derive_child_public(master_b.public_key(), index);
+        let wrong_pk = derive_child_public(master_b.public_key(), b"test-ns", index);
         assert!(!wrong_pk.verify(b"ns", b"msg", &sig));
     }
 
     #[test]
     fn test_tampered_message_verify_fails() {
         let master_sk = PrivateKey::random(&mut OsRng);
-        let signer = ExtPrivateKey::derive_child_signer(&master_sk, 0);
+        let signer = ExtPrivateKey::derive_child_signer(&master_sk, b"test-ns", 0);
         let pubkey = signer.public_key();
         let sig = signer.sign(b"ns", b"original");
 
@@ -277,7 +294,7 @@ mod tests {
     #[test]
     fn test_clone_equivalence() {
         let master_sk = PrivateKey::random(&mut OsRng);
-        let original = ExtPrivateKey::derive_child_signer(&master_sk, 7);
+        let original = ExtPrivateKey::derive_child_signer(&master_sk, b"test-ns", 7);
         let cloned = original.clone();
 
         assert_eq!(original.public_key(), cloned.public_key());
@@ -290,7 +307,7 @@ mod tests {
     #[test]
     fn test_empty_namespace_and_msg() {
         let master_sk = PrivateKey::random(&mut OsRng);
-        let signer = ExtPrivateKey::derive_child_signer(&master_sk, 0);
+        let signer = ExtPrivateKey::derive_child_signer(&master_sk, b"test-ns", 0);
         let pubkey = signer.public_key();
 
         let sig = signer.sign(b"", b"");
@@ -300,9 +317,41 @@ mod tests {
     #[test]
     fn test_index_boundaries() {
         let master_sk = PrivateKey::random(&mut OsRng);
-        let child_min = ExtPrivateKey::derive_child_signer(&master_sk, 0);
-        let child_max = ExtPrivateKey::derive_child_signer(&master_sk, u32::MAX);
+        let child_min = ExtPrivateKey::derive_child_signer(&master_sk, b"test-ns", 0);
+        let child_max = ExtPrivateKey::derive_child_signer(&master_sk, b"test-ns", u32::MAX);
 
         assert_ne!(child_min.public_key(), child_max.public_key());
+    }
+
+    // The same master node key and observer index must produce different observer
+    // keys under different namespaces, so an observer key issued for one deployment cannot
+    // be authorized as an observer on another. The signer and public derivations must mix
+    // in the namespace identically (so they still match each other within a namespace).
+    #[test]
+    fn test_namespace_domain_separation() {
+        let master_sk = PrivateKey::random(&mut OsRng);
+        let master_pk = master_sk.public_key();
+        let index = 3;
+
+        let signer_a = ExtPrivateKey::derive_child_signer(&master_sk, b"deployment-a", index);
+        let signer_b = ExtPrivateKey::derive_child_signer(&master_sk, b"deployment-b", index);
+
+        // Different namespace => different observer identity for the same master + index.
+        assert_ne!(
+            signer_a.public_key(),
+            signer_b.public_key(),
+            "same master+index must derive different keys per namespace"
+        );
+
+        // Public derivation matches the signer within the same namespace...
+        assert_eq!(
+            derive_child_public(master_pk.clone(), b"deployment-a", index),
+            signer_a.public_key()
+        );
+        // ...and is also namespace-separated.
+        assert_ne!(
+            derive_child_public(master_pk.clone(), b"deployment-a", index),
+            derive_child_public(master_pk, b"deployment-b", index)
+        );
     }
 }


### PR DESCRIPTION
Addresses https://github.com/SeismicSystems/summit/issues/335.

Changes:
- Mix the genesis namespace into the child key derivation.
- Add unit tests.