### PR TITLE
fix: bind checkpoint state position to the verified terminal header

### DIFF
--- a/finalizer/src/actor.rs
+++ b/finalizer/src/actor.rs
@@ -658,7 +658,7 @@ impl<
                                 self.db
                                     .get_finalized_header(epoch - 1)
                                     .await
-                                    .map(|h| h.header.digest.0)
+                                    .map(|h| h.header().get_digest().0)
                             } else {
                                 // Future epoch we have not reached: no genesis to serve.
                                 None

--- a/node/src/test_harness/common.rs
+++ b/node/src/test_harness/common.rs
@@ -283,7 +283,7 @@ pub fn run_until_height(
         }
 
         // Verify all validators share the same state root
-        assert_state_root_consensus(&consensus_state_queries).await;
+        assert_state_root_consensus_synced(&context, &consensus_state_queries, &[]).await;
 
         context.auditor().state()
     })

--- a/node/src/tests/checkpointing/creation.rs
+++ b/node/src/tests/checkpointing/creation.rs
@@ -213,7 +213,7 @@ fn test_checkpoint_created() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus(&consensus_state_queries).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[]).await;
 
         context.auditor().state()
     });
@@ -417,7 +417,7 @@ fn test_previous_header_hash_matches() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus(&consensus_state_queries).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[]).await;
 
         context.auditor().state()
     });

--- a/node/src/tests/checkpointing/joining.rs
+++ b/node/src/tests/checkpointing/joining.rs
@@ -363,7 +363,7 @@ fn test_node_joins_later_with_checkpoint() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus(&consensus_state_queries).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[]).await;
 
         context.auditor().state()
     });
@@ -621,7 +621,7 @@ fn test_node_joins_later_with_checkpoint_not_in_genesis() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus(&consensus_state_queries).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[]).await;
 
         context.auditor().state()
     });

--- a/node/src/tests/checkpointing/verification.rs
+++ b/node/src/tests/checkpointing/verification.rs
@@ -417,7 +417,7 @@ fn test_checkpoint_verification_fixed_committee() {
             "expected PrevEpochHeaderHashMismatch for epoch 0, got: {err}"
         );
 
-        common::assert_state_root_consensus(&consensus_state_queries).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[]).await;
 
         context.auditor().state()
     });
@@ -648,8 +648,12 @@ fn test_checkpoint_verification_dynamic_committee() {
         checkpoint::verify_checkpoint_chain(&genesis, &finalized_headers, &raw_checkpoint)
             .expect("checkpoint verification with dynamic committee failed");
 
-        common::assert_state_root_consensus_skip(&consensus_state_queries, &[withdrawing_idx])
-            .await;
+        common::assert_state_root_consensus_synced(
+            &context,
+            &consensus_state_queries,
+            &[withdrawing_idx],
+        )
+        .await;
 
         context.auditor().state()
     });

--- a/node/src/tests/execution_requests/deposit_withdrawal_combined.rs
+++ b/node/src/tests/execution_requests/deposit_withdrawal_combined.rs
@@ -217,7 +217,7 @@ fn test_deposit_and_withdrawal_request_single() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus(&consensus_state_queries).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[]).await;
 
         context.auditor().state()
     })
@@ -470,7 +470,7 @@ fn test_deposit_and_withdrawal_request_multiple() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus(&consensus_state_queries).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[]).await;
 
         context.auditor().state()
     })
@@ -677,7 +677,7 @@ fn test_deposit_blocked_by_pending_withdrawal() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus_skip(&consensus_state_queries, &[0]).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[0]).await;
 
         context.auditor().state()
     })
@@ -885,7 +885,7 @@ fn test_invalid_deposit_refund_does_not_merge_with_later_withdrawal() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus_skip(&consensus_state_queries, &[0]).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[0]).await;
 
         context.auditor().state()
     })
@@ -1131,7 +1131,7 @@ fn test_process_time_invalid_new_validator_refund_does_not_merge_with_reused_pub
                 .is_ok()
         );
 
-        common::assert_state_root_consensus(&consensus_state_queries).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[]).await;
 
         context.auditor().state()
     })
