### PR TITLE
fix: treat any single tracked-actor exit as an engine failure

### DIFF
--- a/node/src/engine.rs
+++ b/node/src/engine.rs
@@ -16,7 +16,7 @@ use commonware_storage::archive::immutable;
 use commonware_utils::acknowledgement::Exact;
 use commonware_utils::{NZU64, NZUsize};
 use futures::FutureExt;
-use futures::future::try_join_all;
+use futures::stream::{FuturesUnordered, StreamExt};
 use governor::clock::Clock as GClock;
 use rand::{CryptoRng, Rng};
 use std::marker::PhantomData;
@@ -495,49 +495,60 @@ where
             self.orchestrator
                 .start(pending_network, recovered_network, resolver_network);
 
-        // Wait for either all actors to finish or cancellation signal
-        let actors_fut = try_join_all(vec![
-            app_handle,
-            buffer_handle,
-            finalizer_handle,
-            syncer_handle,
-            orchestrator_handle,
-        ])
-        .fuse();
-        let cancellation_fut = self.cancellation_token.cancelled().fuse();
-        futures::pin_mut!(actors_fut, cancellation_fut);
+        // Supervise actors with first-completion semantics: any actor finishing —
+        // cleanly or not — without a coordinated cancellation is a failure. A join
+        // that waits for all actors would leave the engine pending on a single
+        // clean Ok(()) exit, keeping the node half-alive with a dead service.
+        let mut actors: FuturesUnordered<_> = [
+            ("application", app_handle),
+            ("buffer", buffer_handle),
+            ("finalizer", finalizer_handle),
+            ("syncer", syncer_handle),
+            ("orchestrator", orchestrator_handle),
+        ]
+        .into_iter()
+        .map(|(name, handle)| handle.map(move |result| (name, result)))
+        .collect();
 
