### PR TITLE
fix: use configured fetch_timeout for the backfill resolver

### DIFF
--- a/node/src/engine.rs
+++ b/node/src/engine.rs
@@ -55,6 +55,12 @@ const FREEZER_JOURNAL_COMPRESSION: Option<u8> = Some(3);
 const FREEZER_TABLE_INITIAL_SIZE: u32 = 1024 * 1024; // 100mb
 const MAX_REPAIR: NonZero<usize> = NZUsize!(10);
 
+/// Initial expected per-peer latency assumed by the backfill resolver's
+/// peer-performance tracking before any responses are observed.
+const BACKFILL_INITIAL_EXPECTED: Duration = Duration::from_secs(1);
+/// Delay before re-queuing a backfill fetch after a timeout or failed send.
+const BACKFILL_FETCH_RETRY_TIMEOUT: Duration = Duration::from_millis(1500);
+
 //
 // Onboarding config
 
@@ -107,6 +113,7 @@ pub struct Engine<
     oracle: O,
     node_public_key: PublicKey,
     mailbox_size: usize,
+    fetch_timeout: Duration,
     sync_start: SyncStart,
     checkpoint: Option<SyncCheckpoint<Block, MultisigScheme>>,
     cancellation_token: CancellationToken,
@@ -366,11 +373,34 @@ where
             oracle: cfg.oracle,
             node_public_key: cfg.key_store.node_key.public_key(),
             mailbox_size: cfg.mailbox_size,
+            fetch_timeout: cfg.fetch_timeout,
             sync_start,
             checkpoint,
             cancellation_token,
             #[cfg(feature = "permissioned")]
             paused,
+        }
+    }
+
+    /// Configuration for the backfill resolver.
+    ///
+    /// The active-request timeout must come from [`EngineConfig::fetch_timeout`]: the
+    /// resolver drops in-flight requests when the timeout fires, so responses arriving
+    /// later are discarded and backfill never completes if the timeout is shorter than
+    /// what peers need to serve finalized history.
+    pub(crate) fn backfill_resolver_config(
+        &self,
+    ) -> summit_syncer::resolver::p2p::Config<PublicKey, O, O> {
+        summit_syncer::resolver::p2p::Config {
+            public_key: self.node_public_key.clone(),
+            provider: self.oracle.clone(),
+            blocker: self.oracle.clone(),
+            mailbox_size: self.mailbox_size,
+            initial: BACKFILL_INITIAL_EXPECTED,
+            timeout: self.fetch_timeout,
+            fetch_retry_timeout: BACKFILL_FETCH_RETRY_TIMEOUT,
+            priority_requests: false,
+            priority_responses: false,
         }
     }
 
