### PR TITLE
fix: track joining validators as secondary peers, not primary

### DIFF
--- a/finalizer/src/actor.rs
+++ b/finalizer/src/actor.rs
@@ -1088,23 +1088,46 @@ impl<
                 self.canonical_state.clear_removed_validators();
             }
 
-            // Create the list of validators for the p2p network for the next epoch.
-            // We also include the validators that already staked and are waiting to join the committee.
-            let active_validators = self.canonical_state.get_active_or_joining_validators();
-            let network_keys: Vec<_> = active_validators
+            // Create the peer sets for the next epoch's P2P network.
+            //
+            // Only active validators go into the PRIMARY set: the backfill
+            // resolver draws its fetch sources from primary, so a peer that is
+            // merely warming up (Joining) must not be selectable as a source it
+            // may be unable to serve. Joining validators are tracked as SECONDARY
+            // instead, connectable for warm-up but not a backfill source, and
+            // are promoted to primary automatically once they become active in a
+            // later epoch transition. Observers are derived from the full active
+            // or joining set so a joining validator's observer children still
+            // connect during warm-up.
+            let active_node_keys: Vec<_> = self
+                .canonical_state
+                .get_active_validators()
                 .iter()
                 .map(|(node_key, _)| node_key.clone())
                 .collect();
+            let active_or_joining_node_keys: Vec<_> = self
+                .canonical_state
+                .get_active_or_joining_validators()
+                .iter()
+                .map(|(node_key, _)| node_key.clone())
+                .collect();
+            let joining_node_keys: Vec<_> = active_or_joining_node_keys
+                .iter()
+                .filter(|key| !active_node_keys.contains(key))
+                .cloned()
+                .collect();
             let observer_keys = derive_observer_keys(
-                &network_keys,
+                &active_or_joining_node_keys,
                 &self.namespace,
                 self.canonical_state.get_observers_per_validator(),
             );
+            let secondary_keys: Vec<_> =
+                joining_node_keys.into_iter().chain(observer_keys).collect();
             self.oracle
                 .track(
                     self.canonical_state.get_epoch(),
-                    network_keys,
-                    observer_keys,
+                    active_node_keys,
+                    secondary_keys,
                 )
                 .await;
 

--- a/finalizer/src/actor.rs
+++ b/finalizer/src/actor.rs
@@ -658,7 +658,7 @@ impl<
                                 self.db
                                     .get_finalized_header(epoch - 1)
                                     .await