-        futures::select! {
-            result = actors_fut => {
-                match result {
-                    Err(e) => {
-                        error!(?e, "engine failed: a tracked actor returned an error");
-                        Err(anyhow::anyhow!("consensus engine actor failed: {e}"))
-                    }
-                    Ok(_) => {
-                        // Without a cancellation signal, a tracked actor returning on its own
-                        // is an unexpected exit. It should be surfaced as a failure so the node comes
-                        // down for restart rather than lingering.
-                        warn!("engine stopped: a tracked actor exited unexpectedly");
-                        Err(anyhow::anyhow!(
-                            "consensus engine stopped: a tracked actor exited unexpectedly"
-                        ))
-                    }
-                }
-            }
+        let cancellation_fut = self.cancellation_token.cancelled().fuse();
+        futures::pin_mut!(cancellation_fut);
+
+        futures::select_biased! {
+            // Cancellation is polled first: a fatal-error self-cancel or committee
+            // exit makes the cancelling actor finish in the same instant, and must
+            // not be misclassified as an unexpected exit.
             _ = cancellation_fut => {
                 info!("cancellation triggered, waiting for actors to finish");
-                match actors_fut.await {
+                let mut failure = None;
+                while let Some((name, result)) = actors.next().await {
+                    if let Err(e) = result {
+                        error!(?e, actor = name, "actor failed during graceful shutdown");
+                        failure.get_or_insert(anyhow::anyhow!(
+                            "consensus engine actor {name} failed during graceful shutdown: {e}"
+                        ));
+                    }
+                }
+                // Cancellation is an intentional shutdown (fatal-error self-cancel or
+                // committee exit). The node still comes down via the supervisor; this is
+                // not a panic, so report it as a clean stop.
+                failure.map_or(Ok(()), Err)
+            }
+            completed = actors.next() => {
+                let (name, result) = completed.expect("actor set is non-empty");
+                // Bring the siblings down too; actual teardown is the process exit
+                // triggered when this error reaches the node supervisor.
+                self.cancellation_token.cancel();
+                match result {
                     Err(e) => {
-                        error!(?e, "engine failed during graceful shutdown");
+                        error!(?e, actor = name, "engine failed: a tracked actor returned an error");
+                        Err(anyhow::anyhow!("consensus engine actor {name} failed: {e}"))
+                    }
+                    Ok(()) => {
+                        warn!(actor = name, "engine stopped: a tracked actor exited unexpectedly");
                         Err(anyhow::anyhow!(
-                            "consensus engine failed during graceful shutdown: {e}"
+                            "consensus engine actor {name} exited unexpectedly"
                         ))
                     }
-                    // Cancellation is an intentional shutdown (fatal-error self-cancel or
-                    // committee exit). The node still comes down via the supervisor; this is
-                    // not a panic, so report it as a clean stop.
-                    Ok(_) => Ok(()),
                 }
             }
         }

--- a/node/src/tests/engine.rs
+++ b/node/src/tests/engine.rs
@@ -1,24 +1,29 @@
-//! Engine-level configuration tests.
+//! Engine-level configuration and supervision tests.
 
 use crate::engine::Engine;
 use crate::test_harness::common::{
     GENESIS_HASH, SimulatedOracle, get_default_engine_config, get_initial_state,
+    register_validators,
 };
 use crate::test_harness::mock_engine_client::MockEngineNetwork;
 use commonware_cryptography::{Signer, bls12381};
 use commonware_macros::test_traced;
 use commonware_math::algebra::Random;
-use commonware_p2p::simulated::{self, Network};
+use commonware_p2p::{
+    CheckedSender, LimitedSender, Message, Receiver, Recipients,
+    simulated::{self, Network},
+};
 use commonware_runtime::{
-    Metrics, Runner as _,
+    Clock, IoBufs, Metrics, Runner as _,
     deterministic::{self, Runner},
 };
 use commonware_utils::{NZUsize, from_hex_formatted};
+use futures::FutureExt;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
-use std::time::Duration;
-use summit_types::PrivateKey;
+use std::time::{Duration, SystemTime};
 use summit_types::keystore::KeyStore;
+use summit_types::{PrivateKey, PublicKey};
 
 /// Regression test: the backfill resolver must inherit
 /// [`EngineConfig::fetch_timeout`](crate::config::EngineConfig::fetch_timeout) instead of
@@ -74,5 +79,134 @@ fn test_backfill_resolver_inherits_fetch_timeout() {
         let engine = Engine::new(context.with_label("engine"), config).await;
         let resolver_config = engine.backfill_resolver_config();
         assert_eq!(resolver_config.timeout, fetch_timeout);
+    });
+}
+
+/// A backfill sender whose sends silently reach nobody.
+#[derive(Clone, Debug)]
+struct DeadBackfillSender;
+
+struct DeadBackfillCheckedSender;
+
+impl CheckedSender for DeadBackfillCheckedSender {
+    type PublicKey = PublicKey;
+    type Error = std::io::Error;
+
+    async fn send(
+        self,
+        _message: impl Into<IoBufs> + Send,
+        _priority: bool,
+    ) -> Result<Vec<PublicKey>, Self::Error> {
+        Ok(Vec::new())
+    }
+}
+
+impl LimitedSender for DeadBackfillSender {
+    type PublicKey = PublicKey;
+    type Checked<'a> = DeadBackfillCheckedSender;
+
+    async fn check(
+        &mut self,
+        _recipients: Recipients<PublicKey>,
+    ) -> Result<Self::Checked<'_>, SystemTime> {
+        Ok(DeadBackfillCheckedSender)
+    }
+}
+
+/// A backfill receiver that fails on the first `recv`, killing the resolver engine.
+#[derive(Debug)]
+struct ClosedBackfillReceiver;
+
+impl Receiver for ClosedBackfillReceiver {
+    type Error = std::io::Error;
+    type PublicKey = PublicKey;
+
+    async fn recv(&mut self) -> Result<Message<PublicKey>, Self::Error> {
+        Err(std::io::Error::other("backfill network closed"))
+    }
+}
+
+/// A single tracked actor exiting cleanly while its siblings keep running must
+/// surface as an engine failure.
+///
+/// The failing backfill receiver makes the (untracked) commonware resolver engine exit
+/// ("receiver closed"), which drops the handler channel into the syncer, so the syncer
+/// clean-returns ("handler closed, shutting down") — one of five tracked actors dead
+/// while application, buffer, finalizer, and orchestrator keep running. `try_join_all`
+/// only resolves early on `Err` (panic/abort), so the engine handle stays pending and
+/// the node lingers half-alive instead of coming down for restart.
+#[test_traced("INFO")]
+fn test_engine_detects_single_actor_clean_exit() {
+    let executor = Runner::from(deterministic::Config::default());
+    executor.start(|context| async move {
+        let (network, oracle) = Network::new(
+            context.with_label("network"),
+            simulated::Config {
+                max_size: 1024 * 1024,
+                disconnect_on_block: true,
+                tracked_peer_sets: NZUsize!(10),
+            },
+        );
+        network.start();
+
+        let mut rng = StdRng::seed_from_u64(0);
+        let node_key = PrivateKey::random(&mut rng);
+        let node_public_key = node_key.public_key();
+        let consensus_key = bls12381::PrivateKey::random(&mut rng);
+        let validators = vec![(node_public_key.clone(), consensus_key.public_key())];
+        let key_store = KeyStore {
+            node_key,
+            consensus_key,
+        };
+
+        let mut registrations =
+            register_validators(&oracle, std::slice::from_ref(&node_public_key)).await;
+        let (pending, recovered, resolver, broadcast, _backfill) =
+            registrations.remove(&node_public_key).unwrap();
+
+        let genesis_hash: [u8; 32] = from_hex_formatted(GENESIS_HASH)
+            .expect("failed to decode genesis hash")
+            .try_into()
+            .expect("failed to convert genesis hash");
+        let initial_state =
+            get_initial_state(genesis_hash, &validators, None, None, 32_000_000_000);
+        let engine_client =
+            MockEngineNetwork::new(genesis_hash, None).create_client("single_actor_exit".into());
+
+        let config = get_default_engine_config(
+            engine_client,
+            SimulatedOracle::new(oracle),
+            "single_actor_exit".into(),
+            genesis_hash,
+            "_SUMMIT".into(),
+            key_store,
+            validators,
+            initial_state,
+        );
+
+        let engine = Engine::new(context.with_label("engine"), config).await;
+        let engine_handle = engine.start(
+            pending,
+            recovered,
+            resolver,
+            broadcast,
+            (DeadBackfillSender, ClosedBackfillReceiver),
+        );
+
+        let engine_fut = engine_handle.fuse();
+        let timeout = context.sleep(Duration::from_secs(120)).fuse();
+        futures::pin_mut!(engine_fut, timeout);
+        futures::select! {
+            outcome = engine_fut => {
+                let result = outcome.expect("engine task must not panic");
+                assert!(
+                    result.is_err(),
+                    "an uncoordinated actor exit must surface as an engine error, got {result:?}"
+                );
+            }
+            _ = timeout => panic!(
+                "engine ignored the dead syncer for 120s and stayed half-alive (#360)"
+            ),
+        }
     });
 }


### PR DESCRIPTION
Addresses https://github.com/SeismicSystems/summit/issues/360.

Changes:
- node/src/engine.rs — replaced try_join_all with first-completion supervision: the actor handles are collected into a named FuturesUnordered, and any completion without a coordinated cancellation cancels the siblings and returns an Err naming the actor, bringing the node down via the supervisor.
- node/src/engine.rs — cancellation is polled first (select_biased!) so a fatal-error self-cancel or committee exit isn't misclassified as an unexpected exit; the graceful-shutdown arm drains all actors and preserves the existing semantics (Ok on clean stop, Err if an actor fails during shutdown).
- node/src/tests/engine.rs (new) — regression test test_engine_detects_single_actor_clean_exit: a failing backfill receiver kills the commonware resolver engine, which closes the handler channel into the syncer, which clean-returns; asserts the engine handle resolves with an error instead of staying pending for 120 simulated seconds. Red on try_join_all, green with this fix.