### PR TITLE
fix: bind live P2P and consensus domains to chain identity

### DIFF
--- a/finalizer/src/actor.rs
+++ b/finalizer/src/actor.rs
@@ -392,9 +392,12 @@ pub struct Finalizer<
     oracle: O,
     node_public_key: PublicKey,
 
-    /// Chain namespace (genesis), mixed into observer child-key derivation for
-    /// domain separation across deployments.
-    namespace: Vec<u8>,
+    /// Chain bound domain (`chain_domain(config_digest)`) used to derive the
+    /// authorized observer child keys. Must match the domain the live P2P
+    /// observer signer is derived with (see node startup), or observers will
+    /// not be authenticated. Distinct from the raw deposit namespace, which is
+    /// already folded into `deposit_signature_domain`.
+    observer_domain: Vec<u8>,
     validator_exit: bool,
     cancellation_token: CancellationToken,
     _signer_marker: PhantomData<S>,
@@ -511,7 +514,7 @@ impl<
                     &cfg.namespace,
                 ),
                 node_public_key: cfg.node_public_key,
-                namespace: cfg.namespace,
+                observer_domain: cfg.observer_domain,
                 validator_exit: false,
                 cancellation_token: cfg.cancellation_token,
                 _signer_marker: PhantomData,
@@ -547,7 +550,7 @@ impl<
             .collect();
         let observer_keys = derive_observer_keys(
             &network_keys,
-            &self.namespace,
+            &self.observer_domain,
             self.canonical_state.get_observers_per_validator(),
         );
         self.oracle
@@ -1346,7 +1349,7 @@ impl<
                 .collect();
             let observer_keys = derive_observer_keys(
                 &active_or_joining_node_keys,
-                &self.namespace,
+                &self.observer_domain,
                 self.canonical_state.get_observers_per_validator(),
             );
             let secondary_keys: Vec<_> =

--- a/finalizer/src/config.rs
+++ b/finalizer/src/config.rs
@@ -26,6 +26,10 @@ pub struct FinalizerConfig<C: EngineClient, O: NetworkOracle<PublicKey>, V: Vari
     /// alongside the genesis hash so deposit authorizations are bound to this
     /// specific deployment (not just the EL genesis).
     pub namespace: Vec<u8>,
+    /// The chain bound domain (`chain_domain(config_digest)`) used to derive the
+    /// authorized observer child keys. Must match the domain the live P2P
+    /// observer signer is derived with, or observers will not be authenticated.
+    pub observer_domain: Vec<u8>,
     /// Optional initial state to initialize the finalizer with
     pub initial_state: ConsensusState,
     /// Protocol version for the consensus protocol