-                                    .map(|h| h.header.digest.0)
+                                    .map(|h| h.header().get_digest().0)
                             } else {
                                 // Future epoch we have not reached: no genesis to serve.
                                 None

--- a/finalizer/src/tests/mocks.rs
+++ b/finalizer/src/tests/mocks.rs
@@ -230,3 +230,41 @@ impl commonware_p2p::Blocker for MockNetworkOracle {
     type PublicKey = PublicKey;
     async fn block(&mut self, _public_key: Self::PublicKey) {}
 }
+
+/// A single recorded `track` call: the epoch and the peer tiers handed to the
+/// P2P oracle.
+#[derive(Clone)]
+pub struct TrackCall {
+    pub index: u64,
+    pub primary: Vec<PublicKey>,
+    pub secondary: Vec<PublicKey>,
+}
+
+/// A NetworkOracle that records every `track` call so tests can assert how
+/// validators are tiered (primary = resolver backfill sources + outbound dial,
+/// secondary = connectable-only).
+#[derive(Clone, Default)]
+pub struct RecordingNetworkOracle {
+    pub calls: Arc<Mutex<Vec<TrackCall>>>,
+}
+
+impl RecordingNetworkOracle {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl NetworkOracle<PublicKey> for RecordingNetworkOracle {
+    async fn track(&mut self, index: u64, primary: Vec<PublicKey>, secondary: Vec<PublicKey>) {
+        self.calls.lock().unwrap().push(TrackCall {
+            index,
+            primary,
+            secondary,
+        });
+    }
+}
+
+impl commonware_p2p::Blocker for RecordingNetworkOracle {
+    type PublicKey = PublicKey;
+    async fn block(&mut self, _public_key: Self::PublicKey) {}
+}

--- a/finalizer/src/tests/validator_lifecycle.rs
+++ b/finalizer/src/tests/validator_lifecycle.rs
@@ -1,6 +1,9 @@
 //! Tests for validator lifecycle: exit, removal from committee, etc.
 
-use super::mocks::{MockEngineClient, MockNetworkOracle, create_test_schemes, make_finalization};
+use super::mocks::{
+    MockEngineClient, MockNetworkOracle, RecordingNetworkOracle, create_test_schemes,
+    make_finalization,
+};
 use crate::actor::Finalizer;
 use crate::config::{FinalizerConfig, ProtocolConsts};
 use alloy_primitives::{Address, U256};
@@ -394,6 +397,164 @@ fn test_validator_exit_triggers_cancellation() {
         assert!(
             token_clone.is_cancelled(),
             "Token should be cancelled at first block of new epoch after validator exit"
+        );
+
+        context.auditor().state()
+    });
+}
+
+/// A deposited validator's P2P peer tier must follow its lifecycle.
+///
+/// The backfill resolver draws its fetch sources from the PRIMARY peer set, so
+/// while a validator is `Joining` (warming up, not yet an active voter) it must
+/// be tracked as SECONDARY only — connectable for warm-up but not selectable as
+/// a backfill source. Once it activates it must move INTO primary so it serves
+/// backfill and is dialed like any voter.
+///
+/// Drives two epoch boundaries: the validator is Joining at the epoch-1
+/// transition (assert secondary, not primary) and activates at the epoch-2
+/// transition (assert primary).
+#[test]
+fn test_joining_validator_peer_tier_follows_activation() {
+    let cfg = deterministic::Config::default().with_seed(334);
+    let executor = Runner::from(cfg);
+    executor.start(|context| async move {
+        let genesis_hash = [0x33u8; 32];
+        let node_key = ed25519::PrivateKey::from_seed(0);
+        let node_pubkey = node_key.public_key();
+
+        // 4 active validators, plus a fifth that has deposited and is Joining.
+        let mut initial_state =
+            create_test_initial_state(genesis_hash, NonZeroU64::new(5).unwrap());
+
+        use rand::SeedableRng;
+        let joining_key = ed25519::PrivateKey::from_seed(99);
+        let joining_pubkey = joining_key.public_key();
+        let mut rng = rand::rngs::StdRng::seed_from_u64(99);
+        let joining_consensus = bls12381::PrivateKey::random(&mut rng).public_key();
+        let joining_account = ValidatorAccount {
+            consensus_public_key: joining_consensus.clone(),
+            withdrawal_credentials: Address::from([99u8; 20]),
+            balance: 32_000_000_000,
+            status: ValidatorStatus::Joining,
+            has_pending_deposit: false,
+            has_pending_withdrawal: false,
+            // Activates at epoch 2: still Joining across the epoch-1 boundary,
+            // promoted to Active at the epoch-2 boundary.
+            joining_epoch: 2,
+            last_deposit_index: 0,
+        };
+        let joining_bytes: [u8; 32] = joining_pubkey.as_ref().try_into().unwrap();
+        initial_state.set_account(joining_bytes, joining_account);
+        // Registering the validator in the added-validators queue for epoch 2 is
+        // what drives the Joining -> Active promotion at that epoch boundary.
+        initial_state.add_validator(
+            2,
+            AddedValidator {
+                node_key: joining_pubkey.clone(),
+                consensus_key: joining_consensus,
+            },
+        );
+
+        let oracle = RecordingNetworkOracle::new();
+        let track_calls = oracle.calls.clone();
+
+        let (orchestrator_tx, _orchestrator_rx) = futures_mpsc::channel(100);
+        let orchestrator_mailbox = summit_orchestrator::Mailbox::new(orchestrator_tx);
+
+        let finalizer_cfg = FinalizerConfig::<MockEngineClient, RecordingNetworkOracle, MinPk> {
+            mailbox_size: 100,
+            db_prefix: "test_joining_secondary".to_string(),
+            engine_client: MockEngineClient::new(),
+            oracle,
+            protocol_consts: ProtocolConsts {
+                validator_num_warm_up_epochs: 2,
+                validator_withdrawal_num_epochs: 2,
+            },
+            page_cache: CacheRef::from_pooler(
+                &context,
+                std::num::NonZero::new(4096).unwrap(),
+                NZUsize!(100),
+            ),
+            genesis_hash,
+            initial_state,
+            protocol_version: 1,
+            node_public_key: node_pubkey,
+            cancellation_token: CancellationToken::new(),
+            drain_interval: Duration::from_millis(100),
+            buffered_blocks_warn_threshold: 100,
+            pending_notarized_max: 1000,
+            namespace: Vec::new(),
+            _variant_marker: PhantomData,
+        };
+
+        let (finalizer, _state, mut mailbox) = Finalizer::<
+            _,
+            MockEngineClient,
+            RecordingNetworkOracle,
+            ed25519::PrivateKey,
+            MinPk,
+        >::new(context.with_label("finalizer"), finalizer_cfg)
+        .await;
+
+        let _handle = finalizer.start(orchestrator_mailbox);
+        context.sleep(Duration::from_millis(100)).await;
+
+        // Drive two epoch boundaries (epoch_length = 5). A finalization
+        // certificate on the last block of each epoch (heights 5 and 10) drives
+        // that epoch's transition and its peer-tracking.
+        let genesis_block = Block::genesis(genesis_hash);
+        let mut parent_digest = genesis_block.digest();
+        let schemes = create_test_schemes(4);
+        let quorum = 3;
+
+        for height in 1..=10u64 {
+            let epoch = height / 5; // heights 1-4 -> epoch 0, 5-9 -> epoch 1, 10 -> epoch 2
+            let block = create_test_block_with_epoch(
+                parent_digest,
+                height,
+                height + 1,
+                13000 + height,
+                epoch,
+            );
+            let block_digest = block.digest();
+            parent_digest = block_digest;
+            // The last block of an epoch (heights 4 and 9) carries a finalization
+            // and triggers the transition + peer-tracking for the next epoch.
+            let finalization = (height % 5 == 4)
+                .then(|| make_finalization(block_digest, height, height + 1, &schemes, quorum));
+            let (ack, _) = Exact::handle();
+            mailbox
+                .report(Update::FinalizedBlock((block, finalization), ack))
+                .await;
+            context.sleep(Duration::from_millis(50)).await;
+        }
+
+        let calls = track_calls.lock().unwrap();
+        assert!(!calls.is_empty(), "finalizer must have tracked peers");
+
+        // While Joining (epoch-1 transition): secondary, never primary.
+        let epoch1 = calls
+            .iter()
+            .find(|c| c.index == 1)
+            .expect("expected a track() for epoch 1");
+        assert!(
+            !epoch1.primary.contains(&joining_pubkey),
+            "joining validator must NOT be a primary peer (resolver backfill source) before activation"
+        );
+        assert!(
+            epoch1.secondary.contains(&joining_pubkey),
+            "joining validator should be a secondary (warm-up) peer while it is Joining"
+        );
+
+        // After activation (epoch-2 transition): promoted into primary.
+        let epoch2 = calls
+            .iter()
+            .find(|c| c.index == 2)
+            .expect("expected a track() for epoch 2");
+        assert!(
+            epoch2.primary.contains(&joining_pubkey),
+            "once active, the validator must be a primary peer (eligible backfill source + dialed)"
         );
 
         context.auditor().state()

--- a/finalizer/src/tests/validator_lifecycle.rs
+++ b/finalizer/src/tests/validator_lifecycle.rs
@@ -501,7 +501,7 @@ fn test_joining_validator_peer_tier_follows_activation() {
         context.sleep(Duration::from_millis(100)).await;
 
         // Drive two epoch boundaries (epoch_length = 5). A finalization
-        // certificate on the last block of each epoch (heights 5 and 10) drives
+        // certificate on the last block of each epoch (heights 4 and 9) drives
         // that epoch's transition and its peer-tracking.
         let genesis_block = Block::genesis(genesis_hash);
         let mut parent_digest = genesis_block.digest();

--- a/node/src/test_harness/common.rs
+++ b/node/src/test_harness/common.rs
@@ -283,7 +283,7 @@ pub fn run_until_height(
         }
 
         // Verify all validators share the same state root
-        assert_state_root_consensus(&consensus_state_queries).await;
+        assert_state_root_consensus_synced(&context, &consensus_state_queries, &[]).await;
 
         context.auditor().state()
     })

--- a/node/src/tests/checkpointing/creation.rs
+++ b/node/src/tests/checkpointing/creation.rs
@@ -213,7 +213,7 @@ fn test_checkpoint_created() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus(&consensus_state_queries).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[]).await;
 
         context.auditor().state()
     });
