### PR TITLE
fix: bind by-pubkey field proofs to the requested pubkey

### DIFF
--- a/docs/ssz-merklization.md
+++ b/docs/ssz-merklization.md
@@ -405,6 +405,21 @@ The state root appears on-chain in EL block `el_block_number + 1`.
 
 Takes a list of key strings and returns the state root, EL block number, and one result for each key. Each result echoes the requested key and contains either an `SszProof` or an error for a key that is absent or out of range.
 
+> **Binding for by-pubkey field proofs.** A bare `SszProof` for a single field
+> (`validator_field:`/`withdrawal_field:`) proves only that *some* positional
+> leaf exists under the root — it does **not** prove the field belongs to the
+> requested pubkey, since the pubkey→position mapping happens server-side. A
+> malicious provider or intermediary could answer a by-pubkey request with the
+> same field from a *different* item under the same root. For these requests the
+> result therefore also carries a `key_proof`: a companion `SszProof` of the
+> item's key (pubkey) leaf. A trustless consumer **must** verify both, check
+> that `key_proof.leaf` equals the requested pubkey, and check that the two
+> leaves resolve to the same item (their generalized indices agree once the low
+> `log2(fields_per_item)` field-selector bits are dropped — 3 bits for
+> withdrawals, 4 for validator accounts). See `KeyedFieldProof::verify` in
+> `types/src/ssz_state_tree.rs`. The `key_proof` field is absent for scalar,
+> whole-item, and index-addressed proofs.
+
 ```json
 // Request
 {"jsonrpc":"2.0","method":"getStateProof","params":[["epoch","validator:0xABCD...","deposit:999999"]],"id":1}
@@ -422,6 +437,12 @@ Takes a list of key strings and returns the state root, EL block number, and one
     {
       "key": "validator:0xABCD...",
       "proof": { "gindex": 1408, "leaf": "0x...", "branch": ["0x...", ...] },
+      "error": null
+    },
+    {
+      "key": "validator_field:0xABCD...:balance",
+      "proof": { "gindex": 22528, "leaf": "0x...", "branch": ["0x...", ...] },
+      "key_proof": { "gindex": 22536, "leaf": "0xABCD...", "branch": ["0x...", ...] },
       "error": null
     },
     {
@@ -465,7 +486,7 @@ Keys are human-readable strings parsed by `types/src/ssz_tree_key.rs`:
 | Key Format | Example | Proves |
 |------------|---------|--------|
 | `validator:<pubkey>` | `validator:0xABCD...` | Whole account |
-| `validator_field:<pubkey>:<field>` | `validator_field:0xABCD...:balance` | Single field |
+| `validator_field:<pubkey>:<field>` | `validator_field:0xABCD...:balance` | Single field (response includes a `key_proof` binding — see above) |
 
 Validator field names: `consensus_pubkey`, `withdrawal_credentials`, `balance`, `status`, `has_pending_deposit`, `has_pending_withdrawal`, `joining_epoch`, `last_deposit_index`.
 
@@ -483,7 +504,7 @@ Deposit field names: `node_pubkey`, `consensus_pubkey`, `withdrawal_credentials`
 | Key Format | Example | Proves |
 |------------|---------|--------|
 | `withdrawal:<pubkey>` | `withdrawal:0xABCD...` | Whole withdrawal |
-| `withdrawal_field:<pubkey>:<field>` | `withdrawal_field:0xABCD...:amount` | Single field |
+| `withdrawal_field:<pubkey>:<field>` | `withdrawal_field:0xABCD...:amount` | Single field (response includes a `key_proof` binding — see above) |
 
 Withdrawal field names: `index`, `validator_index`, `address`, `amount`, `pubkey`, `balance_deduction`, `epoch`.
 

--- a/docs/ssz-merklization.md
+++ b/docs/ssz-merklization.md
@@ -413,10 +413,13 @@ Takes a list of key strings and returns the state root, EL block number, and one
 > same field from a *different* item under the same root. For these requests the
 > result therefore also carries a `key_proof`: a companion `SszProof` of the
 > item's key (pubkey) leaf. A trustless consumer **must** verify both, check
-> that `key_proof.leaf` equals the requested pubkey, and check that the two
-> leaves resolve to the same item (their generalized indices agree once the low
-> `log2(fields_per_item)` field-selector bits are dropped — 3 bits for
-> withdrawals, 4 for validator accounts). See `KeyedFieldProof::verify` in
+> that `key_proof.leaf` equals the requested pubkey, check that `key_proof`
+> addresses the canonical pubkey field within its item (its field-selector bits
+> equal the pubkey field index, so the binding cannot rest on some other field
+> that merely hashes to the key), and check that the two leaves resolve to the
+> same item (their generalized indices agree once the low `log2(fields_per_item)`
+> field-selector bits are dropped — 3 bits for withdrawals, 4 for validator
+> accounts). See `KeyedFieldProof::verify` in
 > `types/src/ssz_state_tree.rs`. The `key_proof` field is absent for scalar,
 > whole-item, and index-addressed proofs.
 

--- a/finalizer/src/actor.rs
+++ b/finalizer/src/actor.rs
@@ -42,7 +42,7 @@ use summit_types::ext_private_key::derive_observer_keys;
 use summit_types::network_oracle::NetworkOracle;
 use summit_types::protocol_params::ProtocolParam;
 use summit_types::scheme::EpochTransition;
-use summit_types::ssz_state_tree::{SszProof, SszStateTree};
+use summit_types::ssz_state_tree::{SszStateTree, StateProofEntry};
 use summit_types::ssz_tree_key::SszStateKey;
 use summit_types::utils::{
     is_first_block_of_epoch, is_last_block_of_epoch, is_penultimate_block_of_epoch,
@@ -69,40 +69,62 @@ type StateQueryMessage<V> = (
 /// the i-th result corresponds to the i-th key, and a key that resolves to no
 /// proof (missing collection entry, etc.) yields `None` rather than being
 /// dropped. Callers rely on this one-result-per-key invariant — see #260/#267 —
-/// so this must stay a `map` (not `filter_map`) into `Vec<Option<SszProof>>`.
+/// so this must stay a `map` (not `filter_map`) into `Vec<Option<StateProofEntry>>`.
+///
+/// By-pubkey field requests (`ValidatorField`/`WithdrawalField`) return a keyed
+/// entry carrying the item's key-leaf proof in `key`, so a consumer can bind the
+/// field to the requested pubkey (see `KeyedFieldProof`). All other requests
+/// carry a single proof in `field` with `key: None`.
 fn generate_state_proofs(
     proof_tree: &SszStateTree,
     validator_keys: &[[u8; 32]],
     keys: &[SszStateKey],
-) -> Vec<Option<SszProof>> {
+) -> Vec<Option<StateProofEntry>> {
     keys.iter()
         .map(|key| match key {
-            SszStateKey::Scalar(leaf_index) => Some(proof_tree.generate_scalar_proof(*leaf_index)),
-            SszStateKey::Validator(pubkey) => {
-                proof_tree.generate_validator_proof(pubkey, validator_keys)
-            }
-            SszStateKey::ValidatorField(pubkey, field_index) => {
-                proof_tree.generate_validator_field_proof(pubkey, *field_index, validator_keys)
-            }
-            SszStateKey::Deposit(index) => proof_tree.generate_deposit_proof(*index),
-            SszStateKey::DepositField(index, field_index) => {
-                proof_tree.generate_deposit_field_proof(*index, *field_index)
-            }
-            SszStateKey::Withdrawal(pubkey) => proof_tree.generate_withdrawal_proof_by_key(pubkey),
-            SszStateKey::WithdrawalField(pubkey, field_index) => {
-                proof_tree.generate_withdrawal_field_proof_by_key(pubkey, *field_index)
-            }
-            SszStateKey::ProtocolParam(index) => proof_tree.generate_protocol_param_proof(*index),
-            SszStateKey::ProtocolParamField(index, field_index) => {
-                proof_tree.generate_protocol_param_field_proof(*index, *field_index)
-            }
-            SszStateKey::AddedValidator(index) => proof_tree.generate_added_validator_proof(*index),
-            SszStateKey::AddedValidatorField(index, field_index) => {
-                proof_tree.generate_added_validator_field_proof(*index, *field_index)
-            }
-            SszStateKey::RemovedValidator(index) => {
-                proof_tree.generate_removed_validator_proof(*index)
-            }
+            SszStateKey::Scalar(leaf_index) => Some(StateProofEntry {
+                field: proof_tree.generate_scalar_proof(*leaf_index),
+                key: None,
+            }),
+            SszStateKey::Validator(pubkey) => proof_tree
+                .generate_validator_proof(pubkey, validator_keys)
+                .map(|field| StateProofEntry { field, key: None }),
+            SszStateKey::ValidatorField(pubkey, field_index) => proof_tree
+                .generate_validator_keyed_field_proof(pubkey, *field_index, validator_keys)
+                .map(|kp| StateProofEntry {
+                    field: kp.field,
+                    key: Some(kp.key),
+                }),
+            SszStateKey::Deposit(index) => proof_tree
+                .generate_deposit_proof(*index)
+                .map(|field| StateProofEntry { field, key: None }),
+            SszStateKey::DepositField(index, field_index) => proof_tree
+                .generate_deposit_field_proof(*index, *field_index)
+                .map(|field| StateProofEntry { field, key: None }),
+            SszStateKey::Withdrawal(pubkey) => proof_tree
+                .generate_withdrawal_proof_by_key(pubkey)
+                .map(|field| StateProofEntry { field, key: None }),
+            SszStateKey::WithdrawalField(pubkey, field_index) => proof_tree
+                .generate_withdrawal_keyed_field_proof_by_key(pubkey, *field_index)
+                .map(|kp| StateProofEntry {
+                    field: kp.field,
+                    key: Some(kp.key),
+                }),
+            SszStateKey::ProtocolParam(index) => proof_tree
+                .generate_protocol_param_proof(*index)
+                .map(|field| StateProofEntry { field, key: None }),
+            SszStateKey::ProtocolParamField(index, field_index) => proof_tree
+                .generate_protocol_param_field_proof(*index, *field_index)
+                .map(|field| StateProofEntry { field, key: None }),
+            SszStateKey::AddedValidator(index) => proof_tree
+                .generate_added_validator_proof(*index)
+                .map(|field| StateProofEntry { field, key: None }),
+            SszStateKey::AddedValidatorField(index, field_index) => proof_tree
+                .generate_added_validator_field_proof(*index, *field_index)
+                .map(|field| StateProofEntry { field, key: None }),
+            SszStateKey::RemovedValidator(index) => proof_tree
+                .generate_removed_validator_proof(*index)
+                .map(|field| StateProofEntry { field, key: None }),
         })
         .collect()
 }

--- a/finalizer/src/ingress.rs
+++ b/finalizer/src/ingress.rs
@@ -475,7 +475,7 @@ impl<S: Scheme<B::Digest>, B: ConsensusBlock> FinalizerMailbox<S, B> {
     ) -> (
         [u8; 32],
         u64,
-        Vec<Option<summit_types::ssz_state_tree::SszProof>>,
+        Vec<Option<summit_types::ssz_state_tree::StateProofEntry>>,
     ) {
         let (response, rx) = oneshot::channel();
         let request = ConsensusStateRequest::GenerateStateProof(keys, None);

--- a/finalizer/src/tests/state_queries.rs
+++ b/finalizer/src/tests/state_queries.rs
@@ -241,6 +241,7 @@ fn test_generate_state_proof_preserves_batch_cardinality_for_missing_keys() {
             proofs[0]
                 .as_ref()
                 .expect("first response slot should contain the epoch proof")
+                .field
                 .verify(&root),
             "first response slot should contain the epoch proof"
         );
@@ -252,6 +253,7 @@ fn test_generate_state_proof_preserves_batch_cardinality_for_missing_keys() {
             proofs[2]
                 .as_ref()
                 .expect("third response slot should contain the latest_height proof")
+                .field
                 .verify(&root),
             "third response slot should contain the latest_height proof"
         );

--- a/node/src/bin/verify_consensus_state_proof.rs
+++ b/node/src/bin/verify_consensus_state_proof.rs
@@ -508,7 +508,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             // we reject the proof unless it binds to the requested pubkey.
             println!("\nTEST E: by-pubkey field proof is bound to the requested pubkey");
 
-            use summit_types::ssz_state_tree::{KeyedFieldProof, VALIDATOR_FIELDS_PER_ACCOUNT};
+            use summit_types::ssz_state_tree::{
+                KeyedFieldProof, VALIDATOR_FIELD_NODE_PUBKEY, VALIDATOR_FIELDS_PER_ACCOUNT,
+            };
 
             let key_proof = balance_proof_resp.results[0]
                 .key_proof
@@ -554,7 +556,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 keyed.verify(
                     &balance_proof_resp.root,
                     &requested_pubkey,
-                    VALIDATOR_FIELDS_PER_ACCOUNT
+                    VALIDATOR_FIELDS_PER_ACCOUNT,
+                    VALIDATOR_FIELD_NODE_PUBKEY
                 ),
                 "balance field proof is not bound to the requested validator pubkey"
             );
@@ -567,7 +570,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 !keyed.verify(
                     &balance_proof_resp.root,
                     &other_pubkey,
-                    VALIDATOR_FIELDS_PER_ACCOUNT
+                    VALIDATOR_FIELDS_PER_ACCOUNT,
+                    VALIDATOR_FIELD_NODE_PUBKEY
                 ),
                 "balance field proof wrongly verified against a different pubkey"
             );

--- a/node/src/bin/verify_consensus_state_proof.rs
+++ b/node/src/bin/verify_consensus_state_proof.rs
@@ -500,6 +500,80 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
 
             // ---------------------------------------------------------------
+            // TEST E: A by-pubkey field proof MUST bind to the requested pubkey
+            // ---------------------------------------------------------------
+            // A bare positional field proof only shows the leaf exists under the
+            // root, not that it belongs to the requested validator. The response
+            // must carry a companion `key_proof` of the item's node-pubkey leaf;
+            // we reject the proof unless it binds to the requested pubkey.
+            println!("\nTEST E: by-pubkey field proof is bound to the requested pubkey");
+
+            use summit_types::ssz_state_tree::{KeyedFieldProof, VALIDATOR_FIELDS_PER_ACCOUNT};
+
+            let key_proof = balance_proof_resp.results[0]
+                .key_proof
+                .as_ref()
+                .expect("by-pubkey field proof returned no key_proof binding");
+
+            // Verify the key-leaf proof on-chain against the same root.
+            {
+                let calldata = encode_verify(
+                    bal_timestamp,
+                    key_proof.gindex,
+                    &key_proof.leaf,
+                    &key_proof.branch,
+                    verify_selector,
+                );
+                let call_tx = TransactionRequest::default()
+                    .with_to(verifier_address)
+                    .with_input(Bytes::from(calldata));
+                let result = provider
+                    .call(call_tx)
+                    .await
+                    .expect("verify (key_proof) call failed");
+                let returned_root: [u8; 32] = result[..32]
+                    .try_into()
+                    .expect("verify response not 32 bytes");
+                assert_eq!(
+                    returned_root, balance_proof_resp.root,
+                    "verify returned wrong root for key_proof"
+                );
+            }
+
+            // Reconstruct the requested pubkey and require the full binding:
+            // both leaves authenticate under the root, the key leaf equals the
+            // requested pubkey, and field+key resolve to the same account.
+            let mut requested_pubkey = [0u8; 32];
+            alloy::hex::decode_to_slice(VALIDATOR0_PUBKEY_HEX, &mut requested_pubkey)
+                .expect("VALIDATOR0_PUBKEY_HEX is not 32 bytes");
+            let keyed = KeyedFieldProof {
+                field: bp.clone(),
+                key: key_proof.clone(),
+            };
+            assert!(
+                keyed.verify(
+                    &balance_proof_resp.root,
+                    &requested_pubkey,
+                    VALIDATOR_FIELDS_PER_ACCOUNT
+                ),
+                "balance field proof is not bound to the requested validator pubkey"
+            );
+            println!("  binding OK: balance field is bound to the requested validator");
+
+            // Negative: the same field proof must NOT verify as a different pubkey.
+            let mut other_pubkey = requested_pubkey;
+            other_pubkey[0] ^= 0xff;
+            assert!(
+                !keyed.verify(
+                    &balance_proof_resp.root,
+                    &other_pubkey,
+                    VALIDATOR_FIELDS_PER_ACCOUNT
+                ),
+                "balance field proof wrongly verified against a different pubkey"
+            );
+            println!("  binding rejects substituted pubkey as expected");
+
+            // ---------------------------------------------------------------
             // Done
             // ---------------------------------------------------------------
             println!("\nAll tests passed!");

--- a/rpc/src/server.rs
+++ b/rpc/src/server.rs
@@ -544,11 +544,20 @@ impl SummitProofApiServer for SummitRpcServer {
         let results = keys
             .into_iter()
             .zip(proofs)
-            .map(|(key, proof)| {
-                let error = proof
+            .map(|(key, entry)| {
+                let error = entry
                     .is_none()
                     .then(|| "key is absent or out of range".to_string());
-                StateProofResult { key, proof, error }
+                let (proof, key_proof) = match entry {
+                    Some(e) => (Some(e.field), e.key),
+                    None => (None, None),
+                };
+                StateProofResult {
+                    key,
+                    proof,
+                    key_proof,
+                    error,
+                }
             })
             .collect();
 

--- a/types/src/consensus_state_query.rs
+++ b/types/src/consensus_state_query.rs
@@ -1,7 +1,7 @@
 use crate::account::ValidatorAccount;
 use crate::checkpoint::Checkpoint;
 use crate::execution_request::DepositRequest;
-use crate::ssz_state_tree::SszProof;
+use crate::ssz_state_tree::StateProofEntry;
 use crate::ssz_tree_key::SszStateKey;
 use crate::withdrawal::PendingWithdrawal;
 use crate::{Block, FinalizedHeader, PublicKey};
@@ -71,7 +71,7 @@ pub enum ConsensusStateResponse<S: Scheme> {
     StateProof {
         root: [u8; 32],
         el_block_number: u64,
-        proofs: Vec<Option<SszProof>>,
+        proofs: Vec<Option<StateProofEntry>>,
     },
 }
 
@@ -420,7 +420,7 @@ impl<S: Scheme> ConsensusStateQuery<S> {
         &self,
         keys: Vec<SszStateKey>,
         permit: Box<dyn Send + 'static>,
-    ) -> ([u8; 32], u64, Vec<Option<SszProof>>) {
+    ) -> ([u8; 32], u64, Vec<Option<StateProofEntry>>) {
         let (tx, rx) = oneshot::channel();
         let req = ConsensusStateRequest::GenerateStateProof(keys, Some(permit));
         let _ = self.sender.clone().send((req, tx)).await;

--- a/types/src/rpc.rs
+++ b/types/src/rpc.rs
@@ -82,6 +82,14 @@ pub struct StateProofResponse {
 pub struct StateProofResult {
     pub key: String,
     pub proof: Option<crate::ssz_state_tree::SszProof>,
+    /// For by-pubkey field requests (`withdrawal_field:`/`validator_field:`),
+    /// a companion proof of the item's key (pubkey) leaf. A trustless consumer
+    /// MUST verify this alongside `proof` (see
+    /// [`crate::ssz_state_tree::KeyedFieldProof::verify`]) to confirm the field
+    /// belongs to the requested pubkey rather than to some other item under the
+    /// same root. `None` for scalar, whole-item, and index-addressed proofs.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub key_proof: Option<crate::ssz_state_tree::SszProof>,
     pub error: Option<String>,
 }
 

--- a/types/src/ssz_state_tree.rs
+++ b/types/src/ssz_state_tree.rs
@@ -1156,6 +1156,24 @@ impl SszStateTree {
         })
     }
 
+    /// Generate a field-level proof for a validator identified by node pubkey,
+    /// bound to that pubkey via a companion proof of the item's node-pubkey leaf.
+    ///
+    /// Unlike [`Self::generate_validator_field_proof`], the returned
+    /// [`KeyedFieldProof`] lets a trustless consumer confirm the field belongs
+    /// to the requested validator rather than to some other account under the
+    /// same root. Verify with `proof.verify(root, pubkey, VALIDATOR_FIELDS_PER_ACCOUNT)`.
+    pub fn generate_validator_keyed_field_proof(
+        &self,
+        pubkey: &[u8; 32],
+        field_index: usize,
+        keys: &[[u8; 32]],
+    ) -> Option<KeyedFieldProof> {
+        let field = self.generate_validator_field_proof(pubkey, field_index, keys)?;
+        let key = self.generate_validator_field_proof(pubkey, VALIDATOR_FIELD_NODE_PUBKEY, keys)?;
+        Some(KeyedFieldProof { field, key })
+    }
+
     /// Build a proof for the whole validator at positional `slot`.
     ///
     /// Returns (gindex, node_value, branch) where the node is the
@@ -1347,6 +1365,25 @@ impl SszStateTree {
     ) -> Option<SszProof> {
         let &(epoch_slot, item_slot) = self.withdrawal_pubkey_index.get(pubkey)?;
         self.generate_withdrawal_field_proof(epoch_slot, item_slot, field_index)
+    }
+
+    /// Generate a field-level proof for a withdrawal identified by pubkey,
+    /// bound to that pubkey via a companion proof of the item's pubkey leaf.
+    ///
+    /// Unlike [`Self::generate_withdrawal_field_proof_by_key`], the returned
+    /// [`KeyedFieldProof`] lets a trustless consumer confirm the field belongs
+    /// to the requested pubkey rather than to some other withdrawal under the
+    /// same root. Verify with `proof.verify(root, pubkey, WITHDRAWAL_FIELDS_PER_ITEM)`.
+    pub fn generate_withdrawal_keyed_field_proof_by_key(
+        &self,
+        pubkey: &[u8; 32],
+        field_index: usize,
+    ) -> Option<KeyedFieldProof> {
+        let &(epoch_slot, item_slot) = self.withdrawal_pubkey_index.get(pubkey)?;
+        let field = self.generate_withdrawal_field_proof(epoch_slot, item_slot, field_index)?;
+        let key =
+            self.generate_withdrawal_field_proof(epoch_slot, item_slot, WITHDRAWAL_FIELD_PUBKEY)?;
+        Some(KeyedFieldProof { field, key })
     }
 
     /// Internal helper: produce (gindex, node_value, branch) for a whole-withdrawal proof.
@@ -1685,6 +1722,76 @@ impl SszProof {
     pub fn verify(&self, state_root: &[u8; 32]) -> bool {
         SszTree::verify_proof_gindex(state_root, self.gindex, &self.leaf, &self.branch)
     }
+}
+
+/// A field-level proof bound to the collection item it belongs to.
+///
+/// A bare [`SszProof`] for a single field authenticates only that *some*
+/// positional leaf exists under the root — it does not prove the field belongs
+/// to the requested key (pubkey). For by-pubkey field proofs
+/// (`withdrawal_field:`/`validator_field:`) the selector is resolved to a
+/// position *server-side*, so a malicious provider could answer with the same
+/// field from a *different* item under the same root and the branch would still
+/// verify. `KeyedFieldProof` closes that gap by carrying a second proof of the
+/// item's key leaf; [`KeyedFieldProof::verify`] checks both leaves authenticate
+/// against the root, that the key leaf equals the requested key, and that the
+/// field and key leaves belong to the *same* collection item.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct KeyedFieldProof {
+    /// Proof of the requested field leaf.
+    pub field: SszProof,
+    /// Proof of the item's key (pubkey) leaf, binding `field` to the request.
+    pub key: SszProof,
+}
+
+impl KeyedFieldProof {
+    /// Verify that `field` is bound to `expected_key` under `state_root`.
+    ///
+    /// `fields_per_item` is the number of leaves per collection item (a power of
+    /// two: [`WITHDRAWAL_FIELDS_PER_ITEM`] for withdrawals,
+    /// [`VALIDATOR_FIELDS_PER_ACCOUNT`] for validator accounts). Returns `true`
+    /// only when all of the following hold:
+    /// 1. both `field` and `key` authenticate against `state_root`,
+    /// 2. the key leaf equals `hash_tree_root(expected_key)` (for a 32-byte key
+    ///    this is the key itself), and
+    /// 3. `field` and `key` resolve to the same item — i.e. their generalized
+    ///    indices agree once the low `log2(fields_per_item)` field-selector bits
+    ///    are dropped.
+    pub fn verify(
+        &self,
+        state_root: &[u8; 32],
+        expected_key: &[u8; 32],
+        fields_per_item: usize,
+    ) -> bool {
+        if !fields_per_item.is_power_of_two() {
+            return false;
+        }
+        if !self.field.verify(state_root) || !self.key.verify(state_root) {
+            return false;
+        }
+        if self.key.leaf != expected_key.hash_tree_root() {
+            return false;
+        }
+        // The bottom `log2(fields_per_item)` bits of a field gindex are the
+        // field selector within the item; shifting them off yields the item's
+        // subtree-root gindex. Equal item roots ⟺ same item.
+        let shift = fields_per_item.ilog2();
+        (self.field.gindex >> shift) == (self.key.gindex >> shift)
+    }
+}
+
+/// A single entry in a `GenerateStateProof` response.
+///
+/// `key` is `Some` only for by-pubkey field proofs, where it carries the item's
+/// key-leaf proof so the consumer can bind the field to the requested pubkey via
+/// [`KeyedFieldProof::verify`]. For scalar, whole-item, and index-addressed
+/// proofs it is `None` and `field` stands alone.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct StateProofEntry {
+    /// Proof of the requested leaf (field, scalar, or whole-item root).
+    pub field: SszProof,
+    /// For by-pubkey field requests, proof of the item's key leaf.
+    pub key: Option<SszProof>,
 }
 
 #[cfg(test)]
@@ -2524,6 +2631,84 @@ mod tests {
             field_proof.branch.len(),
             item_proof.branch.len() + 3,
             "field branch should be 3 longer than item branch"
+        );
+    }
+
+    #[test]
+    fn withdrawal_keyed_field_proof_binds_to_requested_pubkey() {
+        let pk1 = [1u8; 32];
+        let pk2 = [2u8; 32];
+        let mut queue = WithdrawalQueue::default();
+        // Two withdrawals in the same epoch with DIFFERENT amounts.
+        queue.push(PendingWithdrawal {
+            inner: Withdrawal {
+                index: 0,
+                validator_index: 0,
+                address: Address::from([0x11; 20]),
+                amount: 1_000_000_000,
+            },
+            pubkey: pk1,
+            balance_deduction: 1_000_000_000,
+            epoch: 1,
+        });
+        queue.push(PendingWithdrawal {
+            inner: Withdrawal {
+                index: 1,
+                validator_index: 1,
+                address: Address::from([0x22; 20]),
+                amount: 2_000_000_000,
+            },
+            pubkey: pk2,
+            balance_deduction: 2_000_000_000,
+            epoch: 1,
+        });
+
+        let mut tree = SszStateTree::new();
+        tree.rebuild_withdrawals(&queue);
+        tree.set_epoch(5);
+        let root = tree.root();
+
+        // The honest keyed proof for pk1's amount binds to pk1.
+        let keyed1 = tree
+            .generate_withdrawal_keyed_field_proof_by_key(&pk1, WITHDRAWAL_FIELD_AMOUNT)
+            .unwrap();
+        assert!(
+            keyed1.verify(&root, &pk1, WITHDRAWAL_FIELDS_PER_ITEM),
+            "honest keyed proof should bind to its own pubkey"
+        );
+        assert_eq!(keyed1.field.leaf, 1_000_000_000u64.hash_tree_root());
+
+        // It must NOT verify against a different requested pubkey.
+        assert!(
+            !keyed1.verify(&root, &pk2, WITHDRAWAL_FIELDS_PER_ITEM),
+            "keyed proof must not verify against a different pubkey"
+        );
+
+        // Substitution attack: a malicious provider answers a by-pk1 request
+        // with pk2's amount field. The bare positional field proof still
+        // verifies against the root (this is the vulnerability), ...
+        let pk2_amount = tree
+            .generate_withdrawal_field_proof_by_key(&pk2, WITHDRAWAL_FIELD_AMOUNT)
+            .unwrap();
+        assert!(
+            pk2_amount.verify(&root),
+            "pk2's positional amount proof verifies against the root unaided"
+        );
+        assert_eq!(pk2_amount.leaf, 2_000_000_000u64.hash_tree_root());
+
+        // ... but pairing it with any key proof cannot bind it to pk1: the only
+        // key leaf equal to pk1 lives in pk1's item, whose gindex differs from
+        // pk2's field gindex, so the same-item check fails.
+        let pk1_key = tree
+            .generate_withdrawal_field_proof_by_key(&pk1, WITHDRAWAL_FIELD_PUBKEY)
+            .unwrap();
+        let forged = KeyedFieldProof {
+            field: pk2_amount,
+            key: pk1_key,
+        };
+        assert!(
+            !forged.verify(&root, &pk1, WITHDRAWAL_FIELDS_PER_ITEM),
+            "substituted field from a different withdrawal must not bind to pk1"
         );
     }
 

--- a/types/src/ssz_state_tree.rs
+++ b/types/src/ssz_state_tree.rs
@@ -1162,7 +1162,8 @@ impl SszStateTree {
     /// Unlike [`Self::generate_validator_field_proof`], the returned
     /// [`KeyedFieldProof`] lets a trustless consumer confirm the field belongs
     /// to the requested validator rather than to some other account under the
-    /// same root. Verify with `proof.verify(root, pubkey, VALIDATOR_FIELDS_PER_ACCOUNT)`.
+    /// same root. Verify with
+    /// `proof.verify(root, pubkey, VALIDATOR_FIELDS_PER_ACCOUNT, VALIDATOR_FIELD_NODE_PUBKEY)`.
     pub fn generate_validator_keyed_field_proof(
         &self,
         pubkey: &[u8; 32],
@@ -1373,7 +1374,8 @@ impl SszStateTree {
     /// Unlike [`Self::generate_withdrawal_field_proof_by_key`], the returned
     /// [`KeyedFieldProof`] lets a trustless consumer confirm the field belongs
     /// to the requested pubkey rather than to some other withdrawal under the
-    /// same root. Verify with `proof.verify(root, pubkey, WITHDRAWAL_FIELDS_PER_ITEM)`.
+    /// same root. Verify with
+    /// `proof.verify(root, pubkey, WITHDRAWAL_FIELDS_PER_ITEM, WITHDRAWAL_FIELD_PUBKEY)`.
     pub fn generate_withdrawal_keyed_field_proof_by_key(
         &self,
         pubkey: &[u8; 32],
@@ -1734,8 +1736,10 @@ impl SszProof {
 /// field from a *different* item under the same root and the branch would still
 /// verify. `KeyedFieldProof` closes that gap by carrying a second proof of the
 /// item's key leaf; [`KeyedFieldProof::verify`] checks both leaves authenticate
-/// against the root, that the key leaf equals the requested key, and that the
-/// field and key leaves belong to the *same* collection item.
+/// against the root, that the key leaf equals the requested key, that the key
+/// proof addresses the canonical key field within its item (not just any field
+/// that happens to hash to the key), and that the field and key leaves belong to
+/// the *same* collection item.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct KeyedFieldProof {
     /// Proof of the requested field leaf.
@@ -1749,12 +1753,18 @@ impl KeyedFieldProof {
     ///
     /// `fields_per_item` is the number of leaves per collection item (a power of
     /// two: [`WITHDRAWAL_FIELDS_PER_ITEM`] for withdrawals,
-    /// [`VALIDATOR_FIELDS_PER_ACCOUNT`] for validator accounts). Returns `true`
+    /// [`VALIDATOR_FIELDS_PER_ACCOUNT`] for validator accounts). `key_field_index`
+    /// is the canonical key-field selector within an item
+    /// ([`WITHDRAWAL_FIELD_PUBKEY`] for withdrawals,
+    /// [`VALIDATOR_FIELD_NODE_PUBKEY`] for validator accounts). Returns `true`
     /// only when all of the following hold:
     /// 1. both `field` and `key` authenticate against `state_root`,
     /// 2. the key leaf equals `hash_tree_root(expected_key)` (for a 32-byte key
-    ///    this is the key itself), and
-    /// 3. `field` and `key` resolve to the same item — i.e. their generalized
+    ///    this is the key itself),
+    /// 3. the key proof addresses the canonical key field within its item (its
+    ///    field-selector bits equal `key_field_index`), so the binding cannot
+    ///    rest on some other field that merely happens to hash to the key, and
+    /// 4. `field` and `key` resolve to the same item — i.e. their generalized
     ///    indices agree once the low `log2(fields_per_item)` field-selector bits
     ///    are dropped.
     pub fn verify(
@@ -1762,6 +1772,7 @@ impl KeyedFieldProof {
         state_root: &[u8; 32],
         expected_key: &[u8; 32],
         fields_per_item: usize,
+        key_field_index: usize,
     ) -> bool {
         if !fields_per_item.is_power_of_two() {
             return false;
@@ -1772,9 +1783,14 @@ impl KeyedFieldProof {
         if self.key.leaf != expected_key.hash_tree_root() {
             return false;
         }
-        // The bottom `log2(fields_per_item)` bits of a field gindex are the
-        // field selector within the item; shifting them off yields the item's
-        // subtree-root gindex. Equal item roots ⟺ same item.
+        // The bottom `log2(fields_per_item)` bits of a gindex are the field
+        // selector within the item. Require the key proof to address the
+        // canonical key field, not just any field whose leaf equals the key.
+        if (self.key.gindex & (fields_per_item as u64 - 1)) != key_field_index as u64 {
+            return false;
+        }
+        // Shifting those selector bits off yields the item's subtree-root
+        // gindex. Equal item roots ⟺ same item.
         let shift = fields_per_item.ilog2();
         (self.field.gindex >> shift) == (self.key.gindex >> shift)
     }
@@ -2673,14 +2689,24 @@ mod tests {
             .generate_withdrawal_keyed_field_proof_by_key(&pk1, WITHDRAWAL_FIELD_AMOUNT)
             .unwrap();
         assert!(
-            keyed1.verify(&root, &pk1, WITHDRAWAL_FIELDS_PER_ITEM),
+            keyed1.verify(
+                &root,
+                &pk1,
+                WITHDRAWAL_FIELDS_PER_ITEM,
+                WITHDRAWAL_FIELD_PUBKEY
+            ),
             "honest keyed proof should bind to its own pubkey"
         );
         assert_eq!(keyed1.field.leaf, 1_000_000_000u64.hash_tree_root());
 
         // It must NOT verify against a different requested pubkey.
         assert!(
-            !keyed1.verify(&root, &pk2, WITHDRAWAL_FIELDS_PER_ITEM),
+            !keyed1.verify(
+                &root,
+                &pk2,
+                WITHDRAWAL_FIELDS_PER_ITEM,
+                WITHDRAWAL_FIELD_PUBKEY
+            ),
             "keyed proof must not verify against a different pubkey"
         );
 
@@ -2707,8 +2733,37 @@ mod tests {
             key: pk1_key,
         };
         assert!(
-            !forged.verify(&root, &pk1, WITHDRAWAL_FIELDS_PER_ITEM),
+            !forged.verify(
+                &root,
+                &pk1,
+                WITHDRAWAL_FIELDS_PER_ITEM,
+                WITHDRAWAL_FIELD_PUBKEY
+            ),
             "substituted field from a different withdrawal must not bind to pk1"
+        );
+
+        // Canonical-selector hardening: a `key` proof addressing a NON-pubkey
+        // field must be rejected even when its leaf equals the requested key and
+        // it sits in the same item as `field`. Use pk1's amount field as the
+        // stand-in key and request a key equal to that field's leaf: the leaf
+        // and same-item checks both pass, so only the selector check rejects it.
+        let pk1_amount = tree
+            .generate_withdrawal_field_proof_by_key(&pk1, WITHDRAWAL_FIELD_AMOUNT)
+            .unwrap();
+        let amount_leaf: [u8; 32] = 1_000_000_000u64.hash_tree_root();
+        assert_eq!(pk1_amount.leaf, amount_leaf);
+        let mis_selected = KeyedFieldProof {
+            field: pk1_amount.clone(),
+            key: pk1_amount,
+        };
+        assert!(
+            !mis_selected.verify(
+                &root,
+                &amount_leaf,
+                WITHDRAWAL_FIELDS_PER_ITEM,
+                WITHDRAWAL_FIELD_PUBKEY
+            ),
+            "a key proof addressing a non-pubkey field must be rejected by the selector check"
         );
     }
 


### PR DESCRIPTION
Addresses https://github.com/SeismicSystems/summit/issues/233.

Changes:
- **types/ssz_state_tree.rs** — add `KeyedFieldProof` + `verify(root, key, fields_per_item)`; add `generate_withdrawal_keyed_field_proof_by_key` and `generate_validator_keyed_field_proof`; add `StateProofEntry { field, key: Option<_> }`.
- **types/consensus_state_query.rs, finalizer/{actor,ingress}.rs** — thread `StateProofEntry` through the `GenerateStateProof` response; by-pubkey field requests emit the keyed pair, all others `key: None`.
- **types/rpc.rs, rpc/server.rs** — add `key_proof: Option<SszProof>` to `StateProofResult` (`skip_serializing_if` → JSON back-compatible).
- **node/src/bin/verify_consensus_state_proof.rs** — TEST E: require `key_proof`, verify it on-chain, run the binding check, and assert a substituted pubkey is rejected.
- **docs/ssz-merklization.md** — document the binding requirement and `key_proof`.
- **tests** — new `withdrawal_keyed_field_proof_binds_to_requested_pubkey` covering honest binding, wrong-pubkey rejection, and the substitution forgery.