### PR TITLE
fix: bound RPC request time via configurable timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6714,6 +6714,7 @@ dependencies = [
  "http-body",
  "iri-string",
  "pin-project-lite",
+ "tokio",
  "tower 0.5.2",
  "tower-layer",
  "tower-service",

--- a/node/src/args.rs
+++ b/node/src/args.rs
@@ -12,8 +12,8 @@ use commonware_cryptography::{Signer, certificate::Scheme};
 use commonware_p2p::{Ingress, authenticated};
 use commonware_runtime::{Handle, Metrics as _, Runner, Spawner, tokio};
 use summit_rpc::{
-    DEFAULT_RPC_BODY_LIMIT_BYTES, PathSender, RpcBodyLimits, start_rpc_server,
-    start_rpc_server_for_genesis,
+    DEFAULT_RPC_BODY_LIMIT_BYTES, DEFAULT_RPC_REQUEST_TIMEOUT_SECS, PathSender, RpcBodyLimits,
+    start_rpc_server, start_rpc_server_for_genesis,
 };
 use tokio_util::sync::CancellationToken;
 
@@ -124,6 +124,12 @@ pub struct RunFlags {
     /// Maximum JSON-RPC response body size, in bytes.
     #[arg(long, default_value_t = DEFAULT_RPC_BODY_LIMIT_BYTES)]
     pub rpc_max_response_body_size: u32,
+
+    /// Maximum time, in seconds, a single RPC request may hold its connection
+    /// permit (HTTP body read plus method dispatch) before it is timed out.
+    /// Bounds slow/partial-body clients that would otherwise occupy permits.
+    #[arg(long, default_value_t = DEFAULT_RPC_REQUEST_TIMEOUT_SECS)]
+    pub rpc_request_timeout_secs: u64,
 
     /// Number of tokio worker threads (defaults to number of logical CPUs)
     #[arg(long)]
@@ -305,6 +311,7 @@ async fn acquire_genesis(context: &tokio::Context, flags: &RunFlags) -> Genesis 
     let rpc_body_limits = RpcBodyLimits {
         max_request_body_size: flags.rpc_max_request_body_size,
         max_response_body_size: flags.rpc_max_response_body_size,
+        request_timeout: std::time::Duration::from_secs(flags.rpc_request_timeout_secs),
     };
     let rpc_genesis_path = genesis_path.clone();
     let _rpc_handle = context
@@ -894,6 +901,7 @@ where
     let rpc_body_limits = RpcBodyLimits {
         max_request_body_size: flags.rpc_max_request_body_size,
         max_response_body_size: flags.rpc_max_response_body_size,
+        request_timeout: std::time::Duration::from_secs(flags.rpc_request_timeout_secs),
     };
     let stop_signal = context.stopped();
     let rpc_handle = context.with_label("rpc").spawn(move |_context| async move {

--- a/node/src/bin/observer.rs
+++ b/node/src/bin/observer.rs
@@ -512,6 +512,7 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         admin_rpc_port: (3031 + (node * 10)) as u16,
         rpc_max_request_body_size: summit_rpc::DEFAULT_RPC_BODY_LIMIT_BYTES,
         rpc_max_response_body_size: summit_rpc::DEFAULT_RPC_BODY_LIMIT_BYTES,
+        rpc_request_timeout_secs: summit_rpc::DEFAULT_RPC_REQUEST_TIMEOUT_SECS,
         worker_threads: Some(2),
         log_level: "debug".into(),
         db_prefix: format!("{node}"),

--- a/node/src/bin/protocol_params.rs
+++ b/node/src/bin/protocol_params.rs
@@ -403,6 +403,7 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         admin_rpc_port: (3031 + (node * 10)) as u16,
         rpc_max_request_body_size: summit_rpc::DEFAULT_RPC_BODY_LIMIT_BYTES,
         rpc_max_response_body_size: summit_rpc::DEFAULT_RPC_BODY_LIMIT_BYTES,
+        rpc_request_timeout_secs: summit_rpc::DEFAULT_RPC_REQUEST_TIMEOUT_SECS,
         worker_threads: Some(2),
         log_level: "debug".into(),
         db_prefix: format!("{node}"),

--- a/node/src/bin/stake_and_checkpoint.rs
+++ b/node/src/bin/stake_and_checkpoint.rs
@@ -694,6 +694,7 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         admin_rpc_port: (3031 + (node * 10)) as u16,
         rpc_max_request_body_size: summit_rpc::DEFAULT_RPC_BODY_LIMIT_BYTES,
         rpc_max_response_body_size: summit_rpc::DEFAULT_RPC_BODY_LIMIT_BYTES,
+        rpc_request_timeout_secs: summit_rpc::DEFAULT_RPC_REQUEST_TIMEOUT_SECS,
         worker_threads: Some(2),
         log_level: "debug".into(),
         db_prefix: format!("{node}"),

--- a/node/src/bin/stake_and_join_with_outdated_ckpt.rs
+++ b/node/src/bin/stake_and_join_with_outdated_ckpt.rs
@@ -812,6 +812,7 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         admin_rpc_port: (3031 + (node * 10)) as u16,
         rpc_max_request_body_size: summit_rpc::DEFAULT_RPC_BODY_LIMIT_BYTES,
         rpc_max_response_body_size: summit_rpc::DEFAULT_RPC_BODY_LIMIT_BYTES,
+        rpc_request_timeout_secs: summit_rpc::DEFAULT_RPC_REQUEST_TIMEOUT_SECS,
         worker_threads: Some(2),
         log_level: "debug".into(),
         db_prefix: format!("{node}"),

--- a/node/src/bin/sync_from_genesis.rs
+++ b/node/src/bin/sync_from_genesis.rs
@@ -676,6 +676,7 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         admin_rpc_port: (3031 + (node * 10)) as u16,
         rpc_max_request_body_size: summit_rpc::DEFAULT_RPC_BODY_LIMIT_BYTES,
         rpc_max_response_body_size: summit_rpc::DEFAULT_RPC_BODY_LIMIT_BYTES,
+        rpc_request_timeout_secs: summit_rpc::DEFAULT_RPC_REQUEST_TIMEOUT_SECS,
         worker_threads: Some(2),
         log_level: "debug".into(),
         db_prefix: format!("{node}"),

--- a/node/src/bin/testnet.rs
+++ b/node/src/bin/testnet.rs
@@ -190,6 +190,7 @@ fn get_node_flags(node: usize) -> RunFlags {
         admin_rpc_port: (3031 + (node * 10)) as u16,
         rpc_max_request_body_size: summit_rpc::DEFAULT_RPC_BODY_LIMIT_BYTES,
         rpc_max_response_body_size: summit_rpc::DEFAULT_RPC_BODY_LIMIT_BYTES,
+        rpc_request_timeout_secs: summit_rpc::DEFAULT_RPC_REQUEST_TIMEOUT_SECS,
         worker_threads: Some(2),
         log_level: "debug".into(),
         db_prefix: format!("{node}"),

--- a/node/src/bin/verify_consensus_state_proof.rs
+++ b/node/src/bin/verify_consensus_state_proof.rs
@@ -574,6 +574,7 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         admin_rpc_port: (3031 + (node * 10)) as u16,
         rpc_max_request_body_size: summit_rpc::DEFAULT_RPC_BODY_LIMIT_BYTES,
         rpc_max_response_body_size: summit_rpc::DEFAULT_RPC_BODY_LIMIT_BYTES,
+        rpc_request_timeout_secs: summit_rpc::DEFAULT_RPC_REQUEST_TIMEOUT_SECS,
         worker_threads: Some(2),
         log_level: "debug".into(),
         db_prefix: format!("{node}"),

--- a/node/src/bin/withdraw_and_exit.rs
+++ b/node/src/bin/withdraw_and_exit.rs
@@ -398,6 +398,7 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         admin_rpc_port: (3031 + (node * 10)) as u16,
         rpc_max_request_body_size: summit_rpc::DEFAULT_RPC_BODY_LIMIT_BYTES,
         rpc_max_response_body_size: summit_rpc::DEFAULT_RPC_BODY_LIMIT_BYTES,
+        rpc_request_timeout_secs: summit_rpc::DEFAULT_RPC_REQUEST_TIMEOUT_SECS,
         worker_threads: Some(2),
         log_level: "debug".into(),
         db_prefix: format!("{node}"),

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -30,7 +30,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tracing.workspace = true
 tower = { workspace = true }
-tower-http = { version = "0.6", features = ["cors"] }
+tower-http = { version = "0.6", features = ["cors", "timeout"] }
 http = { workspace = true }
 hyper = "1.0"
 bytes = { workspace = true }

--- a/rpc/src/builder.rs
+++ b/rpc/src/builder.rs
@@ -1,22 +1,30 @@
 use http::{HeaderValue, Method};
 use jsonrpsee::server::{ServerBuilder, ServerConfigBuilder, ServerHandle};
 use std::net::SocketAddr;
+use std::time::Duration;
 use tower::ServiceBuilder;
 use tower_http::cors::{AllowOrigin, Any, CorsLayer};
+use tower_http::timeout::TimeoutLayer;
 
 pub struct RpcServerBuilder {
     addr: SocketAddr,
     config: ServerConfigBuilder,
     cors_domains: Option<String>,
+    request_timeout: Duration,
 }
 
-pub struct RpcServer {
-    inner: jsonrpsee::server::Server<
-        tower::layer::util::Stack<
-            tower::util::Either<CorsLayer, tower::layer::util::Identity>,
-            tower::layer::util::Identity,
-        >,
+/// The HTTP middleware stack applied to every RPC server: a per-request
+/// timeout wrapping an optional CORS layer (see `build`).
+type RpcHttpMiddleware = tower::layer::util::Stack<
+    TimeoutLayer,
+    tower::layer::util::Stack<
+        tower::util::Either<CorsLayer, tower::layer::util::Identity>,
+        tower::layer::util::Identity,
     >,
+>;
+
+pub struct RpcServer {
+    inner: jsonrpsee::server::Server<RpcHttpMiddleware>,
 }
 
 impl RpcServer {
@@ -38,6 +46,7 @@ impl RpcServerBuilder {
             addr: SocketAddr::from(([0, 0, 0, 0], port)),
             config: ServerConfigBuilder::new(),
             cors_domains: None,
+            request_timeout: Duration::from_secs(crate::DEFAULT_RPC_REQUEST_TIMEOUT_SECS),
         }
     }
 
@@ -49,6 +58,7 @@ impl RpcServerBuilder {
             addr: SocketAddr::from(([127, 0, 0, 1], port)),
             config: ServerConfigBuilder::new(),
             cors_domains: None,
+            request_timeout: Duration::from_secs(crate::DEFAULT_RPC_REQUEST_TIMEOUT_SECS),
         }
     }
 
@@ -72,6 +82,17 @@ impl RpcServerBuilder {
         self
     }
 
+    /// Sets the per-request timeout. jsonrpsee takes the `max_connections`
+    /// permit before reading the HTTP body and has no body read deadline of its
+    /// own, so without a bound a slow or withheld body holds a permit
+    /// indefinitely and a few hundred such requests can deny all RPC. This caps
+    /// how long any single request may hold its permit, from accept through body
+    /// read and method dispatch.
+    pub fn with_request_timeout(mut self, timeout: Duration) -> Self {
+        self.request_timeout = timeout;
+        self
+    }
+
     pub async fn build(self) -> anyhow::Result<RpcServer> {
         let cors_layer = self
             .cors_domains
@@ -79,7 +100,9 @@ impl RpcServerBuilder {
             .map(create_cors_layer)
             .transpose()?;
 
-        let http_middleware = ServiceBuilder::new().option_layer(cors_layer);
+        let http_middleware = ServiceBuilder::new()
+            .option_layer(cors_layer)
+            .layer(TimeoutLayer::new(self.request_timeout));
 
         let server = ServerBuilder::new()
             .set_config(self.config.build())

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -32,10 +32,17 @@ use tokio_util::sync::CancellationToken;
 
 pub const DEFAULT_RPC_BODY_LIMIT_BYTES: u32 = 50 * 1024 * 1024;
 
+/// Default per-request timeout, in seconds. Bounds how long a single HTTP
+/// request may hold a connection permit (jsonrpsee acquires the permit before
+/// reading the body and has no body read deadline of its own).
+pub const DEFAULT_RPC_REQUEST_TIMEOUT_SECS: u64 = 30;
+
 #[derive(Debug, Clone, Copy)]
 pub struct RpcBodyLimits {
     pub max_request_body_size: u32,
     pub max_response_body_size: u32,
+    /// Per-request timeout (accept through body read and method dispatch).
+    pub request_timeout: std::time::Duration,
 }
 
 impl Default for RpcBodyLimits {
@@ -43,6 +50,7 @@ impl Default for RpcBodyLimits {
         Self {
             max_request_body_size: DEFAULT_RPC_BODY_LIMIT_BYTES,
             max_response_body_size: DEFAULT_RPC_BODY_LIMIT_BYTES,
+            request_timeout: std::time::Duration::from_secs(DEFAULT_RPC_REQUEST_TIMEOUT_SECS),
         }
     }
 }
@@ -79,6 +87,7 @@ pub async fn start_rpc_server(
         .with_max_connections(1000)
         .with_max_request_body_size(body_limits.max_request_body_size)
         .with_max_response_body_size(body_limits.max_response_body_size)
+        .with_request_timeout(body_limits.request_timeout)
         .with_cors(Some("*".to_string()))
         .build()
         .await?;
@@ -94,6 +103,7 @@ pub async fn start_rpc_server(
         .with_max_connections(1000)
         .with_max_request_body_size(body_limits.max_request_body_size)
         .with_max_response_body_size(body_limits.max_response_body_size)
+        .with_request_timeout(body_limits.request_timeout)
         .build()
         .await?;
 
@@ -241,6 +251,7 @@ pub async fn start_rpc_server_for_genesis(
     let server = builder::RpcServerBuilder::new_localhost(port)
         .with_max_request_body_size(body_limits.max_request_body_size)
         .with_max_response_body_size(body_limits.max_response_body_size)
+        .with_request_timeout(body_limits.request_timeout)
         .build()
         .await?;
     let addr = server.local_addr()?;


### PR DESCRIPTION
Addresses https://github.com/SeismicSystems/summit/issues/347.

Changes:
- rpc builder: always apply tower_http::timeout::TimeoutLayer; add a with_request_timeout setter (enable tower-http "timeout" feature).
- RpcBodyLimits: add request_timeout; thread it through the public, admin, and genesis start paths.
- CLI: new --rpc-request-timeout-secs flag (default 30s), wired into RpcBodyLimits; add the field to the e2e/testnet RunFlags literals.