@@ -417,7 +417,7 @@ fn test_previous_header_hash_matches() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus(&consensus_state_queries).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[]).await;
 
         context.auditor().state()
     });

--- a/node/src/tests/checkpointing/joining.rs
+++ b/node/src/tests/checkpointing/joining.rs
@@ -363,7 +363,7 @@ fn test_node_joins_later_with_checkpoint() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus(&consensus_state_queries).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[]).await;
 
         context.auditor().state()
     });
@@ -621,7 +621,7 @@ fn test_node_joins_later_with_checkpoint_not_in_genesis() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus(&consensus_state_queries).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[]).await;
 
         context.auditor().state()
     });

--- a/node/src/tests/checkpointing/verification.rs
+++ b/node/src/tests/checkpointing/verification.rs
@@ -417,7 +417,7 @@ fn test_checkpoint_verification_fixed_committee() {
             "expected PrevEpochHeaderHashMismatch for epoch 0, got: {err}"
         );
 
-        common::assert_state_root_consensus(&consensus_state_queries).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[]).await;
 
         context.auditor().state()
     });
@@ -648,8 +648,12 @@ fn test_checkpoint_verification_dynamic_committee() {
         checkpoint::verify_checkpoint_chain(&genesis, &finalized_headers, &raw_checkpoint)
             .expect("checkpoint verification with dynamic committee failed");
 
-        common::assert_state_root_consensus_skip(&consensus_state_queries, &[withdrawing_idx])
-            .await;
+        common::assert_state_root_consensus_synced(
+            &context,
+            &consensus_state_queries,
+            &[withdrawing_idx],
+        )
+        .await;
 
         context.auditor().state()
     });