@@ -1329,7 +1329,7 @@ fn test_withdrawal_blocked_by_pending_deposit() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus(&consensus_state_queries).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[]).await;
 
         context.auditor().state()
     })
@@ -1533,7 +1533,7 @@ fn test_deposit_and_withdrawal_same_block() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus(&consensus_state_queries).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[]).await;
 
         context.auditor().state()
     })

--- a/node/src/tests/execution_requests/deposits.rs
+++ b/node/src/tests/execution_requests/deposits.rs
@@ -179,7 +179,7 @@ fn test_deposit_request_single() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus(&consensus_state_queries).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[]).await;
 
         context.auditor().state()
     });
@@ -1024,7 +1024,7 @@ fn test_deposit_request_invalid_node_signature() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus(&consensus_state_queries).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[]).await;
 
         context.auditor().state()
     });
@@ -1224,7 +1224,7 @@ fn test_deposit_request_invalid_consensus_signature() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus(&consensus_state_queries).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[]).await;
 
         context.auditor().state()
     });

--- a/node/src/tests/execution_requests/protocol_params.rs
+++ b/node/src/tests/execution_requests/protocol_params.rs
@@ -150,7 +150,7 @@ fn test_grouped_protocol_param_requests_in_single_eip7685_entry() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus(&consensus_state_queries).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[]).await;
 
         context.auditor().state()
     })
@@ -313,7 +313,7 @@ fn test_protocol_param_allowed_timestamp_future() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus(&consensus_state_queries).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[]).await;
 
         context.auditor().state()
     })
@@ -492,7 +492,7 @@ fn test_protocol_param_max_stake() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus(&consensus_state_queries).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[]).await;
 
         context.auditor().state()
     })
@@ -782,7 +782,7 @@ fn test_protocol_param_stake_update_committee() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus_skip(&consensus_state_queries, &[9]).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[9]).await;
 
         context.auditor().state()
     })
@@ -969,7 +969,7 @@ fn test_minimum_validator_count_limits_stake_bound_force_removals() {
                 .verify_consensus_skip(None, Some(stop_height), &[validator_uids[0].as_str()])
                 .is_ok()
         );
-        common::assert_state_root_consensus_skip(&consensus_state_queries, &[0]).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[0]).await;
 
         context.auditor().state()
     })
@@ -1162,7 +1162,7 @@ fn test_protocol_param_treasury_address() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus(&consensus_state_queries).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[]).await;
 
         context.auditor().state()
     })
@@ -1317,7 +1317,7 @@ fn test_protocol_param_max_deposits_per_epoch() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus(&consensus_state_queries).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[]).await;
 
         context.auditor().state()
     })
@@ -1472,7 +1472,7 @@ fn test_protocol_param_max_deposits_per_epoch_rejected_above_max() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus(&consensus_state_queries).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[]).await;
 
         context.auditor().state()
     })
@@ -2180,7 +2180,7 @@ fn test_stake_bound_skips_pending_deposit_placeholder() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus(&consensus_state_queries).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[]).await;
 
         context.auditor().state()
     })
@@ -2459,7 +2459,7 @@ fn test_stake_bound_refunds_top_up_when_max_lowered_before_processing() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus(&consensus_state_queries).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[]).await;
 
         context.auditor().state()
     })

--- a/node/src/tests/execution_requests/validator_set.rs
+++ b/node/src/tests/execution_requests/validator_set.rs
@@ -218,7 +218,7 @@ fn test_added_validators_at_epoch_boundary() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus(&finalizer_mailboxes).await;
+        common::assert_state_root_consensus_synced(&context, &finalizer_mailboxes, &[]).await;
 
         context.auditor().state()
     });
@@ -431,7 +431,8 @@ fn test_removed_validators_at_epoch_boundary() {
         );
 
         // Skip the withdrawn validator since its finalizer shuts down after exit
