### PR TITLE
fix: cap JSON-RPC batch size

### DIFF
--- a/node/src/args.rs
+++ b/node/src/args.rs
@@ -12,8 +12,8 @@ use commonware_cryptography::{Signer, certificate::Scheme};
 use commonware_p2p::{Ingress, authenticated};
 use commonware_runtime::{Handle, Metrics as _, Runner, Spawner, tokio};
 use summit_rpc::{
-    DEFAULT_RPC_BODY_LIMIT_BYTES, DEFAULT_RPC_REQUEST_TIMEOUT_SECS, PathSender, RpcBodyLimits,
-    start_rpc_server, start_rpc_server_for_genesis,
+    DEFAULT_RPC_BODY_LIMIT_BYTES, DEFAULT_RPC_MAX_BATCH_SIZE, DEFAULT_RPC_REQUEST_TIMEOUT_SECS,
+    PathSender, RpcBodyLimits, start_rpc_server, start_rpc_server_for_genesis,
 };
 use tokio_util::sync::CancellationToken;
 
@@ -130,6 +130,11 @@ pub struct RunFlags {
     /// Bounds slow/partial-body clients that would otherwise occupy permits.
     #[arg(long, default_value_t = DEFAULT_RPC_REQUEST_TIMEOUT_SECS)]
     pub rpc_request_timeout_secs: u64,
+
+    /// Maximum number of calls allowed in a single JSON-RPC batch request.
+    /// Bounds batch fan-out into expensive methods. `0` disables batching.
+    #[arg(long, default_value_t = DEFAULT_RPC_MAX_BATCH_SIZE)]
+    pub rpc_max_batch_size: u32,
 
     /// Number of tokio worker threads (defaults to number of logical CPUs)
     #[arg(long)]
@@ -312,6 +317,7 @@ async fn acquire_genesis(context: &tokio::Context, flags: &RunFlags) -> Genesis 
         max_request_body_size: flags.rpc_max_request_body_size,
         max_response_body_size: flags.rpc_max_response_body_size,
         request_timeout: std::time::Duration::from_secs(flags.rpc_request_timeout_secs),
+        max_batch_size: flags.rpc_max_batch_size,
     };
     let rpc_genesis_path = genesis_path.clone();
     let _rpc_handle = context
@@ -915,6 +921,7 @@ where
         max_request_body_size: flags.rpc_max_request_body_size,
         max_response_body_size: flags.rpc_max_response_body_size,
         request_timeout: std::time::Duration::from_secs(flags.rpc_request_timeout_secs),