--- a/node/src/tests/execution_requests/deposit_withdrawal_combined.rs
+++ b/node/src/tests/execution_requests/deposit_withdrawal_combined.rs
@@ -217,7 +217,7 @@ fn test_deposit_and_withdrawal_request_single() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus(&consensus_state_queries).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[]).await;
 
         context.auditor().state()
     })
@@ -470,7 +470,7 @@ fn test_deposit_and_withdrawal_request_multiple() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus(&consensus_state_queries).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[]).await;
 
         context.auditor().state()
     })
@@ -677,7 +677,7 @@ fn test_deposit_blocked_by_pending_withdrawal() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus_skip(&consensus_state_queries, &[0]).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[0]).await;
 
         context.auditor().state()
     })
@@ -885,7 +885,7 @@ fn test_invalid_deposit_refund_does_not_merge_with_later_withdrawal() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus_skip(&consensus_state_queries, &[0]).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[0]).await;
 
         context.auditor().state()
     })
@@ -1131,7 +1131,7 @@ fn test_process_time_invalid_new_validator_refund_does_not_merge_with_reused_pub
                 .is_ok()
         );
 
-        common::assert_state_root_consensus(&consensus_state_queries).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[]).await;
 
         context.auditor().state()
     })
@@ -1329,7 +1329,7 @@ fn test_withdrawal_blocked_by_pending_deposit() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus(&consensus_state_queries).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[]).await;
 
         context.auditor().state()
     })
@@ -1533,7 +1533,7 @@ fn test_deposit_and_withdrawal_same_block() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus(&consensus_state_queries).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[]).await;
 
         context.auditor().state()
     })

--- a/node/src/tests/execution_requests/deposits.rs
+++ b/node/src/tests/execution_requests/deposits.rs
@@ -179,7 +179,7 @@ fn test_deposit_request_single() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus(&consensus_state_queries).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[]).await;
 
         context.auditor().state()
     });
