### PR TITLE
fix: observer resolver excluding its parent validator as self

### DIFF
--- a/node/src/args.rs
+++ b/node/src/args.rs
@@ -845,14 +845,16 @@ where
 
     let oracle = DiscoveryOracle::new(oracle);
 
-    // In observer mode the live P2P identity is this derived child key, not
-    // the master node key; the RPC server reports it instead of the keystore
-    // identity and disables keystore-signing methods.
-    let observer_node_key = flags.observer.map(|index| {
+    // In observer mode the node's identity is this derived child key, not the
+    // master node key: the engine identifies itself by it (resolver
+    // self-exclusion, broadcast attribution, finalizer self-lookup), and the
+    // RPC server reports it instead of the keystore identity and disables
+    // keystore-signing methods.
+    let observer_network_key = flags.observer.map(|index| {
         ExtPrivateKey::derive_child_signer(&key_store.node_key, genesis.namespace.as_bytes(), index)
             .public_key()
-            .to_string()
     });
+    let observer_node_key = observer_network_key.as_ref().map(|pk| pk.to_string());
 
     let mut config = EngineConfig::get_engine_config(
         engine_client,
@@ -868,6 +870,7 @@ where
     )
     .unwrap();
     config.force_verifier_only = flags.observer.is_some();
+    config.observer_network_key = observer_network_key;
 
     let pending_limit = Quota::per_second(NonZeroU32::new(512).unwrap());
     let pending = network.register(PENDING_CHANNEL, pending_limit, MESSAGE_BACKLOG);

--- a/node/src/args.rs
+++ b/node/src/args.rs
@@ -537,6 +537,10 @@ async fn run_node_inner(
 
     let (engine, p2p, rpc_handle) = if let Some(index) = flags.observer {
         let signer = ExtPrivateKey::derive_child_signer(&key_store.node_key, namespace, index);
+        // The observer's network identity is exactly this P2P signer's public
+        // key; capture it here so the engine and resolver reuse the same derived
+        // key rather than deriving it a second time (which could drift).
+        let observer_network_key = Some(signer.public_key());
         let mut p2p_cfg = authenticated::discovery::Config::recommended(
             signer,
             namespace,
@@ -557,6 +561,7 @@ async fn run_node_inner(
             initial_state,
             loaded.last_block,
             loaded.finalized_header,
+            observer_network_key,
         )
         .await
     } else {
@@ -581,6 +586,7 @@ async fn run_node_inner(
             initial_state,
             loaded.last_block,
             loaded.finalized_header,
+            None,
         )
         .await
     };
@@ -691,6 +697,10 @@ async fn run_node_local_inner(
 
     let (engine, p2p, rpc_handle) = if let Some(index) = flags.observer {
         let signer = ExtPrivateKey::derive_child_signer(&key_store.node_key, namespace, index);
+        // The observer's network identity is exactly this P2P signer's public
+        // key; capture it here so the engine and resolver reuse the same derived
+        // key rather than deriving it a second time (which could drift).
+        let observer_network_key = Some(signer.public_key());
         let mut p2p_cfg = authenticated::discovery::Config::local(
             signer,
             namespace,
@@ -711,6 +721,7 @@ async fn run_node_local_inner(
             initial_state,
             checkpoint_parent_block,
             None,
+            observer_network_key,
         )
         .await
     } else {
@@ -734,6 +745,7 @@ async fn run_node_local_inner(
             &genesis,
             initial_state,
             checkpoint_parent_block,
+            None,
             None,
         )
         .await
@@ -835,6 +847,7 @@ async fn start_network_and_engine<S, EC>(
     initial_state: ConsensusState,
     checkpoint_last_block: Option<Block>,
     checkpoint_finalized_header: Option<FinalizedHeader<MultisigScheme>>,
+    observer_network_key: Option<PublicKey>,
 ) -> (Handle<anyhow::Result<()>>, Handle<()>, Handle<()>)
 where
     S: Signer<PublicKey = PublicKey>,
@@ -849,11 +862,8 @@ where
     // master node key: the engine identifies itself by it (resolver
     // self-exclusion, broadcast attribution, finalizer self-lookup), and the
     // RPC server reports it instead of the keystore identity and disables
-    // keystore-signing methods.
-    let observer_network_key = flags.observer.map(|index| {
-        ExtPrivateKey::derive_child_signer(&key_store.node_key, genesis.namespace.as_bytes(), index)
-            .public_key()
-    });
+    // keystore-signing methods. It is the public key of the live P2P signer,
+    // passed in by the caller so the two are derived once and cannot drift.
     let observer_node_key = observer_network_key.as_ref().map(|pk| pk.to_string());
 
     let mut config = EngineConfig::get_engine_config(

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -70,6 +70,12 @@ pub struct EngineConfig<C: EngineClient, S: Signer, O: NetworkOracle<S::PublicKe
     pub checkpoint_finalized_header: Option<FinalizedHeader<MultisigScheme>>,
     pub blocks_per_epoch: u64,
     pub force_verifier_only: bool,
+    /// The derived child key used as the live P2P identity when the node runs
+    /// with `--observer`; `None` on validator nodes. When set, the engine
+    /// identifies itself by this key everywhere (resolver self-exclusion,
+    /// broadcast attribution, finalizer self-lookup) instead of the master
+    /// node key in `key_store`.
+    pub observer_network_key: Option<PublicKey>,
 }
 
 impl<C: EngineClient, S: Signer, O: NetworkOracle<S::PublicKey>> EngineConfig<C, S, O> {
@@ -116,6 +122,7 @@ impl<C: EngineClient, S: Signer, O: NetworkOracle<S::PublicKey>> EngineConfig<C,
             checkpoint_finalized_header,
             blocks_per_epoch: genesis.blocks_per_epoch,
             force_verifier_only: false,
+            observer_network_key: None,
         })
     }
 }

--- a/node/src/engine.rs
+++ b/node/src/engine.rs
@@ -135,6 +135,15 @@ where
     pub async fn new(context: E, cfg: EngineConfig<C, S, O>) -> Self {
         let blocks_per_epoch = cfg.blocks_per_epoch;
 
+        // The key this node identifies itself by: the derived child key in
+        // observer mode (the live P2P identity), the master node key otherwise.
+        // Using the master key on an observer would make the resolver exclude
+        // the parent validator as "self" and skip it as a backfill source.
+        let node_public_key = cfg
+            .observer_network_key
+            .clone()
+            .unwrap_or_else(|| cfg.key_store.node_key.public_key());
+
         let page_cache = CacheRef::from_pooler(
             &context,
             NonZero::new(BUFFER_POOL_PAGE_SIZE).unwrap(),
@@ -171,7 +180,7 @@ where
                 namespace: cfg.namespace.as_bytes().to_vec(),
                 initial_state: cfg.initial_state,
                 protocol_version: PROTOCOL_VERSION,
-                node_public_key: cfg.key_store.node_key.public_key().clone(),
+                node_public_key: node_public_key.clone(),
                 cancellation_token: cancellation_token.clone(),
                 drain_interval: FINALIZER_DRAIN_INTERVAL,
                 buffered_blocks_warn_threshold: FINALIZER_BUFFERED_BLOCKS_WARN_THRESHOLD,
@@ -203,7 +212,7 @@ where
         let (buffer, buffer_mailbox) = buffered::Engine::new(
             context.with_label("buffer"),
             buffered::Config {
-                public_key: cfg.key_store.node_key.public_key(),
+                public_key: node_public_key.clone(),
                 mailbox_size: cfg.mailbox_size,
                 deque_size: cfg.deque_size,
                 priority: true,
@@ -374,7 +383,7 @@ where
             orchestrator,
             orchestrator_mailbox,
             oracle: cfg.oracle,
-            node_public_key: cfg.key_store.node_key.public_key(),
+            node_public_key,
             mailbox_size: cfg.mailbox_size,
             fetch_timeout: cfg.fetch_timeout,
             sync_start,

--- a/node/src/test_harness/common.rs
+++ b/node/src/test_harness/common.rs
@@ -704,6 +704,7 @@ where
         checkpoint_finalized_header: None,
         blocks_per_epoch: DEFAULT_BLOCKS_PER_EPOCH,
         force_verifier_only: false,
+        observer_network_key: None,
     }
 }
 

--- a/node/src/tests/observer.rs
+++ b/node/src/tests/observer.rs
@@ -197,3 +197,189 @@ fn test_observer_reaches_end_height() {
         context.auditor().state()
     });
 }
+
+#[test_traced("INFO")]
+fn test_observer_backfills_from_parent_validator() {
+    // Regression test for the resolver self-exclusion bug: production startup
+    // hands the engine the master keystore while p2p runs as the derived child
+    // key, so the resolver treated the parent validator's key as "me" and
+    // excluded the parent from backfill. Mirror that wiring here (master
+    // keystore + observer_network_key override, unlike the test above which
+    // puts the child signer in the keystore), late-join the observer, and link
+    // it ONLY to its parent validator — the sole possible backfill source.
+    let n_validators: u32 = 4;
+    let observers_per_validator: u32 = 1;
+    let observer_index: u32 = 0;
+
+    let link = Link {
+        latency: Duration::from_millis(80),
+        jitter: Duration::from_millis(10),
+        success_rate: 1.0,
+    };
+
+    let cfg = deterministic::Config::default().with_seed(0);
+    let executor = Runner::from(cfg);
+    executor.start(|context| async move {
+        let total_nodes = n_validators + 1;
+        let (network, mut oracle) = Network::new(
+            context.with_label("network"),
+            simulated::Config {
+                max_size: 1024 * 1024,
+                disconnect_on_block: false,
+                tracked_peer_sets: NZUsize!(total_nodes as usize * 10),
+            },
+        );
+        let join_height = DEFAULT_BLOCKS_PER_EPOCH / 2;
+        let stop_height = 2 * DEFAULT_BLOCKS_PER_EPOCH;
+        network.start();
+
+        // Generate validator key material.
+        let mut validator_key_stores = Vec::new();
+        let mut validators = Vec::new();
+        for i in 0..n_validators {
+            let mut rng = StdRng::seed_from_u64(i as u64);
+            let node_key = PrivateKey::random(&mut rng);
+            let consensus_key = bls12381::PrivateKey::random(&mut rng);
+            validators.push((node_key.public_key(), consensus_key.public_key()));
+            validator_key_stores.push(KeyStore {
+                node_key,
+                consensus_key,
+            });
+        }
+        validators.sort_by(|a, b| a.0.cmp(&b.0));
+        validator_key_stores.sort_by(|a, b| a.node_key.public_key().cmp(&b.node_key.public_key()));
+        let validator_pubkeys: Vec<_> = validators.iter().map(|(pk, _)| pk.clone()).collect();
+
+        // The observer runs from the parent validator's master keystore (as in
+        // production) with a child-derived p2p identity.
+        let parent_key_store = KeyStore {
+            node_key: validator_key_stores[0].node_key.clone(),
+            consensus_key: validator_key_stores[0].consensus_key.clone(),
+        };
+        let parent_pubkey = parent_key_store.node_key.public_key();
+        // Must match the namespace the nodes run with so the derived observer
+        // identity matches the engine's namespace-bound child key (#335).
+        let observer_namespace = b"_SUMMIT";
+        let observer_pubkey =
+            derive_child_public(parent_pubkey.clone(), observer_namespace, observer_index);
+
+        // Register all nodes, but link the observer ONLY to its parent.
+        let mut all_pubkeys = validator_pubkeys.clone();
+        all_pubkeys.push(observer_pubkey.clone());
+        let mut registrations = common::register_validators(&oracle, &all_pubkeys).await;
+        common::link_validators(&mut oracle, &validator_pubkeys, link.clone(), None).await;
+        common::join_validator(
+            &mut oracle,
+            &observer_pubkey,
+            std::slice::from_ref(&parent_pubkey),
+            link.clone(),
+        )
+        .await;
+
+        // Shared genesis + engine client network.
+        let genesis_hash = from_hex_formatted(common::GENESIS_HASH).expect("genesis hash hex");
+        let genesis_hash: [u8; 32] = genesis_hash.try_into().expect("genesis hash len");
+        let engine_client_network = MockEngineNetworkBuilder::new(genesis_hash)
+            .with_stop_at(stop_height)
+            .build();
+        let mut initial_state =
+            get_initial_state(genesis_hash, &validators, None, None, 32_000_000_000);
+        initial_state.set_observers_per_validator(observers_per_validator);
+
+        // Start the validators.
+        for key_store in validator_key_stores.into_iter() {
+            let public_key = key_store.node_key.public_key();
+            let uid = format!("validator_{public_key}");
+            let engine_client = engine_client_network.create_client(uid.clone());
+            let config = get_default_engine_config(
+                engine_client,
+                SimulatedOracle::new(oracle.clone()),
+                uid.clone(),
+                genesis_hash,
+                String::from("_SUMMIT"),
+                key_store,
+                validators.clone(),
+                initial_state.clone(),
+            );
+
+            let engine = Engine::new(context.with_label(&uid), config).await;
+
+            let (pending, recovered, resolver, orchestrator, broadcast) =
+                registrations.remove(&public_key).unwrap();
+            engine.start(pending, recovered, resolver, orchestrator, broadcast);
+        }
+
+        // Let the validators advance past join_height so the observer has
+        // history it can only obtain via resolver backfill from its parent.
+        let max_polls = 300;
+        let mut polls = 0;
+        loop {
+            let metrics = context.encode();
+            let advanced = metrics
+                .lines()
+                .filter(|l| l.starts_with("validator_"))
+                .filter(|l| {
+                    let mut parts = l.split_whitespace();
+                    let metric = parts.next().unwrap();
+                    let value = parts.next().unwrap();
+                    metric.ends_with("finalizer_height")
+                        && value.parse::<u64>().unwrap() >= join_height
+                })
+                .count();
+            if advanced as u32 >= n_validators {
+                break;
+            }
+            polls += 1;
+            assert!(polls < max_polls, "validators never reached join height");
+            context.sleep(Duration::from_secs(1)).await;
+        }
+
+        // Late-join the observer with production-style wiring: master keystore,
+        // verifier-only consensus, child key as the effective network identity.
+        let observer_uid = format!("observer_{observer_pubkey}");
+        let observer_engine_client = engine_client_network.create_client(observer_uid.clone());
+        let mut observer_config = get_default_engine_config(
+            observer_engine_client,
+            SimulatedOracle::new(oracle.clone()),
+            observer_uid.clone(),
+            genesis_hash,
+            String::from("_SUMMIT"),
+            parent_key_store,
+            validators.clone(),
+            initial_state.clone(),
+        );
+        observer_config.force_verifier_only = true;
+        observer_config.observer_network_key = Some(observer_pubkey.clone());
+        let observer_engine = Engine::new(context.with_label(&observer_uid), observer_config).await;
+        let (pending, recovered, resolver, orchestrator, broadcast) =
+            registrations.remove(&observer_pubkey).unwrap();
+        observer_engine.start(pending, recovered, resolver, orchestrator, broadcast);
+
+        // The observer must backfill the missed blocks from its parent — the
+        // only peer it is linked to — and reach stop_height.
+        let observer_height_metric = format!("{observer_uid}_finalizer_height");
+        let mut polls = 0;
+        loop {
+            let metrics = context.encode();
+            let observer_done = metrics.lines().any(|l| {
+                let mut parts = l.split_whitespace();
+                let metric = parts.next().unwrap();
+                let value = parts.next().unwrap();
+                metric.ends_with(&observer_height_metric)
+                    && value.parse::<u64>().unwrap() >= stop_height
+            });
+            if observer_done {
+                break;
+            }
+            polls += 1;
+            assert!(
+                polls < max_polls,
+                "observer did not catch up via its parent validator: \
+                 resolver likely excluded the parent as self"
+            );
+            context.sleep(Duration::from_secs(1)).await;
+        }
+
+        context.auditor().state()
+    });
+}


### PR DESCRIPTION
Addresses https://github.com/SeismicSystems/summit/issues/336.

Changes:
- Add EngineConfig.observer_network_key: Option<PublicKey>: the derived child key, Some only in observer mode
- Set it in start_network_and_engine, deriving the child key once and reusing it for the RPC server's observer identity
- Engine::new resolves a single effective node identity (child key in observer mode, master key otherwise) and uses it for the resolver me, broadcast buffer attribution, and finalizer self-lookup
- Add regression test