+        max_batch_size: flags.rpc_max_batch_size,
     };
     let stop_signal = context.stopped();
     let rpc_handle = context.with_label("rpc").spawn(move |_context| async move {

--- a/node/src/bin/observer.rs
+++ b/node/src/bin/observer.rs
@@ -513,6 +513,7 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         rpc_max_request_body_size: summit_rpc::DEFAULT_RPC_BODY_LIMIT_BYTES,
         rpc_max_response_body_size: summit_rpc::DEFAULT_RPC_BODY_LIMIT_BYTES,
         rpc_request_timeout_secs: summit_rpc::DEFAULT_RPC_REQUEST_TIMEOUT_SECS,
+        rpc_max_batch_size: summit_rpc::DEFAULT_RPC_MAX_BATCH_SIZE,
         worker_threads: Some(2),
         log_level: "debug".into(),
         db_prefix: format!("{node}"),

--- a/node/src/bin/protocol_params.rs
+++ b/node/src/bin/protocol_params.rs
@@ -404,6 +404,7 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         rpc_max_request_body_size: summit_rpc::DEFAULT_RPC_BODY_LIMIT_BYTES,
         rpc_max_response_body_size: summit_rpc::DEFAULT_RPC_BODY_LIMIT_BYTES,
         rpc_request_timeout_secs: summit_rpc::DEFAULT_RPC_REQUEST_TIMEOUT_SECS,
+        rpc_max_batch_size: summit_rpc::DEFAULT_RPC_MAX_BATCH_SIZE,
         worker_threads: Some(2),
         log_level: "debug".into(),
         db_prefix: format!("{node}"),

--- a/node/src/bin/stake_and_checkpoint.rs
+++ b/node/src/bin/stake_and_checkpoint.rs
@@ -695,6 +695,7 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         rpc_max_request_body_size: summit_rpc::DEFAULT_RPC_BODY_LIMIT_BYTES,
         rpc_max_response_body_size: summit_rpc::DEFAULT_RPC_BODY_LIMIT_BYTES,
         rpc_request_timeout_secs: summit_rpc::DEFAULT_RPC_REQUEST_TIMEOUT_SECS,
+        rpc_max_batch_size: summit_rpc::DEFAULT_RPC_MAX_BATCH_SIZE,
         worker_threads: Some(2),
         log_level: "debug".into(),
         db_prefix: format!("{node}"),

--- a/node/src/bin/stake_and_join_with_outdated_ckpt.rs
+++ b/node/src/bin/stake_and_join_with_outdated_ckpt.rs
@@ -813,6 +813,7 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         rpc_max_request_body_size: summit_rpc::DEFAULT_RPC_BODY_LIMIT_BYTES,
         rpc_max_response_body_size: summit_rpc::DEFAULT_RPC_BODY_LIMIT_BYTES,
         rpc_request_timeout_secs: summit_rpc::DEFAULT_RPC_REQUEST_TIMEOUT_SECS,
+        rpc_max_batch_size: summit_rpc::DEFAULT_RPC_MAX_BATCH_SIZE,
         worker_threads: Some(2),
         log_level: "debug".into(),
         db_prefix: format!("{node}"),

--- a/node/src/bin/sync_from_genesis.rs
+++ b/node/src/bin/sync_from_genesis.rs
@@ -677,6 +677,7 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         rpc_max_request_body_size: summit_rpc::DEFAULT_RPC_BODY_LIMIT_BYTES,
         rpc_max_response_body_size: summit_rpc::DEFAULT_RPC_BODY_LIMIT_BYTES,
         rpc_request_timeout_secs: summit_rpc::DEFAULT_RPC_REQUEST_TIMEOUT_SECS,
+        rpc_max_batch_size: summit_rpc::DEFAULT_RPC_MAX_BATCH_SIZE,
         worker_threads: Some(2),
         log_level: "debug".into(),
         db_prefix: format!("{node}"),

--- a/node/src/bin/testnet.rs
+++ b/node/src/bin/testnet.rs
@@ -191,6 +191,7 @@ fn get_node_flags(node: usize) -> RunFlags {
         rpc_max_request_body_size: summit_rpc::DEFAULT_RPC_BODY_LIMIT_BYTES,
         rpc_max_response_body_size: summit_rpc::DEFAULT_RPC_BODY_LIMIT_BYTES,
         rpc_request_timeout_secs: summit_rpc::DEFAULT_RPC_REQUEST_TIMEOUT_SECS,
+        rpc_max_batch_size: summit_rpc::DEFAULT_RPC_MAX_BATCH_SIZE,
         worker_threads: Some(2),
         log_level: "debug".into(),
         db_prefix: format!("{node}"),

--- a/node/src/bin/verify_consensus_state_proof.rs
+++ b/node/src/bin/verify_consensus_state_proof.rs
@@ -575,6 +575,7 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         rpc_max_request_body_size: summit_rpc::DEFAULT_RPC_BODY_LIMIT_BYTES,
         rpc_max_response_body_size: summit_rpc::DEFAULT_RPC_BODY_LIMIT_BYTES,
         rpc_request_timeout_secs: summit_rpc::DEFAULT_RPC_REQUEST_TIMEOUT_SECS,
+        rpc_max_batch_size: summit_rpc::DEFAULT_RPC_MAX_BATCH_SIZE,
         worker_threads: Some(2),
         log_level: "debug".into(),
         db_prefix: format!("{node}"),

--- a/node/src/bin/withdraw_and_exit.rs
+++ b/node/src/bin/withdraw_and_exit.rs
@@ -399,6 +399,7 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         rpc_max_request_body_size: summit_rpc::DEFAULT_RPC_BODY_LIMIT_BYTES,
         rpc_max_response_body_size: summit_rpc::DEFAULT_RPC_BODY_LIMIT_BYTES,
         rpc_request_timeout_secs: summit_rpc::DEFAULT_RPC_REQUEST_TIMEOUT_SECS,
+        rpc_max_batch_size: summit_rpc::DEFAULT_RPC_MAX_BATCH_SIZE,
         worker_threads: Some(2),
         log_level: "debug".into(),
         db_prefix: format!("{node}"),

--- a/rpc/src/builder.rs
+++ b/rpc/src/builder.rs
@@ -1,5 +1,5 @@
 use http::{HeaderValue, Method};
-use jsonrpsee::server::{ServerBuilder, ServerConfigBuilder, ServerHandle};
+use jsonrpsee::server::{BatchRequestConfig, ServerBuilder, ServerConfigBuilder, ServerHandle};
 use std::net::SocketAddr;
 use std::time::Duration;
 use tower::ServiceBuilder;
@@ -49,7 +49,9 @@ impl RpcServerBuilder {
             // disabled by default, and an idle upgraded connection holds its
             // max_connections permit until the client closes; disabling websocket
             // upgrades removes that idle-permit-exhaustion vector entirely.
-            config: ServerConfigBuilder::new().http_only(),
+            config: ServerConfigBuilder::new()
+                .http_only()
+                .set_batch_request_config(default_batch_config()),
             cors_domains: None,
             request_timeout: Duration::from_secs(crate::DEFAULT_RPC_REQUEST_TIMEOUT_SECS),
         }
@@ -63,7 +65,9 @@ impl RpcServerBuilder {
             addr: SocketAddr::from(([127, 0, 0, 1], port)),
             // http-only: see `new`. websockets are unused, so disabling upgrades
             // closes the idle-connection permit-exhaustion vector.
-            config: ServerConfigBuilder::new().http_only(),
+            config: ServerConfigBuilder::new()
+                .http_only()
+                .set_batch_request_config(default_batch_config()),
             cors_domains: None,
             request_timeout: Duration::from_secs(crate::DEFAULT_RPC_REQUEST_TIMEOUT_SECS),
         }
@@ -100,6 +104,17 @@ impl RpcServerBuilder {
         self
     }
 
+    /// Limits the number of calls in a single JSON-RPC batch. jsonrpsee defaults
+    /// to unlimited, which lets one body-size-bounded request fan out into very
+    /// many (potentially expensive, finalizer-bound) method calls. `0` disables
+    /// batching entirely; any other value caps the batch at that many calls.
+    pub fn with_batch_limit(mut self, limit: u32) -> Self {
+        self.config = self
+            .config
+            .set_batch_request_config(batch_config_for(limit));
+        self
+    }
+
     pub async fn build(self) -> anyhow::Result<RpcServer> {
         let cors_layer = self
             .cors_domains
@@ -118,6 +133,20 @@ impl RpcServerBuilder {
             .await?;
 
         Ok(RpcServer { inner: server })
+    }
+}
+
+fn default_batch_config() -> BatchRequestConfig {
+    batch_config_for(crate::DEFAULT_RPC_MAX_BATCH_SIZE)
+}
+
+/// Maps a batch-size limit to a [`BatchRequestConfig`]: `0` disables batching,
+/// any other value caps a batch at that many calls.
+fn batch_config_for(limit: u32) -> BatchRequestConfig {
+    if limit == 0 {
+        BatchRequestConfig::Disabled
+    } else {
+        BatchRequestConfig::Limit(limit)
     }
 }
 

--- a/rpc/src/builder.rs
+++ b/rpc/src/builder.rs
@@ -49,6 +49,7 @@ impl RpcServerBuilder {
             // disabled by default, and an idle upgraded connection holds its
             // max_connections permit until the client closes; disabling websocket
             // upgrades removes that idle-permit-exhaustion vector entirely.
+            // The batch config caps calls per JSON-RPC batch (see `with_batch_limit`).
             config: ServerConfigBuilder::new()
                 .http_only()
                 .set_batch_request_config(default_batch_config()),
@@ -65,6 +66,7 @@ impl RpcServerBuilder {
             addr: SocketAddr::from(([127, 0, 0, 1], port)),
             // http-only: see `new`. websockets are unused, so disabling upgrades
             // closes the idle-connection permit-exhaustion vector.
+            // The batch config caps calls per JSON-RPC batch (see `with_batch_limit`).
             config: ServerConfigBuilder::new()
                 .http_only()
                 .set_batch_request_config(default_batch_config()),

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -147,6 +147,31 @@ pub async fn start_rpc_server_with_handle(
     port: u16,
     #[cfg(feature = "permissioned")] paused: Arc<AtomicBool>,
 ) -> anyhow::Result<(ServerHandle, SocketAddr)> {
+    start_rpc_server_with_handle_and_batch_limit(
+        state_query,
+        key_store_path,
+        genesis_hash,
+        namespace,
+        port,
+        DEFAULT_RPC_MAX_BATCH_SIZE,
+        #[cfg(feature = "permissioned")]
+        paused,
+    )
+    .await
+}
+
+/// Like [`start_rpc_server_with_handle`] but with an explicit JSON-RPC batch
+/// limit, so tests can exercise a custom `--rpc-max-batch-size` value (and `0`,
+/// which disables batching entirely).
+pub async fn start_rpc_server_with_handle_and_batch_limit(
+    state_query: ConsensusStateQuery<MultisigScheme>,
+    key_store_path: String,
+    genesis_hash: [u8; 32],
+    namespace: Vec<u8>,
+    port: u16,
+    max_batch_size: u32,
+    #[cfg(feature = "permissioned")] paused: Arc<AtomicBool>,
+) -> anyhow::Result<(ServerHandle, SocketAddr)> {
     let rpc_impl = SummitRpcServer::new(
         key_store_path,
         state_query,
@@ -168,6 +193,7 @@ pub async fn start_rpc_server_with_handle(
         .with_max_connections(1000)
         .with_max_request_body_size(DEFAULT_RPC_BODY_LIMIT_BYTES)
         .with_max_response_body_size(DEFAULT_RPC_BODY_LIMIT_BYTES)
+        .with_batch_limit(max_batch_size)
         .with_cors(Some("*".to_string()))
         .build()
         .await?;

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -36,12 +36,19 @@ pub const DEFAULT_RPC_BODY_LIMIT_BYTES: u32 = 50 * 1024 * 1024;
 /// reading the body and has no body read deadline of its own).
 pub const DEFAULT_RPC_REQUEST_TIMEOUT_SECS: u64 = 30;
 
+/// Default maximum number of calls in a single JSON-RPC batch. jsonrpsee
+/// defaults to unlimited; this bounds batch fan-out (`0` would disable
+/// batching).
+pub const DEFAULT_RPC_MAX_BATCH_SIZE: u32 = 50;
+
 #[derive(Debug, Clone, Copy)]
 pub struct RpcBodyLimits {
     pub max_request_body_size: u32,
     pub max_response_body_size: u32,
     /// Per-request timeout (accept through body read and method dispatch).
     pub request_timeout: std::time::Duration,
+    /// Maximum calls per JSON-RPC batch (`0` disables batching).
+    pub max_batch_size: u32,
 }
 
 impl Default for RpcBodyLimits {
@@ -50,6 +57,7 @@ impl Default for RpcBodyLimits {
             max_request_body_size: DEFAULT_RPC_BODY_LIMIT_BYTES,
             max_response_body_size: DEFAULT_RPC_BODY_LIMIT_BYTES,
             request_timeout: std::time::Duration::from_secs(DEFAULT_RPC_REQUEST_TIMEOUT_SECS),
+            max_batch_size: DEFAULT_RPC_MAX_BATCH_SIZE,
         }
     }
 }
@@ -87,6 +95,7 @@ pub async fn start_rpc_server(
         .with_max_request_body_size(body_limits.max_request_body_size)
         .with_max_response_body_size(body_limits.max_response_body_size)
         .with_request_timeout(body_limits.request_timeout)
+        .with_batch_limit(body_limits.max_batch_size)
         .with_cors(Some("*".to_string()))
         .build()
         .await?;
@@ -103,6 +112,7 @@ pub async fn start_rpc_server(
         .with_max_request_body_size(body_limits.max_request_body_size)
         .with_max_response_body_size(body_limits.max_response_body_size)
         .with_request_timeout(body_limits.request_timeout)
+        .with_batch_limit(body_limits.max_batch_size)
         .build()
         .await?;
 
@@ -251,6 +261,7 @@ pub async fn start_rpc_server_for_genesis(
         .with_max_request_body_size(body_limits.max_request_body_size)
         .with_max_response_body_size(body_limits.max_response_body_size)
         .with_request_timeout(body_limits.request_timeout)
+        .with_batch_limit(body_limits.max_batch_size)
         .build()
         .await?;
     let addr = server.local_addr()?;

--- a/rpc/tests/integration_test.rs
+++ b/rpc/tests/integration_test.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use summit_rpc::{
     PathSender, start_rpc_server_for_genesis_with_handle, start_rpc_server_pair_with_handle,
-    start_rpc_server_with_handle,
+    start_rpc_server_with_handle, start_rpc_server_with_handle_and_batch_limit,
 };
 use utils::{
     MockFinalizerState, create_gated_proof_mailbox, create_test_finalized_header,
@@ -371,6 +371,109 @@ async fn test_oversized_batch_is_rejected() {
     }
     assert!(
         client.batch_request::<String>(big_batch).await.is_err(),
+        "a batch exceeding the configured limit must be rejected"
+    );
+
+    handle.stop().unwrap();
+}
+
+#[tokio::test]
+async fn test_batch_disabled_rejects_all_batches() {
+    // max_batch_size = 0 disables batching entirely: even a single-call batch is
+    // rejected, while plain (non-batch) requests still work.
+    use jsonrpsee::core::client::ClientT;
+    use jsonrpsee::core::params::BatchRequestBuilder;
+    use summit_rpc::SummitApiClient;
+
+    let (mailbox, _finalizer_handle) = create_test_finalizer_mailbox(MockFinalizerState::default());
+    let temp_dir = create_test_keystore().unwrap();
+    let key_store_path = temp_dir.path().to_str().unwrap().to_string();
+
+    let (handle, addr) = start_rpc_server_with_handle_and_batch_limit(
+        mailbox,
+        key_store_path,
+        TEST_GENESIS_HASH,
+        b"_SUMMIT".to_vec(),
+        0, // port
+        0, // max_batch_size = 0 -> batching disabled
+        #[cfg(feature = "permissioned")]
+        Arc::new(AtomicBool::new(false)),
+    )
+    .await
+    .unwrap();
+
+    let client = HttpClientBuilder::default()
+        .build(format!("http://{addr}"))
+        .unwrap();
+
+    // A plain (non-batch) request is still served.
+    assert!(
+        client.health().await.is_ok(),
+        "non-batch requests must still work when batching is disabled"
+    );
+
+    // Even a single-call batch is rejected.
+    let mut batch = BatchRequestBuilder::new();
+    batch.insert("health", jsonrpsee::rpc_params![]).unwrap();
+    assert!(
+        ClientT::batch_request::<String>(&client, batch)
+            .await
+            .is_err(),
+        "any batch must be rejected when max_batch_size = 0"
+    );
+
+    handle.stop().unwrap();
+}
+
+#[tokio::test]
+async fn test_custom_batch_limit_is_honored() {
+    // A non-default configured limit is honored independently of
+    // DEFAULT_RPC_MAX_BATCH_SIZE: a batch at the limit is served, one over it
+    // is rejected.
+    use jsonrpsee::core::client::ClientT;
+    use jsonrpsee::core::params::BatchRequestBuilder;
+
+    let limit: u32 = 3;
+    let (mailbox, _finalizer_handle) = create_test_finalizer_mailbox(MockFinalizerState::default());
+    let temp_dir = create_test_keystore().unwrap();
+    let key_store_path = temp_dir.path().to_str().unwrap().to_string();
+
+    let (handle, addr) = start_rpc_server_with_handle_and_batch_limit(
+        mailbox,
+        key_store_path,
+        TEST_GENESIS_HASH,
+        b"_SUMMIT".to_vec(),
+        0, // port
+        limit,
+        #[cfg(feature = "permissioned")]
+        Arc::new(AtomicBool::new(false)),
+    )
+    .await
+    .unwrap();
+
+    let client = HttpClientBuilder::default()
+        .build(format!("http://{addr}"))
+        .unwrap();
+
+    // Exactly at the limit: served.
+    let mut at_limit = BatchRequestBuilder::new();
+    for _ in 0..limit {
+        at_limit.insert("health", jsonrpsee::rpc_params![]).unwrap();
+    }
+    assert!(
+        client.batch_request::<String>(at_limit).await.is_ok(),
+        "a batch at the configured limit must be served"
+    );
+
+    // One over the limit: rejected.
+    let mut over_limit = BatchRequestBuilder::new();
+    for _ in 0..(limit + 1) {
+        over_limit
+            .insert("health", jsonrpsee::rpc_params![])
+            .unwrap();
+    }
+    assert!(
+        client.batch_request::<String>(over_limit).await.is_err(),
         "a batch exceeding the configured limit must be rejected"
     );
 

--- a/rpc/tests/integration_test.rs
+++ b/rpc/tests/integration_test.rs
@@ -323,6 +323,61 @@ async fn test_get_state_proof_permit_outlives_cancelled_request() {
 }
 
 #[tokio::test]
+async fn test_oversized_batch_is_rejected() {
+    // The server caps JSON-RPC batch size (default DEFAULT_RPC_MAX_BATCH_SIZE).
+    // jsonrpsee defaults to unlimited, which lets one request fan out into very
+    // many expensive calls; a batch over the limit must be rejected, while a
+    // batch within the limit still works.
+    use jsonrpsee::core::client::ClientT;
+    use jsonrpsee::core::params::BatchRequestBuilder;
+    use summit_rpc::DEFAULT_RPC_MAX_BATCH_SIZE;
+
+    let (mailbox, _finalizer_handle) = create_test_finalizer_mailbox(MockFinalizerState::default());
+    let temp_dir = create_test_keystore().unwrap();
+    let key_store_path = temp_dir.path().to_str().unwrap().to_string();
+
+    let (handle, addr) = start_rpc_server_with_handle(
+        mailbox,
+        key_store_path,
+        TEST_GENESIS_HASH,
+        b"_SUMMIT".to_vec(),
+        0,
+        #[cfg(feature = "permissioned")]
+        Arc::new(AtomicBool::new(false)),
+    )
+    .await
+    .unwrap();
+
+    let client = HttpClientBuilder::default()
+        .build(format!("http://{addr}"))
+        .unwrap();
+
+    // Within the limit: succeeds.
+    let mut ok_batch = BatchRequestBuilder::new();
+    for _ in 0..10 {
+        ok_batch.insert("health", jsonrpsee::rpc_params![]).unwrap();
+    }
+    assert!(
+        client.batch_request::<String>(ok_batch).await.is_ok(),
+        "a batch within the limit must be served"
+    );
+
+    // Over the limit: rejected.
+    let mut big_batch = BatchRequestBuilder::new();
+    for _ in 0..(DEFAULT_RPC_MAX_BATCH_SIZE as usize + 1) {
+        big_batch
+            .insert("health", jsonrpsee::rpc_params![])
+            .unwrap();
+    }
+    assert!(
+        client.batch_request::<String>(big_batch).await.is_err(),
+        "a batch exceeding the configured limit must be rejected"
+    );
+
+    handle.stop().unwrap();
+}
+
+#[tokio::test]
 async fn test_get_latest_height() {
     use summit_rpc::SummitApiClient;
 


### PR DESCRIPTION
Builds on https://github.com/SeismicSystems/summit/pull/408.

Addresses https://github.com/SeismicSystems/summit/issues/348.

Changes:
- rpc builder: default to BatchRequestConfig::Limit(DEFAULT_RPC_MAX_BATCH_SIZE) in new/new_localhost; add a with_batch_limit setter (0 disables batching, n caps the batch).
- RpcBodyLimits: add max_batch_size; thread it through the public, admin, and genesis start paths.
- CLI: new --rpc-max-batch-size flag (default 50, 0 = disabled), wired into RpcBodyLimits; add the field to the e2e/testnet RunFlags literals.
- test test_oversized_batch_is_rejected: a within-limit batch is served, an over-limit batch is rejected.