### PR TITLE
fix: batch protocol-param SSZ rebuild in finalizer

### DIFF
--- a/finalizer/src/actor.rs
+++ b/finalizer/src/actor.rs
@@ -2205,6 +2205,12 @@ async fn parse_execution_requests<
     // budget, and therefore starving other validators' legitimate exits in the same block.
     let mut deferred_exit_pubkeys: HashSet<[u8; 32]> = HashSet::new();
 
+    // accumulate decoded protocol param changes across every request in this
+    // block and flush them through a single subtree rebuild after the loop.
+    // pushing per record rebuilds the whole pending param subtree each time,
+    // which is o(n^2) over a grouped batch of 0xFF records.
+    let mut protocol_param_batch: Vec<ProtocolParam> = Vec::new();
+
     for (request_bytes, origin) in pending_requests.chain(current_requests) {
         let is_deferred = origin.is_deferred();
         match ExecutionRequest::parse_eth_entry(request_bytes) {
@@ -2494,7 +2500,7 @@ async fn parse_execution_requests<
                             match ProtocolParam::try_from(protocol_param_request) {
                                 Ok(protocol_param) => {
                                     info!("Adding protocol param change: {protocol_param:?}");
-                                    state.push_protocol_param_change(protocol_param);
+                                    protocol_param_batch.push(protocol_param);
                                 }
                                 Err(e) => {
                                     warn!("Failed to parse protocol param request: {e}");
@@ -2508,6 +2514,12 @@ async fn parse_execution_requests<
                 warn!("Failed to parse execution request: {}", e);
             }
         }
+    }
+
+    // flush every protocol param change decoded above through a single subtree
+    // rebuild, rather than rebuilding once per record.
+    if !protocol_param_batch.is_empty() {
+        state.push_protocol_param_changes(protocol_param_batch);
     }
 }
 

--- a/types/src/consensus_state.rs
+++ b/types/src/consensus_state.rs
@@ -521,6 +521,20 @@ impl ConsensusState {
             .rebuild_protocol_params(&self.protocol_param_changes);
     }
 
+    /// appends a batch of protocol param changes and rebuilds the param subtree
+    /// at most once. rebuild_protocol_params reallocates and reroots the whole
+    /// pending param subtree, so calling push_protocol_param_change per record
+    /// is o(n^2) over a grouped batch. callers that decode several records from
+    /// one block should accumulate them and flush through here instead.
+    pub fn push_protocol_param_changes(&mut self, params: impl IntoIterator<Item = ProtocolParam>) {
+        let before = self.protocol_param_changes.len();
+        self.protocol_param_changes.extend(params);
+        if self.protocol_param_changes.len() != before {
+            self.ssz_tree
+                .rebuild_protocol_params(&self.protocol_param_changes);
+        }
+    }
+
     pub fn push_removed_validator(&mut self, pubkey: PublicKey) {
         self.removed_validators.push(pubkey);
         self.ssz_tree
@@ -3067,6 +3081,67 @@ mod tests {
             root_after,
             state.ssz_tree().root(),
             "incremental reschedule root should match full rebuild"
+        );
+    }
+
+    // A grouped batch of protocol param changes flushed
+    // through push_protocol_param_changes must land in exactly the same state
+    // (queue contents and ssz root) as pushing each record one at a time. the
+    // batch path rebuilds the param subtree once instead of once per record.
+    #[test]
+    fn test_batch_protocol_param_changes_match_per_record() {
+        use crate::protocol_params::ProtocolParam;
+
+        let params = vec![
+            ProtocolParam::MinimumStake(16_000_000_000),
+            ProtocolParam::MaximumStake(64_000_000_000),
+            ProtocolParam::EpochLength(128),
+            ProtocolParam::MaxDepositsPerEpoch(8),
+        ];
+
+        let mut per_record = ConsensusState::default();
+        for param in params.clone() {
+            per_record.push_protocol_param_change(param);
+        }
+
+        let mut batched = ConsensusState::default();
+        batched.push_protocol_param_changes(params.clone());
+
+        assert_eq!(
+            batched.protocol_param_changes.len(),
+            per_record.protocol_param_changes.len(),
+            "batched queue should match per record queue length"
+        );
+        assert_eq!(
+            batched.ssz_tree().root(),
+            per_record.ssz_tree().root(),
+            "batched ssz root should match per record root"
+        );
+
+        // the batch path is equivalent to a full rebuild from the same queue.
+        batched.rebuild_ssz_tree();
+        assert_eq!(
+            batched.ssz_tree().root(),
+            per_record.ssz_tree().root(),
+            "batched root should match a full rebuild"
+        );
+    }
+
+    // an empty batch must be a no op: no queue growth and no root change, so the
+    // finalizer can call it unconditionally without forcing a needless rebuild.
+    #[test]
+    fn test_empty_protocol_param_batch_is_noop() {
+        let mut state = ConsensusState::default();
+        let root_before = state.ssz_tree().root();
+        let len_before = state.protocol_param_changes.len();
+
+        state.push_protocol_param_changes(std::iter::empty());
+
+        assert_eq!(len_before, state.protocol_param_changes.len());
+        assert_eq!(
+            root_before,
+            state.ssz_tree().root(),
+            "empty batch should not change the ssz root"
         );
     }
 }


### PR DESCRIPTION
Addresses https://github.com/SeismicSystems/summit/issues/342.

Changes:
- types/consensus_state.rs: add push_protocol_param_changes(impl IntoIterator) which extends the queue then rebuilds the param subtree at most once (no-op on an empty batch)
- finalizer/actor.rs: process_execution_requests now accumulates accepted ProtocolParams into a batch across the whole block and flushes once after the request loop instead of rebuilding per record, making the per-block rebuild O(N)
- tests: add test_batch_protocol_param_changes_match_per_record (batch root == per-record root == full rebuild) and test_empty_protocol_param_batch_is_noop