### PR TITLE
fix: bind pause/unpause RPC authorization to the deployment

### DIFF
--- a/rpc/src/auth.rs
+++ b/rpc/src/auth.rs
@@ -25,18 +25,32 @@ fn now_secs() -> Result<u64, RpcError> {
         .map_err(|e| RpcError::Internal(format!("system clock before unix epoch: {e}")))
 }
 
+/// `scope` is the hex of the deployment-bound pause domain
+/// (`summit_types::pause_signature_domain` over the EL genesis hash +
+/// namespace). Binding it into the signed message scopes the authorization to
+/// this deployment, so a pause/unpause signature cannot be replayed against
+/// another network that trusts the same admin key.
 pub fn verify_action(
+    scope: &str,
     action: &str,
     timestamp_secs: u64,
     signature_hex: &str,
 ) -> Result<(), RpcError> {
     let admin = admin_address()?;
-    verify_action_with(&admin, now_secs()?, action, timestamp_secs, signature_hex)
+    verify_action_with(
+        &admin,
+        now_secs()?,
+        scope,
+        action,
+        timestamp_secs,
+        signature_hex,
+    )
 }
 
 pub(crate) fn verify_action_with(
     expected: &Address,
     now_secs: u64,
+    scope: &str,
     action: &str,
     timestamp_secs: u64,
     signature_hex: &str,
@@ -49,7 +63,7 @@ pub(crate) fn verify_action_with(
     let sig_bytes = from_hex_formatted(signature_hex).ok_or(RpcError::InvalidSignature)?;
     let signature = Signature::from_raw(&sig_bytes).map_err(|_| RpcError::InvalidSignature)?;
 
-    let message = format!("{DOMAIN}:{action}:{timestamp_secs}");
+    let message = format!("{DOMAIN}:{scope}:{action}:{timestamp_secs}");
     let recovered = signature
         .recover_address_from_msg(message.as_bytes())
         .map_err(|_| RpcError::InvalidSignature)?;
@@ -66,9 +80,19 @@ mod tests {
     use super::*;
     use alloy_signer::SignerSync;
     use alloy_signer_local::PrivateKeySigner;
+    use summit_types::pause_signature_domain;
 
-    fn sign(action: &str, timestamp_secs: u64, signer: &PrivateKeySigner) -> String {
-        let message = format!("{DOMAIN}:{action}:{timestamp_secs}");
+    // Two deployments that share an admin key but differ in their chain
+    // identity (genesis hash and/or namespace).
+    fn scope_a() -> String {
+        alloy_primitives::hex::encode(pause_signature_domain([0x11; 32], b"net-a"))
+    }
+    fn scope_b() -> String {
+        alloy_primitives::hex::encode(pause_signature_domain([0x22; 32], b"net-b"))
+    }
+
+    fn sign(scope: &str, action: &str, timestamp_secs: u64, signer: &PrivateKeySigner) -> String {
+        let message = format!("{DOMAIN}:{scope}:{action}:{timestamp_secs}");
         let sig = signer.sign_message_sync(message.as_bytes()).unwrap();
         format!("0x{}", hex::encode(sig.as_bytes()))
     }
@@ -78,9 +102,10 @@ mod tests {
         let signer = PrivateKeySigner::random();
         let addr = signer.address();
         let now = 1_700_000_000;
-        let sig = sign(ACTION_PAUSE, now, &signer);
+        let scope = scope_a();
+        let sig = sign(&scope, ACTION_PAUSE, now, &signer);
 
-        assert!(verify_action_with(&addr, now, ACTION_PAUSE, now, &sig).is_ok());
+        assert!(verify_action_with(&addr, now, &scope, ACTION_PAUSE, now, &sig).is_ok());
     }
 
     #[test]
@@ -88,9 +113,10 @@ mod tests {
         let signer = PrivateKeySigner::random();
         let addr = signer.address();
         let now = 1_700_000_000;
-        let sig = sign(ACTION_UNPAUSE, now, &signer);
+        let scope = scope_a();
+        let sig = sign(&scope, ACTION_UNPAUSE, now, &signer);
 
-        assert!(verify_action_with(&addr, now, ACTION_UNPAUSE, now, &sig).is_ok());
+        assert!(verify_action_with(&addr, now, &scope, ACTION_UNPAUSE, now, &sig).is_ok());
     }
 
     #[test]
@@ -98,9 +124,29 @@ mod tests {
         let signer = PrivateKeySigner::random();
         let addr = signer.address();
         let now = 1_700_000_000;
-        let pause_sig = sign(ACTION_PAUSE, now, &signer);
+        let scope = scope_a();
+        let pause_sig = sign(&scope, ACTION_PAUSE, now, &signer);
 
-        let err = verify_action_with(&addr, now, ACTION_UNPAUSE, now, &pause_sig).unwrap_err();
+        let err =
+            verify_action_with(&addr, now, &scope, ACTION_UNPAUSE, now, &pause_sig).unwrap_err();
+        assert!(matches!(err, RpcError::InvalidSignature));
+    }
+
+    /// A pause/unpause signature minted for deployment A must not authorize the
+    /// same action on deployment B, even though both trust the same admin key.
+    #[test]
+    fn rejects_other_deployment_scope() {
+        let admin = PrivateKeySigner::random();
+        let addr = admin.address();
+        let now = 1_700_000_000;
+
+        // Admin legitimately signs a pause for deployment A.
+        let sig = sign(&scope_a(), ACTION_PAUSE, now, &admin);
+
+        // Deployment A accepts it...
+        assert!(verify_action_with(&addr, now, &scope_a(), ACTION_PAUSE, now, &sig).is_ok());
+        // ...but deployment B rejects the very same signature.
+        let err = verify_action_with(&addr, now, &scope_b(), ACTION_PAUSE, now, &sig).unwrap_err();
         assert!(matches!(err, RpcError::InvalidSignature));
     }
 
@@ -110,9 +156,11 @@ mod tests {
         let addr = signer.address();
         let signed_at = 1_700_000_000;
         let now = signed_at + TIMESTAMP_WINDOW_SECS + 1;
-        let sig = sign(ACTION_PAUSE, signed_at, &signer);
+        let scope = scope_a();
+        let sig = sign(&scope, ACTION_PAUSE, signed_at, &signer);
 
-        let err = verify_action_with(&addr, now, ACTION_PAUSE, signed_at, &sig).unwrap_err();
+        let err =
+            verify_action_with(&addr, now, &scope, ACTION_PAUSE, signed_at, &sig).unwrap_err();
         assert!(matches!(err, RpcError::TimestampOutOfWindow));
     }
 
@@ -122,9 +170,11 @@ mod tests {
         let addr = signer.address();
         let now = 1_700_000_000;
         let signed_at = now + TIMESTAMP_WINDOW_SECS + 1;
-        let sig = sign(ACTION_PAUSE, signed_at, &signer);
+        let scope = scope_a();
+        let sig = sign(&scope, ACTION_PAUSE, signed_at, &signer);
 
-        let err = verify_action_with(&addr, now, ACTION_PAUSE, signed_at, &sig).unwrap_err();
+        let err =
+            verify_action_with(&addr, now, &scope, ACTION_PAUSE, signed_at, &sig).unwrap_err();
         assert!(matches!(err, RpcError::TimestampOutOfWindow));
     }
 
@@ -133,9 +183,11 @@ mod tests {
         let attacker = PrivateKeySigner::random();
         let admin = PrivateKeySigner::random();
         let now = 1_700_000_000;
-        let sig = sign(ACTION_PAUSE, now, &attacker);
+        let scope = scope_a();
+        let sig = sign(&scope, ACTION_PAUSE, now, &attacker);
 
-        let err = verify_action_with(&admin.address(), now, ACTION_PAUSE, now, &sig).unwrap_err();
+        let err =
+            verify_action_with(&admin.address(), now, &scope, ACTION_PAUSE, now, &sig).unwrap_err();
         assert!(matches!(err, RpcError::InvalidSignature));
     }
 
@@ -145,7 +197,8 @@ mod tests {
         let addr = signer.address();
         let now = 1_700_000_000;
 
-        let err = verify_action_with(&addr, now, ACTION_PAUSE, now, "not-hex-at-all").unwrap_err();
+        let err = verify_action_with(&addr, now, &scope_a(), ACTION_PAUSE, now, "not-hex-at-all")
+            .unwrap_err();
         assert!(matches!(err, RpcError::InvalidSignature));
     }
 
@@ -154,11 +207,12 @@ mod tests {
         let signer = PrivateKeySigner::random();
         let addr = signer.address();
         let signed_at = 1_700_000_000;
-        let sig = sign(ACTION_PAUSE, signed_at, &signer);
+        let scope = scope_a();
+        let sig = sign(&scope, ACTION_PAUSE, signed_at, &signer);
 
         let tampered_ts = signed_at + 5;
-        let err =
-            verify_action_with(&addr, tampered_ts, ACTION_PAUSE, tampered_ts, &sig).unwrap_err();
+        let err = verify_action_with(&addr, tampered_ts, &scope, ACTION_PAUSE, tampered_ts, &sig)
+            .unwrap_err();
         assert!(matches!(err, RpcError::InvalidSignature));
     }
 

--- a/rpc/src/server.rs
+++ b/rpc/src/server.rs
@@ -22,6 +22,8 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use summit_types::consensus_state_query::ConsensusStateQuery;
+#[cfg(feature = "permissioned")]
+use summit_types::pause_signature_domain;
 use summit_types::scheme::MultisigScheme;
 use summit_types::ssz_tree_key::SszStateKey;
 use summit_types::{
@@ -55,6 +57,12 @@ pub struct SummitRpcServer {
     in_flight_state_proofs: Arc<AtomicUsize>,
     #[cfg(feature = "permissioned")]
     paused: Arc<AtomicBool>,
+    /// Hex of the pause-authorization domain (genesis hash + namespace). Bound
+    /// into every pause/unpause signed message so an authorization for one
+    /// deployment cannot be replayed against another that trusts the same
+    /// admin key.
+    #[cfg(feature = "permissioned")]
+    pause_scope: String,
 }
 
 /// Releases one in-flight state-proof slot on drop — covers normal completion,
@@ -84,6 +92,11 @@ impl SummitRpcServer {
             in_flight_state_proofs: Arc::new(AtomicUsize::new(0)),
             #[cfg(feature = "permissioned")]
             paused,
+            #[cfg(feature = "permissioned")]
+            pause_scope: alloy_primitives::hex::encode(pause_signature_domain(
+                genesis_hash,
+                namespace,
+            )),
         }
     }
 }
@@ -447,14 +460,24 @@ impl SummitAdminApiServer for SummitRpcServer {
 #[async_trait]
 impl SummitPermissionedApiServer for SummitRpcServer {
     async fn pause(&self, timestamp_secs: u64, signature: String) -> RpcResult<bool> {
-        auth::verify_action(auth::ACTION_PAUSE, timestamp_secs, &signature)?;
+        auth::verify_action(
+            &self.pause_scope,
+            auth::ACTION_PAUSE,
+            timestamp_secs,
+            &signature,
+        )?;
         self.paused.store(true, Ordering::Relaxed);
         tracing::info!("consensus paused via RPC");
         Ok(true)
     }
 
     async fn unpause(&self, timestamp_secs: u64, signature: String) -> RpcResult<bool> {
-        auth::verify_action(auth::ACTION_UNPAUSE, timestamp_secs, &signature)?;
+        auth::verify_action(
+            &self.pause_scope,
+            auth::ACTION_UNPAUSE,
+            timestamp_secs,
+            &signature,
+        )?;
         self.paused.store(false, Ordering::Relaxed);
         tracing::info!("consensus unpaused via RPC");
         Ok(true)

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -44,6 +44,7 @@ pub type Activity = CActivity<Signature, Digest>;
 pub const PROTOCOL_VERSION: u32 = 1;
 const DEPOSIT_DOMAIN_TAG: &[u8] = b"summit-deposit-v1";
 const CHAIN_DOMAIN_TAG: &[u8] = b"summit-chain-v1";
+const PAUSE_DOMAIN_TAG: &[u8] = b"summit-pause-v1";
 
 /// Domain for live peer authentication and BLS consensus signatures, bound to
 /// the immutable identity of this chain deployment: the protocol version and
@@ -66,18 +67,36 @@ pub fn chain_domain(config_digest: [u8; 32]) -> [u8; 32] {
     Sha256::hash(&domain_data).0
 }
 
-/// Domain for deposit-authorization signatures, bound to the full Summit
-/// deployment boundary: the EL genesis hash AND the Summit `namespace`.
-pub fn deposit_signature_domain(genesis_hash: [u8; 32], namespace: &[u8]) -> Digest {
-    let mut domain_data =
-        Vec::with_capacity(DEPOSIT_DOMAIN_TAG.len() + 4 + 32 + 4 + namespace.len());
-    domain_data.extend_from_slice(DEPOSIT_DOMAIN_TAG);
+/// Folds a purpose tag, protocol version, EL genesis hash, and (length-prefixed)
+/// Summit `namespace` into a single domain digest. The genesis hash + namespace
+/// pin a signature to one deployment; the tag separates signing purposes so a
+/// signature minted for one domain can never be reinterpreted under another.
+fn signature_domain(tag: &[u8], genesis_hash: [u8; 32], namespace: &[u8]) -> Digest {
+    let mut domain_data = Vec::with_capacity(tag.len() + 4 + 32 + 4 + namespace.len());
+    domain_data.extend_from_slice(tag);
     domain_data.extend_from_slice(&PROTOCOL_VERSION.to_le_bytes());
     domain_data.extend_from_slice(&genesis_hash);
     // Length-prefix the variable-length namespace so the domain is unambiguous.
     domain_data.extend_from_slice(&(namespace.len() as u32).to_le_bytes());
     domain_data.extend_from_slice(namespace);
     Sha256::hash(&domain_data)
+}
+
+/// Domain for deposit-authorization signatures, bound to the full Summit
+/// deployment boundary: the EL genesis hash AND the Summit `namespace`.
+pub fn deposit_signature_domain(genesis_hash: [u8; 32], namespace: &[u8]) -> Digest {
+    signature_domain(DEPOSIT_DOMAIN_TAG, genesis_hash, namespace)
+}
+
+/// Domain for consensus-pause RPC authorization signatures, bound to the full
+/// Summit deployment boundary: the EL genesis hash AND the Summit `namespace`.
+///
+/// Binding the deployment scope means a pause/unpause signature minted for one
+/// network cannot be replayed against another that happens to trust the same
+/// admin key. The distinct tag also prevents a deposit signature from being
+/// reinterpreted as a pause authorization (and vice versa).
+pub fn pause_signature_domain(genesis_hash: [u8; 32], namespace: &[u8]) -> Digest {
+    signature_domain(PAUSE_DOMAIN_TAG, genesis_hash, namespace)
 }
 
 /// Auxiliary data needed for block construction


### PR DESCRIPTION
Addresses https://github.com/SeismicSystems/summit/issues/340.

Changes:
- types: add `pause_signature_domain(genesis_hash, namespace)`, sharing a new `signature_domain(tag, …)` helper with `deposit_signature_domain` (distinct `summit-pause-v1` tag; deposit domain bytes unchanged).
- rpc/auth: signed message is now `summit-pause-v1:{scope_hex}:{action}:{timestamp}`; `verify_action` takes the deployment scope.
- rpc/server: `SummitRpcServer` stores `pause_scope` (hex of the pause domain), computed in `new()` from the genesis hash + namespace it already receives.
- rpc/auth tests: thread the scope through existing tests; add `rejects_other_deployment_scope` (a signature for net-a is rejected on net-b).

Note:
I don't think a nonce is necessary, since the signed pause message contains a timestamp.
The timestamp allows replays only in the freshness window.
Since the pause is idempoitent, even a replay within the freshness window will not affect the network.
The only realistic scenario is if the network is paused and unpaused inside of the freshness window of the pause message..
An attacker could replay the pause message to undo the unpause. However, this can be countered by unpausing the network again.
It is also likely, that the intended network pause will outlast the freshness window of the pause message.
Cross-deployment replays are an issue, so this PR adds the namespace and genesis hash to the signed message.