@@ -1024,7 +1024,7 @@ fn test_deposit_request_invalid_node_signature() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus(&consensus_state_queries).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[]).await;
 
         context.auditor().state()
     });
@@ -1224,7 +1224,7 @@ fn test_deposit_request_invalid_consensus_signature() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus(&consensus_state_queries).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[]).await;
 
         context.auditor().state()
     });

--- a/node/src/tests/execution_requests/protocol_params.rs
+++ b/node/src/tests/execution_requests/protocol_params.rs
@@ -150,7 +150,7 @@ fn test_grouped_protocol_param_requests_in_single_eip7685_entry() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus(&consensus_state_queries).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[]).await;
 
         context.auditor().state()
     })
@@ -313,7 +313,7 @@ fn test_protocol_param_allowed_timestamp_future() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus(&consensus_state_queries).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[]).await;
 
         context.auditor().state()
     })
@@ -492,7 +492,7 @@ fn test_protocol_param_max_stake() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus(&consensus_state_queries).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[]).await;
 
         context.auditor().state()
     })
@@ -782,7 +782,7 @@ fn test_protocol_param_stake_update_committee() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus_skip(&consensus_state_queries, &[9]).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[9]).await;
 
         context.auditor().state()
     })
@@ -969,7 +969,7 @@ fn test_minimum_validator_count_limits_stake_bound_force_removals() {
                 .verify_consensus_skip(None, Some(stop_height), &[validator_uids[0].as_str()])
                 .is_ok()
         );
-        common::assert_state_root_consensus_skip(&consensus_state_queries, &[0]).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[0]).await;
 
         context.auditor().state()
     })
@@ -1162,7 +1162,7 @@ fn test_protocol_param_treasury_address() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus(&consensus_state_queries).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[]).await;
 
         context.auditor().state()
     })
@@ -1317,7 +1317,7 @@ fn test_protocol_param_max_deposits_per_epoch() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus(&consensus_state_queries).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[]).await;
 
         context.auditor().state()
     })
@@ -1472,7 +1472,7 @@ fn test_protocol_param_max_deposits_per_epoch_rejected_above_max() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus(&consensus_state_queries).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[]).await;
 
         context.auditor().state()
     })
@@ -2180,7 +2180,7 @@ fn test_stake_bound_skips_pending_deposit_placeholder() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus(&consensus_state_queries).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[]).await;
 
         context.auditor().state()
     })
@@ -2459,7 +2459,7 @@ fn test_stake_bound_refunds_top_up_when_max_lowered_before_processing() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus(&consensus_state_queries).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[]).await;
 
         context.auditor().state()
     })

--- a/node/src/tests/execution_requests/validator_set.rs
+++ b/node/src/tests/execution_requests/validator_set.rs
@@ -218,7 +218,7 @@ fn test_added_validators_at_epoch_boundary() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus(&finalizer_mailboxes).await;
+        common::assert_state_root_consensus_synced(&context, &finalizer_mailboxes, &[]).await;
 
         context.auditor().state()
     });
@@ -431,7 +431,8 @@ fn test_removed_validators_at_epoch_boundary() {
         );
 
         // Skip the withdrawn validator since its finalizer shuts down after exit
-        common::assert_state_root_consensus_skip(
+        common::assert_state_root_consensus_synced(
+            &context,
             &finalizer_mailboxes,
             &[withdrawing_validator_idx],
         )

--- a/node/src/tests/execution_requests/withdrawals.rs
+++ b/node/src/tests/execution_requests/withdrawals.rs
@@ -214,7 +214,7 @@ fn test_grouped_withdrawal_requests_in_single_eip7685_entry() {
                 .verify_consensus(None, Some(stop_height))
                 .is_ok()
         );
-        common::assert_state_root_consensus(&consensus_state_queries).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[]).await;
 
         context.auditor().state()
     })
@@ -630,7 +630,7 @@ fn test_duplicate_withdrawal_blocked() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus_skip(&consensus_state_queries, &[0]).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[0]).await;
 
         context.auditor().state()
     })
