### PR TITLE
fix: harden keystore file permissions for generated keys

### DIFF
--- a/node/src/keys.rs
+++ b/node/src/keys.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use clap::{Args, Subcommand};
 use std::fs;
 use std::io::{self, Write};
+use std::path::Path;
 
 use commonware_codec::Encode;
 use commonware_cryptography::Signer;
@@ -95,20 +96,22 @@ impl KeySubCmd {
             }
         }
 
-        // Create keystore directory
-        fs::create_dir_all(&keystore_dir).expect("Unable to create keystore directory");
+        // Create keystore directory with owner-only access on Unix (0700) so the
+        // private keys written into it are not exposed via a permissive umask.
+        create_keystore_dir(&keystore_dir).expect("Unable to create keystore directory");
 
         // Generate ed25519 node key
         let node_private_key = PrivateKey::random(&mut rand::thread_rng());
         let node_pub_key = node_private_key.public_key();
         let encoded_node_key = commonware_utils::hex(&node_private_key.encode());
-        fs::write(node_key_path, encoded_node_key).expect("Unable to write node key to disk");
+        write_private_key_file(&node_key_path, &encoded_node_key)
+            .expect("Unable to write node key to disk");
 
         // Generate BLS consensus key
         let consensus_private_key = BlsPrivateKey::random(&mut rand::thread_rng());
         let consensus_pub_key = consensus_private_key.public_key();
         let encoded_consensus_key = commonware_utils::hex(&consensus_private_key.encode());
-        fs::write(consensus_key_path, encoded_consensus_key)
+        write_private_key_file(&consensus_key_path, &encoded_consensus_key)
             .expect("Unable to write consensus key to disk");
 
         println!("Keys generated at {}:", keystore_dir.display());
@@ -136,6 +139,55 @@ pub fn read_keys_from_keystore(keystore_path: &str) -> Result<(PrivateKey, BlsPr
     let node_key = key_paths.read_node_key_from_file()?;
     let consensus_key = key_paths.read_bls_key_from_file()?;
     Ok((node_key, consensus_key))
+}
+
+/// Create the keystore directory, restricting it to the owner (`0700`) on Unix.
+///
+/// `fs::create_dir_all` would create the directory with `0777 & !umask`, which
+/// under the common `022` umask leaves it group/world traversable. The keys
+/// written inside are private, so the directory is owner-only.
+fn create_keystore_dir(dir: &Path) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::DirBuilderExt;
+        fs::DirBuilder::new()
+            .recursive(true)
+            .mode(0o700)
+            .create(dir)
+    }
+    #[cfg(not(unix))]
+    {
+        fs::create_dir_all(dir)
+    }
+}
+
+/// Write private-key material to `path` with owner read/write only (`0600`) on
+/// Unix.
+///
+/// Plain `fs::write` creates files with `0666 & !umask`, so a permissive umask
+/// (e.g. `022`) yields a group/world-readable private key. We instead create
+/// the file with mode `0600`, and — because the create-mode is ignored when the
+/// file already exists (the overwrite path) and truncation preserves the old
+/// mode — re-assert `0600` explicitly afterwards.
+fn write_private_key_file(path: &Path, contents: &str) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(path)?;
+        file.set_permissions(fs::Permissions::from_mode(0o600))?;
+        file.write_all(contents.as_bytes())?;
+        file.sync_all()?;
+        Ok(())
+    }
+    #[cfg(not(unix))]
+    {
+        fs::write(path, contents)
+    }
 }
 
 //#[cfg(test)]