-        common::assert_state_root_consensus_skip(
+        common::assert_state_root_consensus_synced(
+            &context,
             &finalizer_mailboxes,
             &[withdrawing_validator_idx],
         )

--- a/node/src/tests/execution_requests/withdrawals.rs
+++ b/node/src/tests/execution_requests/withdrawals.rs
@@ -214,7 +214,7 @@ fn test_grouped_withdrawal_requests_in_single_eip7685_entry() {
                 .verify_consensus(None, Some(stop_height))
                 .is_ok()
         );
-        common::assert_state_root_consensus(&consensus_state_queries).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[]).await;
 
         context.auditor().state()
     })
@@ -630,7 +630,7 @@ fn test_duplicate_withdrawal_blocked() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus_skip(&consensus_state_queries, &[0]).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[0]).await;
 
         context.auditor().state()
     })
@@ -811,7 +811,7 @@ fn test_withdrawal_wrong_source_address_rejected() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus(&consensus_state_queries).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[]).await;
 
         context.auditor().state()
     })
@@ -990,7 +990,7 @@ fn test_withdrawal_nonexistent_validator_ignored() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus(&consensus_state_queries).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[]).await;
 
         context.auditor().state()
     })
@@ -1207,7 +1207,7 @@ fn test_withdrawal_during_onboarding_aborts() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus(&consensus_state_queries).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[]).await;
 
         context.auditor().state()
     })
@@ -1403,7 +1403,7 @@ fn test_minimum_validator_count_blocks_excess_active_validator_exits() {
                 .verify_consensus_skip(None, Some(stop_height), &[validator_uids[0].as_str()])
                 .is_ok()
         );
-        common::assert_state_root_consensus_skip(&consensus_state_queries, &[0]).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[0]).await;
 
         context.auditor().state()
     })
@@ -1635,7 +1635,8 @@ fn test_withdrawal_on_last_block_of_epoch_deferred() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus_skip(&consensus_state_queries, &[last_idx]).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[last_idx])
+            .await;
 
         context.auditor().state()
     })
@@ -1828,7 +1829,12 @@ fn test_grouped_withdrawal_on_last_block_of_epoch_only_requeues_deferred_request
                 .is_ok()
         );
 
-        common::assert_state_root_consensus_skip(&consensus_state_queries, &[idx_a, idx_b]).await;
+        common::assert_state_root_consensus_synced(
+            &context,
+            &consensus_state_queries,
+            &[idx_a, idx_b],
+        )
+        .await;
 
         context.auditor().state()
     })
@@ -2072,7 +2078,12 @@ fn test_duplicate_last_block_exit_does_not_consume_active_exit_budget() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus_skip(&consensus_state_queries, &[idx_a, idx_b]).await;
+        common::assert_state_root_consensus_synced(
+            &context,
+            &consensus_state_queries,
+            &[idx_a, idx_b],
+        )
+        .await;
 
         context.auditor().state()
     })
@@ -2294,7 +2305,7 @@ fn test_stake_bounds_skips_zero_balance_validator() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus_skip(&consensus_state_queries, &[0]).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[0]).await;
 
         context.auditor().state()
     })
@@ -2518,7 +2529,12 @@ fn test_withdrawal_overflow_rescheduled_to_next_epoch() {
                 .verify_consensus_skip(None, Some(stop_height), &skip_refs)
                 .is_ok()
         );
-        common::assert_state_root_consensus_skip(&consensus_state_queries, &[0, 1, 2, 3]).await;
+        common::assert_state_root_consensus_synced(
+            &context,
+            &consensus_state_queries,
+            &[0, 1, 2, 3],
+        )
+        .await;
 
         context.auditor().state()
     })

--- a/node/src/tests/syncer.rs
+++ b/node/src/tests/syncer.rs
@@ -236,7 +236,7 @@ fn test_node_joins_later_no_checkpoint_in_genesis() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus(&consensus_state_queries).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[]).await;
 
         context.auditor().state()
     });
@@ -464,7 +464,7 @@ fn test_node_joins_later_no_checkpoint_not_in_genesis() {
                 .is_ok()
         );
 
-        common::assert_state_root_consensus(&consensus_state_queries).await;
+        common::assert_state_root_consensus_synced(&context, &consensus_state_queries, &[]).await;
 
         context.auditor().state()
     });