--- a/finalizer/src/tests/fork_handling.rs
+++ b/finalizer/src/tests/fork_handling.rs
@@ -168,6 +168,7 @@ fn test_orphaned_block_processed_when_parent_arrives() {
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
             namespace: Vec::new(),
+            observer_domain: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -263,6 +264,7 @@ fn test_fork_aux_data_does_not_finalize_unfinalized_fork_head() {
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
             namespace: Vec::new(),
+            observer_domain: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -371,6 +373,7 @@ fn test_losing_height_waiter_resolves_false_on_conflicting_finalization() {
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
             namespace: Vec::new(),
+            observer_domain: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -460,6 +463,7 @@ fn test_competing_digest_waiter_stays_pending_until_finalization() {
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
             namespace: Vec::new(),
+            observer_domain: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -550,6 +554,7 @@ fn test_finalization_resolves_lower_waiters_and_preserves_future_waiters() {
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
             namespace: Vec::new(),
+            observer_domain: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -640,6 +645,7 @@ fn test_multiple_forks_tracked() {
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
             namespace: Vec::new(),
+            observer_domain: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -726,6 +732,7 @@ fn test_dead_fork_block_discarded() {
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
             namespace: Vec::new(),
+            observer_domain: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -828,6 +835,7 @@ fn test_fork_states_pruned_after_finalization() {
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
             namespace: Vec::new(),
+            observer_domain: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -949,6 +957,7 @@ fn test_orphaned_blocks_pruned_after_finalization() {
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
             namespace: Vec::new(),
+            observer_domain: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -1062,6 +1071,7 @@ fn test_fork_state_reused_when_notarized_then_finalized() {
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
             namespace: Vec::new(),
+            observer_domain: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -1171,6 +1181,7 @@ fn test_competing_fork_pruned_on_finalization() {
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
             namespace: Vec::new(),
+            observer_domain: Vec::new(),
             _variant_marker: PhantomData,
         };
 

--- a/finalizer/src/tests/state_queries.rs
+++ b/finalizer/src/tests/state_queries.rs
@@ -215,6 +215,7 @@ fn test_generate_state_proof_preserves_batch_cardinality_for_missing_keys() {
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
             namespace: Vec::new(),
+            observer_domain: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -309,6 +310,7 @@ fn test_get_latest_epoch() {
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
             namespace: Vec::new(),
+            observer_domain: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -423,6 +425,7 @@ fn test_epoch_boundary_resets_persisted_view() {
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
             namespace: Vec::new(),
+            observer_domain: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -501,6 +504,7 @@ fn test_epoch_boundary_resets_persisted_view() {
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
             namespace: Vec::new(),
+            observer_domain: Vec::new(),
             _variant_marker: PhantomData,
         };
         let (_finalizer2, reloaded_state, _mailbox2, _state_query2) =
@@ -567,6 +571,7 @@ fn test_first_post_epoch_boundary_aux_data_uses_post_transition_state_root() {
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
             namespace: Vec::new(),
+            observer_domain: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -690,6 +695,7 @@ fn test_epoch_boundary_post_transition_root_survives_restart() {
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
             namespace: Vec::new(),
+            observer_domain: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -764,6 +770,7 @@ fn test_epoch_boundary_post_transition_root_survives_restart() {
                     buffered_blocks_warn_threshold: 100,
                     pending_notarized_max: 1000,
                     namespace: Vec::new(),
+                    observer_domain: Vec::new(),
                     _variant_marker: PhantomData,
                 },
             )
@@ -828,6 +835,7 @@ fn test_get_epoch_genesis_hash() {
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
             namespace: Vec::new(),
+            observer_domain: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -929,6 +937,7 @@ fn test_get_epoch_genesis_hash_for_past_epoch() {
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
             namespace: Vec::new(),
+            observer_domain: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -1051,6 +1060,7 @@ fn test_get_epoch_genesis_hash_for_future_epoch() {
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
             namespace: Vec::new(),
+            observer_domain: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -1115,6 +1125,7 @@ fn test_get_aux_data_from_canonical_chain() {
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
             namespace: Vec::new(),
+            observer_domain: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -1190,6 +1201,7 @@ fn test_get_aux_data_returns_none_for_invalid_parent() {
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
             namespace: Vec::new(),
+            observer_domain: Vec::new(),
             _variant_marker: PhantomData,
         };
 

--- a/finalizer/src/tests/syncing.rs
+++ b/finalizer/src/tests/syncing.rs
@@ -200,6 +200,7 @@ fn test_initial_startup_sync_waits_for_valid() {
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
             namespace: Vec::new(),
+            observer_domain: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -273,6 +274,7 @@ fn test_initial_startup_sync_zero_forkchoice_skips_sync() {
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
             namespace: Vec::new(),
+            observer_domain: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -347,6 +349,7 @@ fn test_execute_block_retries_on_syncing() {
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
             namespace: Vec::new(),
+            observer_domain: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -436,6 +439,7 @@ fn test_notarized_block_retries_on_syncing() {
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
             namespace: Vec::new(),
+            observer_domain: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -517,6 +521,7 @@ fn test_checkpoint_startup_full_flow() {
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
             namespace: Vec::new(),
+            observer_domain: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -638,6 +643,7 @@ fn test_finalizer_mailbox_responsive_under_persistent_syncing() {
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
             namespace: Vec::new(),
+            observer_domain: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -760,6 +766,7 @@ fn test_finalizer_mailbox_responsive_during_startup_syncing() {
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
             namespace: Vec::new(),
+            observer_domain: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -845,6 +852,7 @@ fn test_finalizer_shuts_down_when_pending_notarized_cap_is_reached() {
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 2,
             namespace: Vec::new(),
+            observer_domain: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -948,6 +956,7 @@ fn test_finalizer_finalized_buffer_drains_in_order() {
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
             namespace: Vec::new(),
+            observer_domain: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -1043,6 +1052,7 @@ fn test_duplicate_finalized_delivery_is_idempotent() {
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
             namespace: Vec::new(),
+            observer_domain: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -1147,6 +1157,7 @@ fn test_finalized_commit_hash_syncing_buffers_and_retries() {
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
             namespace: Vec::new(),
+            observer_domain: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -1228,6 +1239,7 @@ fn test_finalized_commit_hash_invalid_shuts_down() {
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
             namespace: Vec::new(),
+            observer_domain: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -1298,6 +1310,7 @@ fn test_notarized_commit_hash_invalid_discards_fork() {
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
             namespace: Vec::new(),
+            observer_domain: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -1386,6 +1399,7 @@ fn test_finalized_reuse_path_commits_finalized_forkchoice_and_shuts_down_on_inva
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
             namespace: Vec::new(),
+            observer_domain: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -1473,6 +1487,7 @@ fn test_finalized_reuse_path_buffers_on_syncing() {
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
             namespace: Vec::new(),
+            observer_domain: Vec::new(),
             _variant_marker: PhantomData,
         };
 

--- a/finalizer/src/tests/validator_lifecycle.rs
+++ b/finalizer/src/tests/validator_lifecycle.rs
@@ -228,6 +228,7 @@ fn test_checkpoint_restart_keeps_submitted_exit_request_validator_in_current_epo
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
             namespace: Vec::new(),
+            observer_domain: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -320,6 +321,7 @@ fn test_validator_exit_triggers_cancellation() {
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
             namespace: Vec::new(),
+            observer_domain: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -450,6 +452,7 @@ fn test_finalizer_rejects_finalized_block_with_wrong_parent() {
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
             namespace: Vec::new(),
+            observer_domain: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -586,6 +589,7 @@ fn test_joining_validator_peer_tier_follows_activation() {
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
             namespace: Vec::new(),
+            observer_domain: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -735,6 +739,7 @@ fn epoch_transition_deltas_are_cleared_before_persisted_state_ack() {
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
             namespace: Vec::new(),
+            observer_domain: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -798,6 +803,7 @@ fn epoch_transition_deltas_are_cleared_before_persisted_state_ack() {
                     buffered_blocks_warn_threshold: 100,
                     pending_notarized_max: 1000,
                     namespace: Vec::new(),
+                    observer_domain: Vec::new(),
                     _variant_marker: PhantomData,
                 },
             )
@@ -911,6 +917,7 @@ fn epoch_boundary_commit_failure_withholds_ack_and_shuts_down() {
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
             namespace: Vec::new(),
+            observer_domain: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -992,6 +999,7 @@ fn epoch_boundary_commit_failure_withholds_ack_and_shuts_down() {
                     buffered_blocks_warn_threshold: 100,
                     pending_notarized_max: 1000,
                     namespace: Vec::new(),
+                    observer_domain: Vec::new(),
                     _variant_marker: PhantomData,
                 },
             )
@@ -1059,6 +1067,7 @@ fn last_block_exit_dominates_concurrent_max_stake_reduction() {
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
             namespace: Vec::new(),
+            observer_domain: Vec::new(),
             _variant_marker: PhantomData,
         };
 
@@ -1271,6 +1280,7 @@ fn joining_validator_withdrawal_excludes_it_from_oracle_tracking() {
             buffered_blocks_warn_threshold: 100,
             pending_notarized_max: 1000,
             namespace: Vec::new(),
+            observer_domain: Vec::new(),
             _variant_marker: PhantomData,
         };
 

--- a/node/src/args.rs
+++ b/node/src/args.rs
@@ -541,8 +541,7 @@ async fn run_node_inner(
     // Bind the live p2p authentication domain to immutable chain identity so a
     // peer from a different deployment that reuses this namespace and the same
     // node keys cannot authenticate against us.
-    let p2p_domain =
-        summit_types::chain_domain(genesis.genesis_hash(), genesis.namespace.as_bytes());
+    let p2p_domain = summit_types::chain_domain(genesis.config_digest());
     let namespace = p2p_domain.as_slice();
     let max_message_size = genesis.max_message_size_bytes as u32;
 
@@ -706,8 +705,7 @@ async fn run_node_local_inner(
     // Bind the live p2p authentication domain to immutable chain identity so a
     // peer from a different deployment that reuses this namespace and the same
     // node keys cannot authenticate against us.
-    let p2p_domain =
-        summit_types::chain_domain(genesis.genesis_hash(), genesis.namespace.as_bytes());
+    let p2p_domain = summit_types::chain_domain(genesis.config_digest());
     let namespace = p2p_domain.as_slice();
     let max_message_size = genesis.max_message_size_bytes as u32;
 

--- a/node/src/args.rs
+++ b/node/src/args.rs
@@ -877,7 +877,10 @@ where
     // self-exclusion, broadcast attribution, finalizer self-lookup), and the
     // RPC server reports it instead of the keystore identity and disables
     // keystore-signing methods. It is the public key of the live P2P signer,
-    // passed in by the caller so the two are derived once and cannot drift.
+    // which the caller derives under the chain bound domain
+    // chain_domain(config_digest) and passes in, so the reported key, the live
+    // P2P identity, and the validators' authorized observer set are all derived
+    // once under the same domain and cannot drift.
     let observer_node_key = observer_network_key.as_ref().map(|pk| pk.to_string());
 
     let mut config = EngineConfig::get_engine_config(

--- a/node/src/args.rs
+++ b/node/src/args.rs
@@ -538,7 +538,12 @@ async fn run_node_inner(
         };
 
     let listen = wildcard_listen_for(our_ip, flags.port);
-    let namespace = genesis.namespace.as_bytes();
+    // Bind the live p2p authentication domain to immutable chain identity so a
+    // peer from a different deployment that reuses this namespace and the same
+    // node keys cannot authenticate against us.
+    let p2p_domain =
+        summit_types::chain_domain(genesis.genesis_hash(), genesis.namespace.as_bytes());
+    let namespace = p2p_domain.as_slice();
     let max_message_size = genesis.max_message_size_bytes as u32;
 
     let (engine, p2p, rpc_handle) = if let Some(index) = flags.observer {
@@ -698,7 +703,12 @@ async fn run_node_local_inner(
         };
 
     let listen = wildcard_listen_for(our_ip, flags.port);
-    let namespace = genesis.namespace.as_bytes();
+    // Bind the live p2p authentication domain to immutable chain identity so a
+    // peer from a different deployment that reuses this namespace and the same
+    // node keys cannot authenticate against us.
+    let p2p_domain =
+        summit_types::chain_domain(genesis.genesis_hash(), genesis.namespace.as_bytes());
+    let namespace = p2p_domain.as_slice();
     let max_message_size = genesis.max_message_size_bytes as u32;
 
     let (engine, p2p, rpc_handle) = if let Some(index) = flags.observer {

--- a/node/src/bin/observer.rs
+++ b/node/src/bin/observer.rs
@@ -383,14 +383,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 from_hex_formatted(&master_key_hex).expect("invalid hex in master node key");
             let master_priv_key = PrivateKey::decode(&master_key_bytes[..])
                 .expect("failed to decode master private key");
-            // Observer child keys are namespace-separated (#335); use the same genesis
-            // namespace the validators authorize against so this matches their derived set.
-            let observer_namespace = Genesis::load_from_file(&e2e_genesis_path_str)
-                .expect("failed to load genesis for observer namespace")
-                .namespace;
+            // Observer child keys are separated by domain (#335) under the chain
+            // bound domain chain_domain(config_digest). That is the same domain the
+            // live P2P observer signer and the validators' authorized observer set
+            // use, so this matches their derived set (not the raw genesis namespace).
+            let observer_genesis = Genesis::load_from_file(&e2e_genesis_path_str)
+                .expect("failed to load genesis for observer domain");
+            let observer_domain = summit_types::chain_domain(observer_genesis.config_digest());
             let observer_pubkey = derive_child_public(
                 master_priv_key.public_key(),
-                observer_namespace.as_bytes(),
+                observer_domain.as_slice(),
                 OBSERVER_DERIVE_IDX,
             );
 

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -2,7 +2,6 @@ use crate::keys::read_keys_from_keystore;
 use anyhow::{Context, Result};
 use commonware_cryptography::Signer;
 use commonware_cryptography::bls12381;
-use commonware_utils::from_hex_formatted;
 use governor::Quota;
 use std::{num::NonZeroU32, time::Duration};
 use summit_types::Block;
@@ -113,10 +112,7 @@ impl<C: EngineClient, S: Signer, O: NetworkOracle<S::PublicKey>> EngineConfig<C,
             fetch_concurrent: FETCH_CONCURRENT,
             fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(FETCH_RATE_P2P).unwrap()),
             namespace: genesis.namespace.clone(),
-            genesis_hash: from_hex_formatted(&genesis.eth_genesis_hash)
-                .map(|hash_bytes| hash_bytes.try_into())
-                .expect("bad eth_genesis_hash")
-                .expect("bad eth_genesis_hash"),
+            genesis_hash: genesis.genesis_hash(),
             initial_state,
             checkpoint_last_block,
             checkpoint_finalized_header,

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -62,6 +62,9 @@ pub struct EngineConfig<C: EngineClient, S: Signer, O: NetworkOracle<S::PublicKe
 
     pub namespace: String,
     pub genesis_hash: [u8; 32],
+    /// Digest of the immutable genesis configuration ([`Genesis::config_digest`]),
+    /// used to derive the chain-bound live P2P + consensus domain.
+    pub config_digest: [u8; 32],
 
     /// Initial state given to the finalizer. All other processes should get initial state from the finalizer not the config
     pub initial_state: ConsensusState,
@@ -113,6 +116,7 @@ impl<C: EngineClient, S: Signer, O: NetworkOracle<S::PublicKey>> EngineConfig<C,
             fetch_rate_per_peer: Quota::per_second(NonZeroU32::new(FETCH_RATE_P2P).unwrap()),
             namespace: genesis.namespace.clone(),
             genesis_hash: genesis.genesis_hash(),
+            config_digest: genesis.config_digest(),
             initial_state,
             checkpoint_last_block,
             checkpoint_finalized_header,

--- a/node/src/engine.rs
+++ b/node/src/engine.rs
@@ -144,13 +144,13 @@ where
             .clone()
             .unwrap_or_else(|| cfg.key_store.node_key.public_key());
 
-        // Live consensus + p2p domain, bound to immutable chain identity (EL
-        // genesis hash + protocol version) so consensus certificates and peer
-        // handshakes cannot verify across deployments that merely reuse the same
-        // namespace and validator keys. The finalizer keeps the raw namespace
-        // because deposit_signature_domain folds in the genesis hash itself.
-        let consensus_domain =
-            summit_types::chain_domain(cfg.genesis_hash, cfg.namespace.as_bytes()).to_vec();
+        // Live consensus + p2p domain, bound to immutable chain identity (the
+        // genesis config digest + protocol version) so consensus certificates
+        // and peer handshakes cannot verify across deployments that merely reuse
+        // the same namespace and validator keys. The finalizer keeps the raw
+        // namespace because deposit_signature_domain folds in the genesis hash
+        // itself.
+        let consensus_domain = summit_types::chain_domain(cfg.config_digest).to_vec();
 
         let page_cache = CacheRef::from_pooler(
             &context,

--- a/node/src/engine.rs
+++ b/node/src/engine.rs
@@ -186,6 +186,10 @@ where
                 page_cache: page_cache.clone(),
                 genesis_hash: cfg.genesis_hash,
                 namespace: cfg.namespace.as_bytes().to_vec(),
+                // Observer child keys are derived and authorized under the same
+                // chain bound domain the live P2P observer signer uses, not the
+                // raw namespace (which stays for the deposit signature domain).
+                observer_domain: consensus_domain.clone(),
                 initial_state: cfg.initial_state,
                 protocol_version: PROTOCOL_VERSION,
                 node_public_key: node_public_key.clone(),

--- a/node/src/engine.rs
+++ b/node/src/engine.rs
@@ -144,6 +144,14 @@ where
             .clone()
             .unwrap_or_else(|| cfg.key_store.node_key.public_key());
 
+        // Live consensus + p2p domain, bound to immutable chain identity (EL
+        // genesis hash + protocol version) so consensus certificates and peer
+        // handshakes cannot verify across deployments that merely reuse the same
+        // namespace and validator keys. The finalizer keeps the raw namespace
+        // because deposit_signature_domain folds in the genesis hash itself.
+        let consensus_domain =
+            summit_types::chain_domain(cfg.genesis_hash, cfg.namespace.as_bytes()).to_vec();
+
         let page_cache = CacheRef::from_pooler(
             &context,
             NonZero::new(BUFFER_POOL_PAGE_SIZE).unwrap(),
@@ -151,12 +159,12 @@ where
         );
 
         let scheme_provider = if cfg.force_verifier_only {
-            SummitSchemeProvider::verifier_only(cfg.namespace.as_bytes().to_vec())
+            SummitSchemeProvider::verifier_only(consensus_domain.clone())
         } else {
             let encoded = cfg.key_store.consensus_key.encode();
             let private_scalar = group::Private::decode(&mut encoded.as_ref())
                 .expect("failed to extract scalar from private key");
-            SummitSchemeProvider::new(private_scalar, cfg.namespace.as_bytes().to_vec())
+            SummitSchemeProvider::new(private_scalar, consensus_domain.clone())
         };
 
         let cancellation_token = CancellationToken::new();
@@ -304,7 +312,7 @@ where
             partition_prefix: cfg.partition_prefix.clone(),
             mailbox_size: cfg.mailbox_size,
             view_retention_timeout: ViewDelta::new(cfg.activity_timeout),
-            namespace: cfg.namespace.as_bytes().to_vec(),
+            namespace: consensus_domain.clone(),
             prunable_items_per_section: PRUNABLE_ITEMS_PER_SECTION,
             page_cache: page_cache.clone(),
             replay_buffer: REPLAY_BUFFER,
@@ -332,7 +340,7 @@ where
                 application: application_mailbox.clone(),
                 scheme_provider: scheme_provider.clone(),
                 syncer_mailbox: syncer_mailbox.clone(),
-                namespace: cfg.namespace.as_bytes().to_vec(),
+                namespace: consensus_domain.clone(),
                 muxer_size: cfg.mailbox_size,
                 mailbox_size: cfg.mailbox_size,
                 epocher: epocher.clone(),

--- a/node/src/test_harness/common.rs
+++ b/node/src/test_harness/common.rs
@@ -682,6 +682,10 @@ where
         oracle,
         partition_prefix,
         genesis_hash,
+        // Tests have no full Genesis here; all harness nodes share `genesis_hash`,
+        // so use it as the config digest to keep their derived chain domain
+        // consistent.
+        config_digest: genesis_hash,
         namespace,
         key_store,
         participants,

--- a/node/src/tests/checkpointing/verification.rs
+++ b/node/src/tests/checkpointing/verification.rs
@@ -156,7 +156,7 @@ fn test_checkpoint_verification_fixed_committee() {
             let uid = format!("validator_{public_key}");
 
             let engine_client = engine_client_network.create_client(uid.clone());
-            let config = get_default_engine_config(
+            let mut config = get_default_engine_config(
                 engine_client,
                 SimulatedOracle::new(oracle.clone()),
                 uid.clone(),
@@ -166,6 +166,11 @@ fn test_checkpoint_verification_fixed_committee() {
                 validators.clone(),
                 initial_state.clone(),
             );
+            // The harness builds the engine config from genesis_hash + namespace,
+            // but these tests verify the produced checkpoint against the full
+            // `genesis`. Align the engine's chain-bound consensus domain with the
+            // verifier by deriving it from the same genesis config digest.
+            config.config_digest = genesis.config_digest();
             let engine = Engine::new(context.with_label(&uid), config).await;
             consensus_state_queries.insert(idx, engine.finalizer_mailbox.clone());
 
@@ -551,7 +556,7 @@ fn test_checkpoint_verification_dynamic_committee() {
             let uid = format!("validator_{public_key}");
 
             let engine_client = engine_client_network.create_client(uid.clone());
-            let config = get_default_engine_config(
+            let mut config = get_default_engine_config(
                 engine_client,
                 SimulatedOracle::new(oracle.clone()),
                 uid.clone(),
@@ -561,6 +566,11 @@ fn test_checkpoint_verification_dynamic_committee() {
                 validators.clone(),
                 initial_state.clone(),
             );
+            // The harness builds the engine config from genesis_hash + namespace,
+            // but these tests verify the produced checkpoint against the full
+            // `genesis`. Align the engine's chain-bound consensus domain with the
+            // verifier by deriving it from the same genesis config digest.
+            config.config_digest = genesis.config_digest();
             let engine = Engine::new(context.with_label(&uid), config).await;
             consensus_state_queries.insert(idx, engine.finalizer_mailbox.clone());
 

--- a/node/src/tests/observer.rs
+++ b/node/src/tests/observer.rs
@@ -71,18 +71,29 @@ fn test_observer_reaches_end_height() {
         let master_priv_key = validator_key_stores[0].node_key.clone();
         let master_consensus_key = validator_key_stores[0].consensus_key.clone();
         let master_pub_key = master_priv_key.public_key();
-        // Must match the namespace the nodes run with (below), so the derived observer
-        // identity matches the finalizer's authorized observer set (#335).
-        let observer_namespace = b"_SUMMIT";
+        // Observer keys are derived under the chain bound domain
+        // chain_domain(config_digest), the same domain the finalizer authorizes
+        // observers under (#335). The harness uses genesis_hash as the
+        // config_digest (see get_default_engine_config), so derive against
+        // chain_domain(genesis_hash) to match the validators' authorized set.
+        let observer_config_digest: [u8; 32] = from_hex_formatted(common::GENESIS_HASH)
+            .expect("genesis hash hex")
+            .try_into()
+            .expect("genesis hash len");
+        let observer_domain = summit_types::chain_domain(observer_config_digest);
         let observer_signer = ExtPrivateKey::derive_child_signer(
             &master_priv_key,
-            observer_namespace,
+            observer_domain.as_slice(),
             observer_index,
         );
         let observer_pubkey = observer_signer.public_key();
         assert_eq!(
             observer_pubkey,
-            derive_child_public(master_pub_key.clone(), observer_namespace, observer_index),
+            derive_child_public(
+                master_pub_key.clone(),
+                observer_domain.as_slice(),
+                observer_index
+            ),
             "signer and public-only derivation must agree"
         );
 
@@ -257,11 +268,21 @@ fn test_observer_backfills_from_parent_validator() {
             consensus_key: validator_key_stores[0].consensus_key.clone(),
         };
         let parent_pubkey = parent_key_store.node_key.public_key();
-        // Must match the namespace the nodes run with so the derived observer
-        // identity matches the engine's namespace-bound child key (#335).
-        let observer_namespace = b"_SUMMIT";
-        let observer_pubkey =
-            derive_child_public(parent_pubkey.clone(), observer_namespace, observer_index);
+        // Observer keys are derived under the chain bound domain
+        // chain_domain(config_digest), the same domain the finalizer authorizes
+        // observers under (#335). The harness uses genesis_hash as the
+        // config_digest (see get_default_engine_config), so derive against
+        // chain_domain(genesis_hash) to match the validators' authorized set.
+        let observer_config_digest: [u8; 32] = from_hex_formatted(common::GENESIS_HASH)
+            .expect("genesis hash hex")
+            .try_into()
+            .expect("genesis hash len");
+        let observer_domain = summit_types::chain_domain(observer_config_digest);
+        let observer_pubkey = derive_child_public(
+            parent_pubkey.clone(),
+            observer_domain.as_slice(),
+            observer_index,
+        );
 
         // Register all nodes, but link the observer ONLY to its parent.
         let mut all_pubkeys = validator_pubkeys.clone();

--- a/types/src/checkpoint.rs
+++ b/types/src/checkpoint.rs
@@ -323,7 +323,11 @@ pub fn verify_checkpoint_chain_with_weak_subjectivity(
         .get_validators()
         .map_err(|e| CheckpointVerificationError::ValidatorSetError(e.to_string()))?;
 
-    let namespace = genesis.namespace.as_bytes().to_vec();
+    // The finalization certificates were produced over the live consensus
+    // domain, which is bound to immutable chain identity. The verifier must
+    // reconstruct that same domain (see `chain_domain`) rather than the raw
+    // configured namespace, or the aggregate signatures will not verify.
+    let namespace = crate::chain_domain(genesis_hash.0, genesis.namespace.as_bytes()).to_vec();
 
     // Build the participant set as Vec<(ed25519::PublicKey, MinPk::Public)>
     // so we can mutate it across epochs

--- a/types/src/checkpoint.rs
+++ b/types/src/checkpoint.rs
@@ -327,7 +327,7 @@ pub fn verify_checkpoint_chain_with_weak_subjectivity(
     // domain, which is bound to immutable chain identity. The verifier must
     // reconstruct that same domain (see `chain_domain`) rather than the raw
     // configured namespace, or the aggregate signatures will not verify.
-    let namespace = crate::chain_domain(genesis_hash.0, genesis.namespace.as_bytes()).to_vec();
+    let namespace = crate::chain_domain(genesis.config_digest()).to_vec();
 
     // Build the participant set as Vec<(ed25519::PublicKey, MinPk::Public)>
     // so we can mutate it across epochs
@@ -1425,10 +1425,13 @@ mod tests {
         participants.sort_by(|lhs, rhs| lhs.0.cmp(&rhs.0));
         let signers: BiMap<ed25519::PublicKey, <MinPk as Variant>::Public> =
             participants.into_iter().try_collect().unwrap();
+        // Certificates must be signed over the same chain-bound consensus domain
+        // that `verify_checkpoint_chain` reconstructs, not the raw namespace.
+        let signing_domain = crate::chain_domain(genesis.config_digest());
         let schemes: Vec<_> = group_privates
             .into_iter()
             .filter_map(|private| {
-                MultisigScheme::signer(namespace.as_bytes(), signers.clone(), private)
+                MultisigScheme::signer(signing_domain.as_slice(), signers.clone(), private)
             })
             .collect();
 

--- a/types/src/genesis.rs
+++ b/types/src/genesis.rs
@@ -142,6 +142,16 @@ impl TryFrom<&GenesisValidator> for Validator {
 }
 
 impl Genesis {
+    /// The EL genesis hash as raw bytes, the immutable identity of this chain
+    /// deployment. Panics if `eth_genesis_hash` is not a 32-byte hex string;
+    /// genesis files are operator-provided and validated at load time.
+    pub fn genesis_hash(&self) -> [u8; 32] {
+        from_hex_formatted(&self.eth_genesis_hash)
+            .map(|bytes| bytes.try_into())
+            .expect("bad eth_genesis_hash")
+            .expect("bad eth_genesis_hash")
+    }
+
     pub fn load_from_file(path: &str) -> Result<Self, Box<dyn std::error::Error>> {
         let file_string = std::fs::read_to_string(path)?;
         let genesis: Genesis = toml::from_str(&file_string)?;

--- a/types/src/genesis.rs
+++ b/types/src/genesis.rs
@@ -7,15 +7,18 @@ use alloy_primitives::Address;
 use anyhow::Context;
 use commonware_codec::DecodeExt;
 use commonware_cryptography::bls12381;
+use commonware_cryptography::{Hasher as _, Sha256};
 use commonware_utils::{from_hex, from_hex_formatted};
 use serde::{Deserialize, Serialize};
+use ssz::Encode as _;
 use std::net::SocketAddr;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ssz_derive::Encode)]
 pub struct Genesis {
     /// List of all validators at genesis block
     pub validators: Vec<GenesisValidator>,
     /// The hash of the genesis file used for the EVM client
+    #[ssz(with = "ssz_string")]
     pub eth_genesis_hash: String,
     /// Amount of time to wait for a leader to propose a payload
     /// in a view.
@@ -41,6 +44,7 @@ pub struct Genesis {
     /// this may include additional metadata, data from the codec, and/or cryptographic signatures.
     pub max_message_size_bytes: u64,
     /// Prefix for all signed messages to prevent replay attacks.
+    #[ssz(with = "ssz_string")]
     pub namespace: String,
     /// Minimum validator stake in gwei
     pub validator_minimum_stake: u64,
@@ -54,6 +58,7 @@ pub struct Genesis {
     pub allowed_timestamp_future_ms: u64,
     /// Address that receives treasury funds. Defaults to the zero address.
     #[serde(default = "default_treasury_address")]
+    #[ssz(with = "ssz_string")]
     pub treasury_address: String,
     /// Maximum number of validators that can join per epoch via deposits.
     #[serde(default = "default_max_deposits_per_epoch")]
@@ -93,11 +98,16 @@ fn default_minimum_validator_count() -> u64 {
     DEFAULT_MINIMUM_VALIDATOR_COUNT
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ssz_derive::Encode)]
 pub struct GenesisValidator {
+    #[ssz(with = "ssz_string")]
     pub node_public_key: String,
+    #[ssz(with = "ssz_string")]
     pub consensus_public_key: String,
+    /// Network topology, not consensus identity: excluded from `config_digest`.
+    #[ssz(skip_serializing)]
     pub ip_address: String,
+    #[ssz(with = "ssz_string")]
     pub withdrawal_credentials: String,
 }
 
@@ -141,6 +151,31 @@ impl TryFrom<&GenesisValidator> for Validator {
     }
 }
 
+/// Domain tag for [`Genesis::config_digest`], separating it from any other
+/// SHA-256 use over genesis bytes.
+const GENESIS_CONFIG_DOMAIN_TAG: &[u8] = b"summit-genesis-config-v1";
+
+/// `#[ssz(with = "ssz_string")]` codec that lets `ssz_derive` encode a `String`
+/// field as an SSZ `List[uint8]` (its raw UTF-8 bytes). Only the `encode` side
+/// is provided because `Genesis` derives `ssz::Encode` solely to feed
+/// [`Genesis::config_digest`]; it is never SSZ-decoded.
+mod ssz_string {
+    pub mod encode {
+        pub fn is_ssz_fixed_len() -> bool {
+            false
+        }
+        pub fn ssz_fixed_len() -> usize {
+            ssz::BYTES_PER_LENGTH_OFFSET
+        }
+        pub fn ssz_bytes_len(value: &str) -> usize {
+            value.len()
+        }
+        pub fn ssz_append(value: &String, buf: &mut Vec<u8>) {
+            buf.extend_from_slice(value.as_bytes());
+        }
+    }
+}
+
 impl Genesis {
     /// The EL genesis hash as raw bytes, the immutable identity of this chain
     /// deployment. Panics if `eth_genesis_hash` is not a 32-byte hex string;
@@ -150,6 +185,26 @@ impl Genesis {
             .map(|bytes| bytes.try_into())
             .expect("bad eth_genesis_hash")
             .expect("bad eth_genesis_hash")
+    }
+
+    /// Deterministic digest over the immutable Summit genesis configuration that
+    /// defines this chain's identity: the EL genesis hash, namespace, every
+    /// consensus/economic parameter fixed at launch, and the genesis validator
+    /// set (node key, consensus key, withdrawal credentials). Used to derive the
+    /// live P2P and consensus [`chain_domain`](crate::chain_domain), so two
+    /// deployments that differ in ANY of these fields derive distinct domains
+    /// and cannot cross-authenticate peers or cross-verify consensus
+    /// certificates.
+    ///
+    /// The bytes come from the `ssz::Encode` derive on `Genesis` (canonical,
+    /// spec-stable, and complete — a new field is automatically included unless
+    /// explicitly `#[ssz(skip_serializing)]`'d). Per-validator `ip_address` is
+    /// skipped: it is network topology, not consensus identity.
+    pub fn config_digest(&self) -> [u8; 32] {
+        let mut hasher = Sha256::new();
+        hasher.update(GENESIS_CONFIG_DOMAIN_TAG);
+        hasher.update(&self.as_ssz_bytes());
+        hasher.finalize().0
     }
 
     pub fn load_from_file(path: &str) -> Result<Self, Box<dyn std::error::Error>> {
@@ -488,5 +543,127 @@ mod tests {
         let mut genesis = Genesis::load_from_file("../example_genesis.toml").unwrap();
         genesis.minimum_validator_count = 0;
         assert!(genesis.validate().is_err());
+    }
+
+    #[test]
+    fn config_digest_is_deterministic() {
+        let genesis = Genesis::load_from_file("../example_genesis.toml").unwrap();
+        assert_eq!(genesis.config_digest(), genesis.config_digest());
+    }
+
+    /// Every identity-bearing genesis field must change the digest, so two
+    /// deployments that differ in any of them derive distinct chain domains.
+    #[test]
+    fn config_digest_separates_every_identity_field() {
+        let base = Genesis::load_from_file("../example_genesis.toml").unwrap();
+        let digest = base.config_digest();
+
+        let cases: Vec<(&str, Box<dyn Fn(&mut Genesis)>)> = vec![
+            (
+                "eth_genesis_hash",
+                Box::new(|g| g.eth_genesis_hash = format!("0x{}", "11".repeat(32))),
+            ),
+            (
+                "namespace",
+                Box::new(|g| g.namespace = "different-ns".into()),
+            ),
+            ("leader_timeout_ms", Box::new(|g| g.leader_timeout_ms += 1)),
+            (
+                "notarization_timeout_ms",
+                Box::new(|g| g.notarization_timeout_ms += 1),
+            ),
+            (
+                "nullify_timeout_ms",
+                Box::new(|g| g.nullify_timeout_ms += 1),
+            ),
+            (
+                "activity_timeout_views",
+                Box::new(|g| g.activity_timeout_views += 1),
+            ),
+            (
+                "skip_timeout_views",
+                Box::new(|g| g.skip_timeout_views += 1),
+            ),
+            (
+                "max_message_size_bytes",
+                Box::new(|g| g.max_message_size_bytes += 1),
+            ),
+            (
+                "validator_minimum_stake",
+                Box::new(|g| g.validator_minimum_stake += 1),
+            ),
+            (
+                "validator_maximum_stake",
+                Box::new(|g| g.validator_maximum_stake += 1),
+            ),
+            ("blocks_per_epoch", Box::new(|g| g.blocks_per_epoch += 1)),
+            (
+                "allowed_timestamp_future_ms",
+                Box::new(|g| g.allowed_timestamp_future_ms += 1),
+            ),
+            (
+                "treasury_address",
+                Box::new(|g| g.treasury_address = format!("0x{}", "22".repeat(20))),
+            ),
+            (
+                "max_deposits_per_epoch",
+                Box::new(|g| g.max_deposits_per_epoch += 1),
+            ),
+            (
+                "max_withdrawals_per_epoch",
+                Box::new(|g| g.max_withdrawals_per_epoch += 1),
+            ),
+            (
+                "observers_per_validator",
+                Box::new(|g| g.observers_per_validator += 1),
+            ),
+            (
+                "minimum_validator_count",
+                Box::new(|g| g.minimum_validator_count += 1),
+            ),
+            (
+                "validator consensus key",
+                Box::new(|g| {
+                    g.validators[0].consensus_public_key = format!("0x{}", "33".repeat(48))
+                }),
+            ),
+            (
+                "validator node key",
+                Box::new(|g| g.validators[0].node_public_key = format!("0x{}", "44".repeat(32))),
+            ),
+            (
+                "validator withdrawal credentials",
+                Box::new(|g| {
+                    g.validators[0].withdrawal_credentials = format!("0x{}", "55".repeat(20))
+                }),
+            ),
+            (
+                "validator set size",
+                Box::new(|g| {
+                    g.validators.pop();
+                }),
+            ),
+        ];
+
+        for (label, mutate) in cases {
+            let mut g = base.clone();
+            mutate(&mut g);
+            assert_ne!(
+                g.config_digest(),
+                digest,
+                "config_digest must change when `{label}` changes"
+            );
+        }
+    }
+
+    /// A validator's `ip_address` is network topology, not consensus identity,
+    /// so it is excluded from the digest: changing it must NOT change identity.
+    #[test]
+    fn config_digest_excludes_ip_address() {
+        let base = Genesis::load_from_file("../example_genesis.toml").unwrap();
+        let digest = base.config_digest();
+        let mut g = base.clone();
+        g.validators[0].ip_address = "127.0.0.1:65000".into();
+        assert_eq!(g.config_digest(), digest);
     }
 }

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -43,6 +43,28 @@ pub type Activity = CActivity<Signature, Digest>;
 
 pub const PROTOCOL_VERSION: u32 = 1;
 const DEPOSIT_DOMAIN_TAG: &[u8] = b"summit-deposit-v1";
+const CHAIN_DOMAIN_TAG: &[u8] = b"summit-chain-v1";
+
+/// Domain for live peer authentication and BLS consensus signatures, bound to
+/// the immutable identity of this chain deployment: the protocol version, the
+/// EL genesis hash, AND the configured `namespace`.
+///
+/// The configured `namespace` alone is mutable operator input, so deriving the
+/// live P2P and consensus domains from it directly lets a separate deployment
+/// that reuses the same namespace and validator keys authenticate peers and
+/// verify consensus certificates across networks. Folding the genesis hash and
+/// protocol version into the domain ties both to immutable chain identity, so a
+/// handshake or certificate from one deployment cannot verify against another.
+pub fn chain_domain(genesis_hash: [u8; 32], namespace: &[u8]) -> [u8; 32] {
+    let mut domain_data = Vec::with_capacity(CHAIN_DOMAIN_TAG.len() + 4 + 32 + 4 + namespace.len());
+    domain_data.extend_from_slice(CHAIN_DOMAIN_TAG);
+    domain_data.extend_from_slice(&PROTOCOL_VERSION.to_le_bytes());
+    domain_data.extend_from_slice(&genesis_hash);
+    // Length-prefix the variable-length namespace so the domain is unambiguous.
+    domain_data.extend_from_slice(&(namespace.len() as u32).to_le_bytes());
+    domain_data.extend_from_slice(namespace);
+    Sha256::hash(&domain_data).0
+}
 
 /// Domain for deposit-authorization signatures, bound to the full Summit
 /// deployment boundary: the EL genesis hash AND the Summit `namespace`.
@@ -77,3 +99,71 @@ pub use commonware_cryptography::bls12381;
 pub type PublicKey = commonware_cryptography::ed25519::PublicKey;
 pub type PrivateKey = commonware_cryptography::ed25519::PrivateKey;
 pub type Signature = commonware_cryptography::ed25519::Signature;
+
+#[cfg(test)]
+mod chain_domain_tests {
+    use super::{chain_domain, deposit_signature_domain};
+
+    const NS: &[u8] = b"_SUMMIT";
+
+    #[test]
+    fn chain_domain_is_deterministic() {
+        let g = [7u8; 32];
+        assert_eq!(chain_domain(g, NS), chain_domain(g, NS));
+    }
+
+    #[test]
+    fn chain_domain_separates_genesis_hash() {
+        // Same namespace and validator keys, different chain: a peer handshake
+        // or consensus certificate from one deployment must not verify against
+        // the other, so the domains must differ.
+        assert_ne!(chain_domain([1u8; 32], NS), chain_domain([2u8; 32], NS));
+    }
+
+    #[test]
+    fn chain_domain_separates_namespace() {
+        let g = [7u8; 32];
+        assert_ne!(chain_domain(g, b"network-a"), chain_domain(g, b"network-b"));
+    }
+
+    #[test]
+    fn chain_domain_namespace_is_unambiguous() {
+        // Length-prefixing prevents a boundary shift between two namespaces from
+        // colliding on the same domain.
+        let g = [7u8; 32];
+        assert_ne!(chain_domain(g, b"ab"), chain_domain(g, b"a"));
+        assert_ne!(chain_domain(g, b"aab"), chain_domain(g, b"aa"));
+    }
+
+    #[test]
+    fn chain_domain_is_distinct_from_deposit_domain() {
+        // The live consensus/p2p domain and the deposit-authorization domain are
+        // separate trust contexts even for identical chain inputs.
+        let g = [7u8; 32];
+        assert_ne!(chain_domain(g, NS), deposit_signature_domain(g, NS).0);
+    }
+
+    #[test]
+    fn chain_domain_blocks_cross_deployment_signature_replay() {
+        use crate::PrivateKey;
+        use commonware_cryptography::{Signer, Verifier};
+        use commonware_math::algebra::Random;
+        use rand_core::OsRng;
+
+        // One validator node key and one namespace, deployed on two chains that
+        // differ only in their genesis hash.
+        let key = PrivateKey::random(&mut OsRng);
+        let pk = key.public_key();
+        let msg = b"peer-handshake";
+
+        let domain_a = chain_domain([1u8; 32], NS);
+        let domain_b = chain_domain([2u8; 32], NS);
+
+        // A signature scoped to chain A's live domain authenticates on chain A,
+        // but cannot be replayed against chain B even with the same key and
+        // namespace, because the live domain carries the genesis hash.
+        let sig = key.sign(domain_a.as_slice(), msg);
+        assert!(pk.verify(domain_a.as_slice(), msg, &sig));
+        assert!(!pk.verify(domain_b.as_slice(), msg, &sig));
+    }
+}

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -46,23 +46,23 @@ const DEPOSIT_DOMAIN_TAG: &[u8] = b"summit-deposit-v1";
 const CHAIN_DOMAIN_TAG: &[u8] = b"summit-chain-v1";
 
 /// Domain for live peer authentication and BLS consensus signatures, bound to
-/// the immutable identity of this chain deployment: the protocol version, the
-/// EL genesis hash, AND the configured `namespace`.
+/// the immutable identity of this chain deployment: the protocol version and
+/// the genesis config digest (see [`crate::genesis::Genesis::config_digest`]).
 ///
-/// The configured `namespace` alone is mutable operator input, so deriving the
-/// live P2P and consensus domains from it directly lets a separate deployment
-/// that reuses the same namespace and validator keys authenticate peers and
-/// verify consensus certificates across networks. Folding the genesis hash and
-/// protocol version into the domain ties both to immutable chain identity, so a
-/// handshake or certificate from one deployment cannot verify against another.
-pub fn chain_domain(genesis_hash: [u8; 32], namespace: &[u8]) -> [u8; 32] {
-    let mut domain_data = Vec::with_capacity(CHAIN_DOMAIN_TAG.len() + 4 + 32 + 4 + namespace.len());
+/// The config digest folds in the EL genesis hash, the configured `namespace`,
+/// the genesis validator set, and every consensus/economic parameter fixed at
+/// launch. Any of those is mutable operator input, so deriving the live P2P and
+/// consensus domains from them directly lets a separate deployment that reuses
+/// the same configuration authenticate peers and verify consensus certificates
+/// across networks. Folding the config digest and protocol version into the
+/// domain ties both to immutable chain identity, so a handshake or certificate
+/// from one deployment cannot verify against another that differs in any
+/// identity-bearing genesis field.
+pub fn chain_domain(config_digest: [u8; 32]) -> [u8; 32] {
+    let mut domain_data = Vec::with_capacity(CHAIN_DOMAIN_TAG.len() + 4 + 32);
     domain_data.extend_from_slice(CHAIN_DOMAIN_TAG);
     domain_data.extend_from_slice(&PROTOCOL_VERSION.to_le_bytes());
-    domain_data.extend_from_slice(&genesis_hash);
-    // Length-prefix the variable-length namespace so the domain is unambiguous.
-    domain_data.extend_from_slice(&(namespace.len() as u32).to_le_bytes());
-    domain_data.extend_from_slice(namespace);
+    domain_data.extend_from_slice(&config_digest);
     Sha256::hash(&domain_data).0
 }
 
@@ -108,31 +108,18 @@ mod chain_domain_tests {
 
     #[test]
     fn chain_domain_is_deterministic() {
-        let g = [7u8; 32];
-        assert_eq!(chain_domain(g, NS), chain_domain(g, NS));
+        let d = [7u8; 32];
+        assert_eq!(chain_domain(d), chain_domain(d));
     }
 
     #[test]
-    fn chain_domain_separates_genesis_hash() {
-        // Same namespace and validator keys, different chain: a peer handshake
-        // or consensus certificate from one deployment must not verify against
-        // the other, so the domains must differ.
-        assert_ne!(chain_domain([1u8; 32], NS), chain_domain([2u8; 32], NS));
-    }
-
-    #[test]
-    fn chain_domain_separates_namespace() {
-        let g = [7u8; 32];
-        assert_ne!(chain_domain(g, b"network-a"), chain_domain(g, b"network-b"));
-    }
-
-    #[test]
-    fn chain_domain_namespace_is_unambiguous() {
-        // Length-prefixing prevents a boundary shift between two namespaces from
-        // colliding on the same domain.
-        let g = [7u8; 32];
-        assert_ne!(chain_domain(g, b"ab"), chain_domain(g, b"a"));
-        assert_ne!(chain_domain(g, b"aab"), chain_domain(g, b"aa"));
+    fn chain_domain_separates_config_digest() {
+        // Different chain identity (genesis config digest) => different domain,
+        // so a peer handshake or consensus certificate from one deployment must
+        // not verify against the other. Per-field separation (genesis hash,
+        // namespace, params, validators) is covered by the `config_digest` tests
+        // in `genesis.rs`.
+        assert_ne!(chain_domain([1u8; 32]), chain_domain([2u8; 32]));
     }
 
     #[test]
@@ -140,7 +127,7 @@ mod chain_domain_tests {
         // The live consensus/p2p domain and the deposit-authorization domain are
         // separate trust contexts even for identical chain inputs.
         let g = [7u8; 32];
-        assert_ne!(chain_domain(g, NS), deposit_signature_domain(g, NS).0);
+        assert_ne!(chain_domain(g), deposit_signature_domain(g, NS).0);
     }
 
     #[test]
@@ -150,18 +137,17 @@ mod chain_domain_tests {
         use commonware_math::algebra::Random;
         use rand_core::OsRng;
 
-        // One validator node key and one namespace, deployed on two chains that
-        // differ only in their genesis hash.
         let key = PrivateKey::random(&mut OsRng);
         let pk = key.public_key();
         let msg = b"peer-handshake";
 
-        let domain_a = chain_domain([1u8; 32], NS);
-        let domain_b = chain_domain([2u8; 32], NS);
+        // Two chains with distinct genesis config digests.
+        let domain_a = chain_domain([1u8; 32]);
+        let domain_b = chain_domain([2u8; 32]);
 
         // A signature scoped to chain A's live domain authenticates on chain A,
-        // but cannot be replayed against chain B even with the same key and
-        // namespace, because the live domain carries the genesis hash.
+        // but cannot be replayed against chain B, because the live domain carries
+        // the chain's config digest.
         let sig = key.sign(domain_a.as_slice(), msg);
         assert!(pk.verify(domain_a.as_slice(), msg, &sig));
         assert!(!pk.verify(domain_b.as_slice(), msg, &sig));


### PR DESCRIPTION
Addresses https://github.com/SeismicSystems/summit/issues/227.

Changes:
- Add `chain_domain(genesis_hash, namespace)` in `types/src/lib.rs`: `H("summit-chain-v1" || PROTOCOL_VERSION || genesis_hash || len(ns) || ns)`, mirroring `deposit_signature_domain`.
- Add `Genesis::genesis_hash()` to centralize `eth_genesis_hash` parsing; reuse it in `node/src/config.rs`.
- `node/src/engine.rs`: derive the consensus domain once in `Engine::new` and use it for the BLS scheme provider (signer and verifier) and the syncer/orchestrator namespace fields.
- `node/src/args.rs`: derive the same domain for the P2P authentication namespace at both node startup paths.
- `types/src/checkpoint.rs`: reconstruct the same domain in `verify_checkpoint_chain` so finalization certificates still verify.
- Keep the finalizer and RPC namespaces raw, since `deposit_signature_domain` already folds in the genesis hash separately.
- Add unit tests.