@@ -170,8 +222,83 @@ pub fn read_keys_from_keystore(keystore_path: &str) -> Result<(PrivateKey, BlsPr
 //                .expect("Unable to read consensus key");
 //
 //            assert_eq!(consensus_pub_key, read_consensus_key.public_key());
-//        }
-//
-//        println!("\nSuccessfully generated and verified BLS keys for 4 testnet nodes");
-//    }
-//}
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    /// Unique temporary keystore path (no external tempfile dependency).
+    fn unique_keystore_dir() -> PathBuf {
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        std::env::temp_dir().join(format!("summit-keys-test-{}-{}", std::process::id(), n))
+    }
+
+    fn mode_of(path: &Path) -> u32 {
+        fs::metadata(path).unwrap().permissions().mode() & 0o7777
+    }
+
+    #[test]
+    fn generated_keys_and_dir_are_owner_only() {
+        let dir = unique_keystore_dir();
+        let flags = KeyFlags {
+            key_store_path: dir.to_string_lossy().into_owned(),
+            no_overwrite: false,
+            yes_overwrite: true,
+        };
+        let cmd = KeySubCmd::Generate {
+            flags: flags.clone(),
+        };
+        cmd.generate_keys(&flags);
+
+        let key_paths = KeyPaths::new(flags.key_store_path.clone());
+        let node_key_path = key_paths.node_key_path().unwrap();
+        let consensus_key_path = key_paths.consensus_key_path().unwrap();
+
+        // Directory must not be group/other accessible.
+        assert_eq!(
+            mode_of(&dir) & 0o077,
+            0,
+            "keystore dir mode {:o} exposes bits to group/other",
+            mode_of(&dir)
+        );
+        // Both private-key files must be owner-only (0600).
+        for p in [&node_key_path, &consensus_key_path] {
+            assert_eq!(
+                mode_of(p) & 0o077,
+                0,
+                "key file {:?} mode {:o} exposes bits to group/other",
+                p,
+                mode_of(p)
+            );
+        }
+
+        // Keys must still load back correctly after tightening.
+        let (_node, _consensus) =
+            read_keys_from_keystore(&flags.key_store_path).expect("generated keys must load");
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn overwrite_tightens_preexisting_loose_mode() {
+        let dir = unique_keystore_dir();
+        create_keystore_dir(&dir).unwrap();
+        let key_paths = KeyPaths::new(dir.to_string_lossy().into_owned());
+        let node_key_path = key_paths.node_key_path().unwrap();
+
+        // Simulate a legacy world-readable key file at the target path.
+        fs::write(&node_key_path, "stale").unwrap();
+        fs::set_permissions(&node_key_path, fs::Permissions::from_mode(0o644)).unwrap();
+        assert_ne!(mode_of(&node_key_path) & 0o077, 0);
+
+        // Re-writing through the secure helper must re-assert 0600.
+        write_private_key_file(&node_key_path, "fresh").unwrap();
+        assert_eq!(mode_of(&node_key_path) & 0o077, 0);
+        assert_eq!(fs::read_to_string(&node_key_path).unwrap(), "fresh");
+
+        fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/types/src/key_paths.rs
+++ b/types/src/key_paths.rs
@@ -67,6 +67,7 @@ impl KeyPaths {
     /// Read the node private key from file (using anyhow::Result for compatibility)
     pub fn read_node_key_from_file(&self) -> Result<PrivateKey> {
         let path = self.node_key_path()?;
+        warn_if_permissions_too_open(&path);
         let encoded_pk = std::fs::read_to_string(&path)
             .context(format!("Failed to read node key from {:?}", path))?;
         let key = from_hex_formatted(&encoded_pk).context("Invalid hex format for node key")?;
@@ -77,6 +78,7 @@ impl KeyPaths {
     /// Read the BLS private key from file (using anyhow::Result for compatibility)
     pub fn read_bls_key_from_file(&self) -> Result<BlsPrivateKey> {
         let path = self.consensus_key_path()?;
+        warn_if_permissions_too_open(&path);
         let encoded_pk = std::fs::read_to_string(&path)
             .context(format!("Failed to read BLS key from {:?}", path))?;
         let key = from_hex_formatted(&encoded_pk).context("Invalid hex format for BLS key")?;
@@ -84,3 +86,25 @@ impl KeyPaths {
         Ok(pk)
     }
 }
+
+/// Warn (Unix only) when a private-key file is readable or writable by group or
+/// other. We warn rather than reject so an existing validator with legacy file
+/// modes is not taken offline on restart; `chmod 600` clears it. On non-Unix
+/// platforms this is a no-op.
+#[cfg(unix)]
+fn warn_if_permissions_too_open(path: &std::path::Path) {
+    use std::os::unix::fs::PermissionsExt;
+    if let Ok(metadata) = std::fs::metadata(path) {
+        let mode = metadata.permissions().mode();
+        if mode & 0o077 != 0 {
+            tracing::warn!(
+                path = %path.display(),
+                mode = format!("{:o}", mode & 0o7777),
+                "private key file is accessible by group/other; tighten it with `chmod 600`"
+            );
+        }
+    }
+}
+
+#[cfg(not(unix))]
+fn warn_if_permissions_too_open(_path: &std::path::Path) {}


### PR DESCRIPTION
Addresses https://github.com/SeismicSystems/summit/issues/220.

Changes:
- node/src/keys.rs
  - create_keystore_dir() — create the keystore dir 0700 on Unix (DirBuilder.mode), create_dir_all fallback elsewhere
  - write_private_key_file() — create key files 0600 via OpenOptions.mode, plus an explicit set_permissions(0600) so the overwrite path also re-tightens a pre-existing loose file (truncate preserves the old mode); fs::write fallback on non-Unix
- types/src/key_paths.rs — both key readers now call warn_if_permissions_too_open(): Unix-only tracing::warn! when mode & 0o077 != 0. Warns rather than rejects so a validator with legacy modes isn't taken offline on restart (chmod 600 clears it).
- Tests (#[cfg(all(test, unix))]) — assert generated dir + both key files are owner-only and still load; assert overwrite tightens a seeded 0644 file back to 0600. No new dependency.