@@ -437,6 +467,9 @@ where
             impl Receiver<PublicKey = PublicKey>,
         ),
     ) -> anyhow::Result<()> {
+        // Build the backfill resolver config before actors take ownership of engine fields
+        let resolver_config = self.backfill_resolver_config();
+
         // start the application
         let app_handle = self
             .application
@@ -445,17 +478,6 @@ where
         let buffer_handle = self.buffer.start(broadcast_network);
 
         // Initialize resolver for backfill
-        let resolver_config = summit_syncer::resolver::p2p::Config {
-            public_key: self.node_public_key.clone(),
-            provider: self.oracle.clone(),
-            blocker: self.oracle.clone(),
-            mailbox_size: self.mailbox_size,
-            initial: Duration::from_secs(1),
-            timeout: Duration::from_secs(2),
-            fetch_retry_timeout: Duration::from_millis(1500),
-            priority_requests: false,
-            priority_responses: false,
-        };
         let (resolver_rx, resolver) =
             summit_syncer::resolver::p2p::init(&self.context, resolver_config, backfill_network);
 

--- a/node/src/tests/engine.rs
+++ b/node/src/tests/engine.rs
@@ -1,0 +1,78 @@
+//! Engine-level configuration tests.
+
+use crate::engine::Engine;
+use crate::test_harness::common::{
+    GENESIS_HASH, SimulatedOracle, get_default_engine_config, get_initial_state,
+};
+use crate::test_harness::mock_engine_client::MockEngineNetwork;
+use commonware_cryptography::{Signer, bls12381};
+use commonware_macros::test_traced;
+use commonware_math::algebra::Random;
+use commonware_p2p::simulated::{self, Network};
+use commonware_runtime::{
+    Metrics, Runner as _,
+    deterministic::{self, Runner},
+};
+use commonware_utils::{NZUsize, from_hex_formatted};
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+use std::time::Duration;
+use summit_types::PrivateKey;
+use summit_types::keystore::KeyStore;
+
+/// Regression test: the backfill resolver must inherit
+/// [`EngineConfig::fetch_timeout`](crate::config::EngineConfig::fetch_timeout) instead of
+/// hard-coding its active-request timeout. Commonware's resolver drops in-flight requests
+/// when the timeout fires and discards responses that arrive afterwards, so a hard-coded
+/// timeout shorter than the configured one prevents catching up from valid finalized
+/// history under slow storage/network conditions.
+#[test_traced("INFO")]
+fn test_backfill_resolver_inherits_fetch_timeout() {
+    let executor = Runner::from(deterministic::Config::default());
+    executor.start(|context| async move {
+        let (network, oracle) = Network::new(
+            context.with_label("network"),
+            simulated::Config {
+                max_size: 1024 * 1024,
+                disconnect_on_block: true,
+                tracked_peer_sets: NZUsize!(10),
+            },
+        );
+        network.start();
+
+        let mut rng = StdRng::seed_from_u64(0);
+        let node_key = PrivateKey::random(&mut rng);
+        let consensus_key = bls12381::PrivateKey::random(&mut rng);
+        let validators = vec![(node_key.public_key(), consensus_key.public_key())];
+        let key_store = KeyStore {
+            node_key,
+            consensus_key,
+        };
+
+        let genesis_hash: [u8; 32] = from_hex_formatted(GENESIS_HASH)
+            .expect("failed to decode genesis hash")
+            .try_into()
+            .expect("failed to convert genesis hash");
+        let initial_state =
+            get_initial_state(genesis_hash, &validators, None, None, 32_000_000_000);
+        let engine_client =
+            MockEngineNetwork::new(genesis_hash, None).create_client("engine_config_test".into());
+
+        let mut config = get_default_engine_config(
+            engine_client,
+            SimulatedOracle::new(oracle),
+            "engine_config_test".into(),
+            genesis_hash,
+            "_SUMMIT".into(),
+            key_store,
+            validators,
+            initial_state,
+        );
+        let fetch_timeout = Duration::from_secs(7);
+        config.fetch_timeout = fetch_timeout;
+
+        let engine = Engine::new(context.with_label("engine"), config).await;
+        let resolver_config = engine.backfill_resolver_config();
+        assert_eq!(resolver_config.timeout, fetch_timeout);
+    });
+}

--- a/node/src/tests/mod.rs
+++ b/node/src/tests/mod.rs
@@ -1,4 +1,5 @@
 mod checkpointing;
+mod engine;
 mod execution_requests;
 mod observer;
 mod syncer;


### PR DESCRIPTION
Addresses https://github.com/SeismicSystems/summit/issues/306.


Changes:
- Add a `fetch_timeout` field to `Engine`, populated from `EngineConfig::fetch_timeout`
- Extract the inline resolver config into `Engine::backfill_resolver_config()`, which uses the configured timeout as the active-request timeout
- Replace the remaining `initial` (1s) and `fetch_retry_timeout` (1.5s) literals with named, documented constants (`BACKFILL_INITIAL_EXPECTED`, `BACKFILL_FETCH_RETRY_TIMEOUT`) — these govern peer-performance priors and retry pacing, not response matching, so they stay independent
- Build the resolver config at the top of `run`, before actors take ownership of engine fields
- Add regression test 