@@ -811,7 +811,7 @@ fn test_withdrawal_wrong_source_address_rejected() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus(&consensus_state_queries).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[]).await;
 
         context.auditor().state()
     })
@@ -990,7 +990,7 @@ fn test_withdrawal_nonexistent_validator_ignored() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus(&consensus_state_queries).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[]).await;
 
         context.auditor().state()
     })
@@ -1207,7 +1207,7 @@ fn test_withdrawal_during_onboarding_aborts() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus(&consensus_state_queries).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[]).await;
 
         context.auditor().state()
     })
@@ -1403,7 +1403,7 @@ fn test_minimum_validator_count_blocks_excess_active_validator_exits() {
                 .verify_consensus_skip(None, Some(stop_height), &[validator_uids[0].as_str()])
                 .is_ok()
         );
-        common::assert_state_root_consensus_skip(&consensus_state_queries, &[0]).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[0]).await;
 
         context.auditor().state()
     })
@@ -1635,7 +1635,8 @@ fn test_withdrawal_on_last_block_of_epoch_deferred() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus_skip(&consensus_state_queries, &[last_idx]).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[last_idx])
+            .await;
 
         context.auditor().state()
     })
@@ -1828,7 +1829,12 @@ fn test_grouped_withdrawal_on_last_block_of_epoch_only_requeues_deferred_request
                 .is_ok()
         );
 
-        common::assert_state_root_consensus_skip(&consensus_state_queries, &[idx_a, idx_b]).await;
+        common::assert_state_root_consensus_synced(
+            &context,
+            &consensus_state_queries,
+            &[idx_a, idx_b],
+        )
+        .await;
 
         context.auditor().state()
     })
@@ -2072,7 +2078,12 @@ fn test_duplicate_last_block_exit_does_not_consume_active_exit_budget() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus_skip(&consensus_state_queries, &[idx_a, idx_b]).await;
+        common::assert_state_root_consensus_synced(
+            &context,
+            &consensus_state_queries,
+            &[idx_a, idx_b],
+        )
+        .await;
 
         context.auditor().state()
     })
@@ -2294,7 +2305,7 @@ fn test_stake_bounds_skips_zero_balance_validator() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus_skip(&consensus_state_queries, &[0]).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[0]).await;
 
         context.auditor().state()
     })
@@ -2518,7 +2529,12 @@ fn test_withdrawal_overflow_rescheduled_to_next_epoch() {
                 .verify_consensus_skip(None, Some(stop_height), &skip_refs)
                 .is_ok()
         );
-        common::assert_state_root_consensus_skip(&consensus_state_queries, &[0, 1, 2, 3]).await;
+        common::assert_state_root_consensus_synced(
+            &context,
+            &consensus_state_queries,
+            &[0, 1, 2, 3],
+        )
+        .await;
 
         context.auditor().state()
     })

--- a/node/src/tests/syncer.rs
+++ b/node/src/tests/syncer.rs
@@ -236,7 +236,7 @@ fn test_node_joins_later_no_checkpoint_in_genesis() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus(&consensus_state_queries).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[]).await;
 
         context.auditor().state()
     });
@@ -464,7 +464,7 @@ fn test_node_joins_later_no_checkpoint_not_in_genesis() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus(&consensus_state_queries).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[]).await;
 
         context.auditor().state()
     });


### PR DESCRIPTION
Addresses https://github.com/SeismicSystems/summit/issues/334.

Changes:
- finalizer/src/actor.rs — at the epoch transition, build the peer sets separately: PRIMARY = get_active_validators(); SECONDARY = joining node keys (active-or-joining minus active) + observer keys. Observers are still derived from the full active-or-joining set so joining validators' observer children connect during warm-up.
- finalizer/src/tests/mocks.rs — added RecordingNetworkOracle (and TrackCall) that captures each track() call's epoch index and primary/secondary tiers, since the existing MockNetworkOracle discards them.
- finalizer/src/tests/validator_lifecycle.rs — added test_joining_validator_peer_tier_follows_activation: drives two epoch boundaries and asserts the validator is secondary (not primary) while Joining, then promoted into primary once Active.