--- a/types/src/checkpoint.rs
+++ b/types/src/checkpoint.rs
@@ -179,6 +179,12 @@ pub enum CheckpointVerificationError {
     PayloadDigestMismatch {
         epoch: u64,
     },
+    /// The decoded checkpoint state's consensus position (height, epoch, or head
+    /// digest) is not bound to the verified terminal finalized header. The
+    /// checkpoint is created at the penultimate block of an epoch, so a valid
+    /// checkpoint's `latest_height` is exactly one below the terminal (last-block)
+    /// header, its `head_digest` is that header's parent, and its epoch matches.
+    CheckpointStatePositionMismatch(String),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -250,6 +256,12 @@ impl fmt::Display for CheckpointVerificationError {
                 write!(
                     f,
                     "epoch {epoch}: header fields do not match the finalization payload digest"
+                )
+            }
+            Self::CheckpointStatePositionMismatch(reason) => {
+                write!(
+                    f,
+                    "checkpoint state position not bound to terminal header: {reason}"
                 )
             }
         }
@@ -496,6 +508,45 @@ pub fn verify_checkpoint_chain_with_weak_subjectivity(
                 "validator {key:?} is active in checkpoint but not in accumulated signing set"
             )));
         }
+    }
+
+    // Step 4: Bind the decoded state position to the terminal finalized header.
+    // The verified terminal header (`last_header`) authenticates the exact
+    // checkpoint bytes (Step 2), but their decoded *position* is otherwise free.
+    // The checkpoint is created at the penultimate block of an epoch and the
+    // terminal header is the last block of that epoch (see finalizer/src/actor.rs),
+    // so for an honest checkpoint: `latest_height` is one below the terminal
+    // header's height, `head_digest` is the terminal header's parent, and the
+    // epoch matches. Reject any checkpoint whose decoded position does not.
+    let terminal = last_header.header();
+    let expected_terminal_height = checkpoint_state.get_latest_height().saturating_add(1);
+    if terminal.height() != expected_terminal_height {
+        return Err(
+            CheckpointVerificationError::CheckpointStatePositionMismatch(format!(
+                "decoded latest_height {} implies terminal height {}, but terminal header is at height {}",
+                checkpoint_state.get_latest_height(),
+                expected_terminal_height,
+                terminal.height()
+            )),
+        );
+    }
+    if checkpoint_state.get_epoch() != terminal.epoch() {
+        return Err(
+            CheckpointVerificationError::CheckpointStatePositionMismatch(format!(
+                "decoded epoch {} does not match terminal header epoch {}",
+                checkpoint_state.get_epoch(),
+                terminal.epoch()
+            )),
+        );
+    }
+    if checkpoint_state.get_head_digest() != terminal.parent() {
+        return Err(
+            CheckpointVerificationError::CheckpointStatePositionMismatch(format!(
+                "decoded head_digest 0x{} is not the terminal header's parent 0x{}",
+                hex(checkpoint_state.get_head_digest().as_ref()),
+                hex(terminal.parent().as_ref())
+            )),
+        );
     }
 
     Ok(())
