### PR TITLE
fix: implement Plan::Forward so silent voters receive certified blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6029,6 +6029,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "anyhow",
+ "commonware-codec",
  "commonware-consensus",
  "commonware-cryptography",
  "commonware-macros",

--- a/application/Cargo.toml
+++ b/application/Cargo.toml
@@ -33,6 +33,7 @@ prometheus-client = "0.22.3"
 [dev-dependencies]
 alloy-primitives.workspace = true
 alloy-rpc-types-engine.workspace = true
+commonware-codec.workspace = true
 
 [features]
 prom = ["metrics"]

--- a/application/src/actor.rs
+++ b/application/src/actor.rs
@@ -14,14 +14,16 @@ use futures::{
 use rand::Rng;
 use tokio_util::sync::CancellationToken;
 
+use commonware_consensus::simplex::Plan;
 use commonware_consensus::simplex::scheme::Scheme;
 use commonware_consensus::types::{Epoch, Epocher, Round, View};
 use commonware_cryptography::bls12381::primitives::variant::Variant;
 use commonware_cryptography::{PublicKey, Signer};
 use std::marker::PhantomData;
 #[cfg(feature = "permissioned")]
+use std::sync::Arc;
+#[cfg(feature = "permissioned")]
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use summit_finalizer::FinalizerMailbox;
 use tracing::{debug, error, info, warn};
@@ -44,9 +46,8 @@ pub struct Actor<
     ES: Epocher,
 > {
     context: ContextCell<R>,
-    mailbox: mpsc::Receiver<Message>,
+    mailbox: mpsc::Receiver<Message<P>>,
     engine_client: C,
-    built_block: Arc<Mutex<Option<(Block, Round)>>>,
     genesis_hash: [u8; 32],
     epocher: ES,
     cancellation_token: CancellationToken,
@@ -61,7 +62,7 @@ pub struct Actor<
 impl<
     R: Storage + Metrics + Clock + Spawner + governor::clock::Clock + Rng,
     C: EngineClient,
-    S: Scheme<Digest>,
+    S: Scheme<Digest, PublicKey = P>,
     P: PublicKey,
     K: Signer,
     V: Variant,
@@ -78,7 +79,6 @@ impl<
                 context: ContextCell::new(context),
                 mailbox: rx,
                 engine_client: cfg.engine_client,
-                built_block: Arc::new(Mutex::new(None)),
                 genesis_hash,
                 epocher: cfg.epocher,
                 cancellation_token: cfg.cancellation_token,
@@ -142,7 +142,6 @@ impl<
                             debug!("{rand_id} application: Handling message Propose for round {} (epoch {}, view {}), parent view: {}",
                                 round, round.epoch(), round.view(), parent.0);
 
-                            let built = self.built_block.clone();
                             #[cfg(feature = "prom")]
                             let proposal_start = std::time::Instant::now();
 
@@ -150,14 +149,9 @@ impl<
                                     res = self.handle_proposal(parent, &mut syncer, &mut finalizer, round) => {
                                         match res {
                                             Ok(block) => {
-                                                // store block
                                                 let digest = block.digest();
                                                 let height = block.height();
                                                 let tx_count = block.payload.payload_inner.payload_inner.transactions.len();
-                                                {
-                                                    let mut built = built.lock().expect("locked poisoned");
-                                                    *built = Some((block.clone(), round));
-                                                }
 
                                                 info!(
                                                     height,
@@ -202,21 +196,26 @@ impl<
                                     }
                             }
                         }
-                        Message::Broadcast { payload: _ } => {
+                        Message::Broadcast { payload, plan } => {
                             #[cfg(feature = "permissioned")]
                             if self.paused.load(Ordering::Relaxed) {
                                 warn!("consensus paused, skipping broadcast");
                                 continue;
                             }
 
-                            info!("{rand_id} Handling message Broadcast");
-
-                            let built_block = self.built_block.lock().expect("poisoned lock").take();
-
-                            if let Some((block, round)) = built_block {
-                                syncer.proposed(round, block).await;
-                            } else {
-                                warn!("Asked to broadcast a block without one built");
+                            match plan {
+                                // Our own proposal was already cached and broadcast
+                                // to all peers via syncer.proposed() at propose time,
+                                // before the digest was returned to consensus.
+                                Plan::Propose => {
+                                    debug!(?payload, "{rand_id} Broadcast(Propose): already broadcast at propose time");
+                                }
+                                // Push the certified block to voters consensus has
+                                // identified as missing it (ForwardingPolicy::SilentVoters).
+                                Plan::Forward { round, peers } => {
+                                    debug!(?round, n_peers = peers.len(), "{rand_id} Broadcast(Forward): forwarding to silent voters");
+                                    syncer.forward(round, payload, peers).await;
+                                }
                             }
                         }
 

--- a/application/src/ingress.rs
+++ b/application/src/ingress.rs
@@ -1,13 +1,14 @@
 use commonware_consensus::types::{Epoch, Round};
 use commonware_consensus::{
-    Automaton, CertifiableAutomaton, Relay, simplex::types::Context, types::View,
+    Automaton, CertifiableAutomaton, Relay,
+    simplex::{Plan, types::Context},
+    types::View,
 };
 use commonware_cryptography::PublicKey;
 use commonware_cryptography::sha256::Digest;
 use commonware_utils::channel::{mpsc, oneshot};
-use std::marker::PhantomData;
 
-pub enum Message {
+pub enum Message<P: PublicKey> {
     Genesis {
         epoch: Epoch,
         response: oneshot::Sender<Digest>,
@@ -19,6 +20,7 @@ pub enum Message {
     },
     Broadcast {
         payload: Digest,
+        plan: Plan<P>,
     },
     Verify {
         round: Round,
@@ -35,16 +37,12 @@ pub enum Message {
 
 #[derive(Clone)]
 pub struct Mailbox<P: PublicKey> {
-    sender: mpsc::Sender<Message>,
-    _signer_marker: PhantomData<P>,
+    sender: mpsc::Sender<Message<P>>,
 }
 
 impl<P: PublicKey> Mailbox<P> {
-    pub fn new(sender: mpsc::Sender<Message>) -> Self {
-        Self {
-            sender,
-            _signer_marker: PhantomData,
-        }
+    pub fn new(sender: mpsc::Sender<Message<P>>) -> Self {
+        Self { sender }
     }
 }
 
@@ -120,10 +118,73 @@ impl<P: PublicKey> Relay for Mailbox<P> {
     type PublicKey = P;
     type Plan = commonware_consensus::simplex::Plan<P>;
 
-    async fn broadcast(&mut self, digest: Self::Digest, _plan: Self::Plan) {
+    async fn broadcast(&mut self, digest: Self::Digest, plan: Self::Plan) {
         self.sender
-            .send(Message::Broadcast { payload: digest })
+            .send(Message::Broadcast {
+                payload: digest,
+                plan,
+            })
             .await
             .expect("Failed to send broadcast");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use commonware_codec::DecodeExt as _;
+    use commonware_cryptography::{Hasher as _, Signer as _, ed25519, sha256::Sha256};
+
+    fn test_public_key(seed: u8) -> ed25519::PublicKey {
+        ed25519::PrivateKey::decode([seed; 32].as_ref())
+            .unwrap()
+            .public_key()
+    }
+
+    /// Regression test for the relay dropping Commonware's broadcast identity:
+    /// the requested digest and the full `Plan` (including `Plan::Forward`'s
+    /// round and peer targets) must survive into `Message::Broadcast` so the
+    /// actor can serve targeted forwarding to silent voters.
+    #[test]
+    fn test_broadcast_preserves_digest_and_plan() {
+        futures::executor::block_on(async {
+            let (tx, mut rx) = mpsc::channel(4);
+            let mut mailbox = Mailbox::<ed25519::PublicKey>::new(tx);
+
+            let digest = Sha256::hash(b"proposal");
+            let round = Round::new(Epoch::new(3), View::new(7));
+            let peers = vec![test_public_key(1), test_public_key(2)];
+
+            mailbox
+                .broadcast(
+                    digest,
+                    Plan::Forward {
+                        round,
+                        peers: peers.clone(),
+                    },
+                )
+                .await;
+            let Some(Message::Broadcast { payload, plan }) = rx.recv().await else {
+                panic!("expected a Broadcast message");
+            };
+            assert_eq!(payload, digest);
+            match plan {
+                Plan::Forward {
+                    round: got_round,
+                    peers: got_peers,
+                } => {
+                    assert_eq!(got_round, round);
+                    assert_eq!(got_peers, peers);
+                }
+                Plan::Propose => panic!("Plan::Forward was lost in the relay"),
+            }
+
+            mailbox.broadcast(digest, Plan::Propose).await;
+            let Some(Message::Broadcast { payload, plan }) = rx.recv().await else {
+                panic!("expected a Broadcast message");
+            };
+            assert_eq!(payload, digest);
+            assert!(matches!(plan, Plan::Propose));
+        });
     }
 }

--- a/syncer/src/lib.rs
+++ b/syncer/src/lib.rs
@@ -1384,4 +1384,75 @@ mod tests {
             assert_eq!(fetched, block);
         });
     }
+
+    /// A targeted forward (the application relay's translation of Commonware's
+    /// `Plan::Forward`, e.g. for `ForwardingPolicy::SilentVoters`) must deliver
+    /// the block to exactly the requested peers: the target receives it without
+    /// any full broadcast having happened, and a non-recipient does not.
+    #[test_traced("WARN")]
+    fn test_forward_targeted_block_delivery() {
+        let runner = deterministic::Runner::timed(Duration::from_secs(60));
+        runner.start(|mut context| async move {
+            use futures::FutureExt as _;
+
+            let mut oracle = setup_network(context.clone(), NZUsize!(1));
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = bls12381_threshold::<V, _>(&mut context, NUM_VALIDATORS);
+
+            let mut manager = oracle.manager();
+            manager
+                .track(0, ordered::Set::try_from(participants.clone()).unwrap())
+                .await;
+
+            let mut actors = Vec::new();
+            for (i, validator) in participants.iter().enumerate() {
+                let (_application, actor, _processed_height) = setup_validator(
+                    context.with_label(&format!("validator_{i}")),
+                    &mut oracle,
+                    validator.clone(),
+                    ConstantProvider::new(schemes[i].clone()),
+                )
+                .await;
+                actors.push(actor);
+            }
+
+            setup_network_links(&mut oracle, &participants, LINK).await;
+
+            let parent = Sha256::hash(b"");
+            let block = B::new::<Sha256>(parent, Height::new(1), 1);
+            let commitment = block.digest();
+            let round = Round::new(Epoch::zero(), View::new(1));
+
+            // The target and a bystander both wait for the block.
+            let mut target = actors[1].clone();
+            let mut bystander = actors[2].clone();
+            let target_rx = target.subscribe(None, commitment).await;
+            let bystander_rx = bystander.subscribe(None, commitment).await;
+
+            // The source caches the block locally WITHOUT broadcasting it
+            // (Message::Verified only populates the cache).
+            let mut source = actors[0].clone();
+            source.verified(round, block.clone()).await;
+
+            // Forward only to the target.
+            source
+                .forward(round, commitment, vec![participants[1].clone()])
+                .await;
+
+            // The target receives the block via the targeted send.
+            let received = target_rx.await.unwrap();
+            assert_eq!(received.digest(), commitment);
+            assert_eq!(received.height, Height::new(1));
+
+            // The bystander was not a recipient and must not have the block.
+            context.sleep(Duration::from_millis(100)).await;
+            assert!(
+                bystander_rx.now_or_never().is_none(),
+                "targeted forward must not reach non-recipients"
+            );
+        });
+    }
 }


### PR DESCRIPTION
Addresses https://github.com/SeismicSystems/summit/issues/302.

Changes:
- Carry `Plan<P>` through `Message::Broadcast` (Message now generic over P)
- Plan::Forward -> syncer.forward(round, payload, peers)
- Plan::Propose -> no-op (block already broadcast at propose time)
- Delete the built_block slot and its stale-broadcast warn
- Require `S: Scheme<Digest, PublicKey = P>` on the application actor
- Unit tests