### PR TITLE
fix: batch deposit-queue SSZ rebuild on capped drain

### DIFF
--- a/finalizer/src/actor.rs
+++ b/finalizer/src/actor.rs
@@ -2545,11 +2545,17 @@ async fn process_execution_requests<
     consts: &ProtocolConsts,
 ) {
     if is_penultimate_block_of_epoch(state.get_epocher(), new_height) {
+        // pop deposits without rebuilding the deposit subtree per pop, then
+        // rebuild once after the loop. front removal shifts every remaining
+        // item, so a per pop rebuild is o(cap * backlog) inside this
+        // consensus-critical block.
+        let mut drained_any_deposit = false;
         for _ in 0..state.get_max_deposits_per_epoch() as usize {
             // Break on empty queue so an oversized max_deposits_per_epoch
             // cannot spin the consensus-critical penultimate block in a
             // long-running no-op loop.
-            if let Some(request) = state.pop_deposit() {
+            if let Some(request) = state.pop_deposit_deferred() {
+                drained_any_deposit = true;
                 let node_pubkey_bytes: [u8; 32] = request.node_pubkey.as_ref().try_into().unwrap();
 
                 // Account should always exist (created early in parse_execution_requests)
@@ -2680,6 +2686,14 @@ async fn process_execution_requests<
             } else {
                 break;
             }
+        }
+
+        // rebuild the deposit subtree once for the whole drained batch. the
+        // per pop rebuild was deferred above, so the subtree is stale until
+        // here; nothing between the drain and the end of block root capture
+        // reads it.
+        if drained_any_deposit {
+            state.rebuild_deposit_tree();
         }
 
         // Stage stake-bound force-removals for the upcoming epoch boundary.

--- a/types/src/consensus_state.rs
+++ b/types/src/consensus_state.rs
@@ -759,6 +759,26 @@ impl ConsensusState {
         Some(request)
     }
 
+    /// pops the front deposit without touching the ssz tree.
+    ///
+    /// front removal shifts every remaining item, so ssz_tree.pop_deposit
+    /// rebuilds the whole deposit subtree. when draining up to the per epoch
+    /// cap that is one full rebuild per pop, which is o(cap * backlog). callers
+    /// that drain a capped batch should pop through here and call
+    /// rebuild_deposit_tree once after the loop instead. the deposit subtree
+    /// root is stale until that flush, so this must only be used in a sequence
+    /// that ends in rebuild_deposit_tree before the state root is read.
+    pub fn pop_deposit_deferred(&mut self) -> Option<DepositRequest> {
+        self.deposit_queue.pop_front()
+    }
+
+    /// rebuilds the deposit subtree from the current queue in a single pass.
+    /// pairs with pop_deposit_deferred to collapse a capped drain into one
+    /// rebuild.
+    pub fn rebuild_deposit_tree(&mut self) {
+        self.ssz_tree.rebuild_deposits(&self.deposit_queue);
+    }
+
     // Withdrawal queue operations
     pub fn push_withdrawal_request(
         &mut self,
@@ -3125,6 +3145,104 @@ mod tests {
             batched.ssz_tree().root(),
             per_record.ssz_tree().root(),
             "batched root should match a full rebuild"
+        );
+    }
+
+    // Draining a capped batch of deposits through
+    // pop_deposit_deferred + a single rebuild_deposit_tree must land in the
+    // exact same state (queue length and ssz root) as draining the same count
+    // one pop at a time, where every pop rebuilt the whole remaining subtree.
+    #[test]
+    fn test_deferred_deposit_drain_matches_per_pop() {
+        // backlog larger than the cap so the drain is partial and the remaining
+        // subtree is non trivial.
+        let backlog = 64usize;
+        let cap = 16usize;
+
+        let mut per_pop = ConsensusState::default();
+        let mut deferred = ConsensusState::default();
+        for i in 0..backlog as u64 {
+            let deposit = create_test_deposit_request(i, 32_000_000_000 + i);
+            per_pop.push_deposit(deposit.clone());
+            deferred.push_deposit(deposit);
+        }
+        assert_eq!(
+            per_pop.ssz_tree().root(),
+            deferred.ssz_tree().root(),
+            "states should start identical"
+        );
+
+        // per pop path: rebuild on every pop (the original behaviour).
+        for _ in 0..cap {
+            per_pop.pop_deposit();
+        }
+
+        // deferred path: pop without rebuilding, then rebuild exactly once.
+        for _ in 0..cap {
+            deferred.pop_deposit_deferred();
+        }
+        deferred.rebuild_deposit_tree();
+
+        assert_eq!(
+            deferred.deposit_count(),
+            per_pop.deposit_count(),
+            "both paths should drain the same number of deposits"
+        );
+        assert_eq!(deferred.deposit_count(), backlog - cap);
+        assert_eq!(
+            deferred.ssz_tree().root(),
+            per_pop.ssz_tree().root(),
+            "deferred single rebuild root should match per pop root"
+        );
+
+        // and the deferred root must equal a fresh full rebuild from the queue.
+        deferred.rebuild_ssz_tree();
+        assert_eq!(
+            deferred.ssz_tree().root(),
+            per_pop.ssz_tree().root(),
+            "deferred root should match a full rebuild"
+        );
+    }
+
+    // draining a backlog smaller than the cap must fully empty the queue and
+    // leave a root identical to per pop draining (mirrors the finalizer break
+    // on empty queue).
+    #[test]
+    fn test_deferred_deposit_drain_empties_small_backlog() {
+        let backlog = 5usize;
+        let cap = 16usize;
+
+        let mut per_pop = ConsensusState::default();
+        let mut deferred = ConsensusState::default();
+        for i in 0..backlog as u64 {
+            let deposit = create_test_deposit_request(i, 32_000_000_000 + i);
+            per_pop.push_deposit(deposit.clone());
+            deferred.push_deposit(deposit);
+        }
+
+        let mut drained_any = false;
+        for _ in 0..cap {
+            if per_pop.pop_deposit().is_none() {
+                break;
+            }
+        }
+        for _ in 0..cap {
+            if deferred.pop_deposit_deferred().is_some() {
+                drained_any = true;
+            } else {
+                break;
+            }
+        }
+        if drained_any {
+            deferred.rebuild_deposit_tree();
+        }
+
+        assert_eq!(deferred.deposit_count(), 0);
+        assert_eq!(per_pop.deposit_count(), 0);
+        assert_eq!(
+            deferred.ssz_tree().root(),
+            per_pop.ssz_tree().root(),
+            "empty queue roots should match"
         );
     }
 


### PR DESCRIPTION
Builds on https://github.com/SeismicSystems/summit/pull/412.

Addresses https://github.com/SeismicSystems/summit/issues/317.

Changes:
- types/consensus_state.rs: add pop_deposit_deferred() (pops the queue front, leaves the deposit subtree untouched) and rebuild_deposit_tree() (one rebuild_deposits over the current queue)
- finalizer/actor.rs: the penultimate-block drain loop now pops via pop_deposit_deferred(), tracks whether anything drained, and calls rebuild_deposit_tree() once after the loop; the subtree is stale only between the drain and the end-of-block root capture, which never reads it. Per-block rebuild is now O(B)
- tests: add test_deferred_deposit_drain_matches_per_pop (backlog 64, cap 16: deferred single-rebuild root == per-pop root == full rebuild) and test_deferred_deposit_drain_empties_small_backlog (backlog < cap, mirrors the break-on-empty)