@@ -1221,7 +1272,15 @@ mod tests {
     // checkpoint, a *different* ("attacker-controlled") checkpoint, and an honest
     // finalized header whose certificate genuinely signs the honest header digest
     // and whose `checkpoint_hash` commits to the honest checkpoint.
-    fn checkpoint_verification_fixture() -> (
+    // Builds a checkpoint whose decoded state sits at `state_latest_height` and a
+    // terminal finalized header at `terminal_header_height` that validly signs it.
+    // An honest checkpoint sets `terminal_header_height == state_latest_height + 1`
+    // (checkpoint at the penultimate block, terminal header at the last block);
+    // passing any other terminal height produces a position-inconsistent checkpoint.
+    fn checkpoint_verification_fixture(
+        state_latest_height: u64,
+        terminal_header_height: u64,
+    ) -> (
         Genesis,
         Checkpoint,
         Checkpoint,
@@ -1322,6 +1381,10 @@ mod tests {
             1,
         );
         state.set_validator_accounts(validator_accounts);
+        // The terminal header below is always built at height 0; passing a
+        // non-zero `state_latest_height` makes the decoded checkpoint position
+        // disagree with the terminal header it is bound to.
+        state.set_latest_height(state_latest_height);
         let checkpoint = Checkpoint::new(&state);
 
         // A distinct checkpoint the attacker would like the chain to authenticate.
@@ -1333,7 +1396,7 @@ mod tests {
         // Honest header commits to the honest checkpoint.
         let header = Header::new(
             [0u8; 32].into(),
-            0,
+            terminal_header_height,
             0,
             0,
             0,
@@ -1376,6 +1439,40 @@ mod tests {
         (genesis, checkpoint, tampered_checkpoint, finalized_header)
     }
 
+    // Binds the decoded checkpoint state position to the verified terminal header.
+    // The terminal header authenticates the checkpoint *bytes* (sha256), but
+    // without this check the decoded `ConsensusState` could advertise a consensus
+    // position (height/epoch/head_digest) that does not correspond to the verified
+    // header chain, letting a node start from the wrong position. The checkpoint is
+    // taken at the penultimate block, so an honest checkpoint's `latest_height` is
+    // exactly one below the terminal (last-block) header.
+    #[test]
+    fn test_checkpoint_verifier_binds_state_position_to_terminal_header() {
+        // Honest: decoded state at penultimate height 5, terminal header at 6.
+        let (genesis, checkpoint, _tampered, honest) = checkpoint_verification_fixture(5, 6);
+        super::verify_checkpoint_chain(&genesis, std::slice::from_ref(&honest), &checkpoint)
+            .expect("a position-consistent checkpoint must verify");
+
+        // Inconsistent: same decoded state (latest_height 5) but the terminal header
+        // claims height 9, so latest_height + 1 (6) != 9. The bytes are still validly
+        // committed by the terminal header and the validator set checks out, yet the
+        // position binding must reject it.
+        let (genesis, checkpoint, _tampered, mismatched) = checkpoint_verification_fixture(5, 9);
+        let result = super::verify_checkpoint_chain(
+            &genesis,
+            std::slice::from_ref(&mismatched),
+            &checkpoint,
+        );
+        assert!(
+            matches!(
+                result,
+                Err(super::CheckpointVerificationError::CheckpointStatePositionMismatch(_))
+            ),
+            "verifier must reject a checkpoint whose decoded state position is not bound \
+             to the terminal finalized header, got {result:?}"
+        );
+    }
+
     // Closes the typed-API trust-boundary gap: a finalized header carries header
     // fields (e.g. `checkpoint_hash`) and a certificate that signs a digest. The
     // fields must be bound to the signed digest, otherwise an attacker can pair a
@@ -1385,7 +1482,8 @@ mod tests {
     fn test_checkpoint_verifier_rejects_typed_header_field_mutation() {
         use crate::header::{FinalizedHeader, FinalizedHeaderError, Header};
 
-        let (genesis, checkpoint, tampered_checkpoint, honest) = checkpoint_verification_fixture();
+        let (genesis, checkpoint, tampered_checkpoint, honest) =
+            checkpoint_verification_fixture(0, 1);
 
         // Sanity: the honest finalized header verifies against the honest checkpoint.
         super::verify_checkpoint_chain(&genesis, std::slice::from_ref(&honest), &checkpoint)


### PR DESCRIPTION
Addresses https://github.com/SeismicSystems/summit/issues/215.

Changes:
- Add a position-binding step to verify_checkpoint_chain. Since the checkpoint is created at the penultimate block of an epoch and the terminal header is the last block, an honest checkpoint satisfies: latest_height + 1 == terminal.height(), head_digest == terminal.parent(), epoch == terminal.epoch(). Reject any checkpoint that doesn't.
- Add CheckpointVerificationError::CheckpointStatePositionMismatch.
- Parameterize checkpoint_verification_fixture by (state_latest_height, terminal_header_height) so it models the penultimate→last structure.
- Add regression test test_checkpoint_verifier_binds_state_position_to_terminal_header: a consistent (5,6) checkpoint verifies; an inconsistent (5,9) one is rejected.