### PR TITLE
fix: disable validator-keystore RPC identity surfaces in observer mode

### DIFF
--- a/node/src/args.rs
+++ b/node/src/args.rs
@@ -750,6 +750,16 @@ where
         authenticated::discovery::Network::new(context.with_label("network"), p2p_cfg);
 
     let oracle = DiscoveryOracle::new(oracle);
+
+    // In observer mode the live P2P identity is this derived child key, not
+    // the master node key; the RPC server reports it instead of the keystore
+    // identity and disables keystore-signing methods.
+    let observer_node_key = flags.observer.map(|index| {
+        ExtPrivateKey::derive_child_signer(&key_store.node_key, index)
+            .public_key()
+            .to_string()
+    });
+
     let mut config = EngineConfig::get_engine_config(
         engine_client,
         oracle,
@@ -809,6 +819,7 @@ where
             admin_rpc_port,
             rpc_body_limits,
             stop_signal,
+            observer_node_key,
             #[cfg(feature = "permissioned")]
             paused,
         )

--- a/rpc/src/api.rs
+++ b/rpc/src/api.rs
@@ -91,7 +91,9 @@ pub trait SummitPermissionedApi {
 /// Admin-only RPC surface. Must be served on a localhost-bound listener.
 ///
 /// `getDepositSignature` uses the node's local validator private keys to sign
-/// caller-supplied deposit data.
+/// caller-supplied deposit data. It is disabled on observer nodes
+/// (`--observer`), whose live P2P identity is a derived child key rather than
+/// the master node key this method signs for.
 #[rpc(server, client)]
 pub trait SummitAdminApi {
     #[method(name = "getDepositSignature")]

--- a/rpc/src/error.rs
+++ b/rpc/src/error.rs
@@ -14,6 +14,7 @@ pub enum RpcError {
     IoError(String),
     InvalidKey(String),
     Internal(String),
+    DisabledInObserverMode,
     #[cfg(feature = "permissioned")]
     InvalidAdminAddress(String),
     #[cfg(feature = "permissioned")]
@@ -58,6 +59,13 @@ impl From<RpcError> for ErrorObjectOwned {
                 ErrorObjectOwned::owned(3002, "Invalid key descriptor", Some(msg))
             }
             RpcError::Internal(msg) => ErrorObjectOwned::owned(5000, "Internal error", Some(msg)),
+            RpcError::DisabledInObserverMode => ErrorObjectOwned::owned(
+                4003,
+                "Method disabled in observer mode",
+                Some(
+                    "this node runs with --observer and does not sign with the validator keystore",
+                ),
+            ),
             #[cfg(feature = "permissioned")]
             RpcError::InvalidAdminAddress(msg) => {
                 ErrorObjectOwned::owned(4000, "Invalid admin address", Some(msg))

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -57,6 +57,7 @@ pub async fn start_rpc_server(
     admin_port: u16,
     body_limits: RpcBodyLimits,
     stop_signal: Signal,
+    observer_node_key: Option<String>,
     #[cfg(feature = "permissioned")] paused: Arc<AtomicBool>,
 ) -> anyhow::Result<()> {
     let rpc_impl = SummitRpcServer::new(
@@ -64,6 +65,7 @@ pub async fn start_rpc_server(
         finalizer_mailbox,
         genesis_hash,
         &namespace,
+        observer_node_key,
         #[cfg(feature = "permissioned")]
         paused,
     );
@@ -131,6 +133,9 @@ pub async fn start_rpc_server_with_handle(
         finalizer_mailbox,
         genesis_hash,
         &namespace,
+        // This helper is only used by tests of validator-mode behavior, so
+        // observer mode is irrelevant here.
+        None,
         #[cfg(feature = "permissioned")]
         paused,
     );
@@ -160,6 +165,7 @@ pub async fn start_rpc_server_with_handle(
 /// handles + bound addresses for both. Used by tests that exercise the
 /// admin (localhost-only) RPC surface. Passing `0` for either port asks
 /// the OS to allocate a free port.
+#[allow(clippy::too_many_arguments)]
 pub async fn start_rpc_server_pair_with_handle(
     finalizer_mailbox: FinalizerMailbox<MultisigScheme, Block>,
     key_store_path: String,
@@ -167,6 +173,7 @@ pub async fn start_rpc_server_pair_with_handle(
     namespace: Vec<u8>,
     port: u16,
     admin_port: u16,
+    observer_node_key: Option<String>,
     #[cfg(feature = "permissioned")] paused: Arc<AtomicBool>,
 ) -> anyhow::Result<RpcHandles> {
     let rpc_impl = SummitRpcServer::new(
@@ -174,6 +181,7 @@ pub async fn start_rpc_server_pair_with_handle(
         finalizer_mailbox,
         genesis_hash,
         &namespace,
+        observer_node_key,
         #[cfg(feature = "permissioned")]
         paused,
     );

--- a/rpc/src/server.rs
+++ b/rpc/src/server.rs
@@ -34,6 +34,12 @@ pub struct SummitRpcServer {
     key_store_path: String,
     finalizer_mailbox: FinalizerMailbox<MultisigScheme, Block>,
     deposit_signature_domain: Digest,
+    /// The derived child public key (hex) used as the live P2P identity when
+    /// the node runs with `--observer`; `None` on validator nodes. Observers
+    /// report this key instead of the master keystore identity and must not
+    /// sign with the validator keystore, so keystore-signing methods are
+    /// disabled when this is set.
+    observer_node_key: Option<String>,
     #[cfg(feature = "permissioned")]
     paused: Arc<AtomicBool>,
 }
@@ -44,12 +50,14 @@ impl SummitRpcServer {
         finalizer_mailbox: FinalizerMailbox<MultisigScheme, Block>,
         genesis_hash: [u8; 32],
         namespace: &[u8],
+        observer_node_key: Option<String>,
         #[cfg(feature = "permissioned")] paused: Arc<AtomicBool>,
     ) -> Self {
         Self {
             key_store_path,
             finalizer_mailbox,
             deposit_signature_domain: deposit_signature_domain(genesis_hash, namespace),
+            observer_node_key,
             #[cfg(feature = "permissioned")]
             paused,
         }
@@ -63,6 +71,16 @@ impl SummitApiServer for SummitRpcServer {
     }
 
     async fn get_public_keys(&self) -> RpcResult<PublicKeysResponse> {
+        // An observer's live P2P identity is the derived child key and it
+        // never acts as a consensus participant; report that key with no
+        // consensus key rather than the validator master identity.
+        if let Some(observer_node_key) = &self.observer_node_key {
+            return Ok(PublicKeysResponse {
+                node: observer_node_key.clone(),
+                consensus: String::new(),
+            });
+        }
+
         let key_paths = KeyPaths::new(self.key_store_path.clone());
 
         let node = key_paths.node_public_key().map_err(|e| {
@@ -330,6 +348,13 @@ impl SummitAdminApiServer for SummitRpcServer {
         amount: u64,
         address: String,
     ) -> RpcResult<DepositTransactionResponse> {
+        // An observer's live P2P identity is a derived child key, not the
+        // master node key this method would sign for — refuse rather than
+        // produce a deposit binding the master validator identity.
+        if self.observer_node_key.is_some() {
+            return Err(RpcError::DisabledInObserverMode.into());
+        }
+
         let mut withdrawal_credentials = [0u8; 32];
         withdrawal_credentials[0] = 0x01;
 

--- a/rpc/tests/integration_test.rs
+++ b/rpc/tests/integration_test.rs
@@ -16,6 +16,20 @@ use utils::{
 
 const TEST_GENESIS_HASH: [u8; 32] = [7u8; 32];
 
+/// Derive the observer child transport key for the keystore's node key, the
+/// same way `--observer <index>` derives the live P2P signer.
+fn derive_observer_node_key(key_store_path: &str, index: u32) -> String {
+    use commonware_cryptography::Signer as _;
+    use summit_types::{KeyPaths, ext_private_key::ExtPrivateKey};
+
+    let node_key = KeyPaths::new(key_store_path.to_string())
+        .read_node_key_from_file()
+        .unwrap();
+    ExtPrivateKey::derive_child_signer(&node_key, index)
+        .public_key()
+        .to_string()
+}
+
 #[tokio::test]
 async fn test_health_endpoint() {
     use summit_rpc::SummitApiClient;
@@ -561,6 +575,7 @@ async fn test_get_deposit_signature_not_on_public_listener() {
         b"_SUMMIT".to_vec(),
         0,
         0,
+        None,
         #[cfg(feature = "permissioned")]
         Arc::new(AtomicBool::new(false)),
     )
@@ -609,6 +624,115 @@ async fn test_get_deposit_signature_not_on_public_listener() {
         handles.admin_addr.ip().is_loopback(),
         "admin listener must be bound to loopback; bound to {}",
         handles.admin_addr.ip()
+    );
+
+    handles.public_handle.stop().unwrap();
+    handles.admin_handle.stop().unwrap();
+}
+
+/// An observer node's live P2P identity is a child key derived from the
+/// master node key; signing a deposit would bind the master validator
+/// identity from a process that doesn't represent it. `getDepositSignature`
+/// must therefore be rejected in observer mode, even on the admin listener.
+#[tokio::test]
+async fn test_get_deposit_signature_disabled_in_observer_mode() {
+    use jsonrpsee::core::ClientError;
+    use summit_rpc::SummitAdminApiClient;
+
+    let (mailbox, _finalizer_handle) = create_test_finalizer_mailbox(MockFinalizerState::default());
+    let temp_dir = create_test_keystore().unwrap();
+    let key_store_path = temp_dir.path().to_str().unwrap().to_string();
+    let observer_node_key = derive_observer_node_key(&key_store_path, 0);
+
+    let handles = start_rpc_server_pair_with_handle(
+        mailbox,
+        key_store_path,
+        TEST_GENESIS_HASH,
+        b"_SUMMIT".to_vec(),
+        0,
+        0,
+        Some(observer_node_key),
+        #[cfg(feature = "permissioned")]
+        Arc::new(AtomicBool::new(false)),
+    )
+    .await
+    .unwrap();
+
+    let admin_url = format!("http://{}", handles.admin_addr);
+    let admin_client = HttpClientBuilder::default().build(&admin_url).unwrap();
+    let address = format!("0x{}", "a".repeat(40));
+    let resp =
+        SummitAdminApiClient::get_deposit_signature(&admin_client, 32_000_000_000, address).await;
+
+    match resp {
+        Err(ClientError::Call(err)) => {
+            assert_eq!(
+                err.code(),
+                4003,
+                "expected observer-mode rejection (4003), got {:?}",
+                err
+            );
+        }
+        other => panic!(
+            "observer node must not serve getDepositSignature; got {:?}",
+            other
+        ),
+    }
+
+    handles.public_handle.stop().unwrap();
+    handles.admin_handle.stop().unwrap();
+}
+
+/// In observer mode `getPublicKeys` must report the derived child key — the
+/// node's live P2P transport identity — rather than the master keystore
+/// identity, and must leave the consensus key empty so the response can't be
+/// read as speaking for the validator's consensus identity.
+#[tokio::test]
+async fn test_get_public_keys_reports_observer_key_in_observer_mode() {
+    use summit_rpc::SummitApiClient;
+
+    let (mailbox, _finalizer_handle) = create_test_finalizer_mailbox(MockFinalizerState::default());
+    let temp_dir = create_test_keystore().unwrap();
+    let key_store_path = temp_dir.path().to_str().unwrap().to_string();
+    let observer_node_key = derive_observer_node_key(&key_store_path, 3);
+    let master_node_key = {
+        use summit_types::KeyPaths;
+        KeyPaths::new(key_store_path.clone())
+            .node_public_key()
+            .unwrap()
+    };
+
+    let handles = start_rpc_server_pair_with_handle(
+        mailbox,
+        key_store_path,
+        TEST_GENESIS_HASH,
+        b"_SUMMIT".to_vec(),
+        0,
+        0,
+        Some(observer_node_key.clone()),
+        #[cfg(feature = "permissioned")]
+        Arc::new(AtomicBool::new(false)),
+    )
+    .await
+    .unwrap();
+
+    let public_url = format!("http://{}", handles.public_addr);
+    let public_client = HttpClientBuilder::default().build(&public_url).unwrap();
+    let keys = SummitApiClient::get_public_keys(&public_client)
+        .await
+        .expect("observer node should still serve getPublicKeys");
+    assert_eq!(
+        keys.node, observer_node_key,
+        "observer should report its derived transport key"
+    );
+    assert_ne!(
+        keys.node, master_node_key,
+        "observer must not report the master node key"
+    );
+    assert!(
+        keys.consensus.is_empty(),
+        "observer must not report a consensus key; got {}",
+        keys.consensus
     );
 
     handles.public_handle.stop().unwrap();


### PR DESCRIPTION
Addresses https://github.com/SeismicSystems/summit/issues/337.

Changes:
- Derive the observer child public key in start_network_and_engine and plumb it into the RPC server as observer_node_key: Option<String> (Some only in observer mode).
- getPublicKeys: in observer mode, return the derived child key (the live P2P transport identity) as node and an empty consensus key; validator-mode behavior unchanged.
- getDepositSignature: reject in observer mode with new error DisabledInObserverMode (code 4003) instead of producing master-key deposit signatures.
- Add regression tests.