### PR TITLE
fix: require checkpoint verification at startup and bind import artifacts to verified chain

### DIFF
--- a/node/src/args.rs
+++ b/node/src/args.rs
@@ -181,6 +181,17 @@ pub struct RunFlags {
     )]
     pub weak_subjectivity_header_digest: Option<String>,
 
+    /// Import a checkpoint WITHOUT verifying it against a finalized-header chain.
+    ///
+    /// UNSAFE: the imported consensus state is trusted entirely from the supplied
+    /// checkpoint artifact. By default, checkpoint startup requires a checkpoint
+    /// directory containing finalized_headers/ together with
+    /// --weak-subjectivity-epoch and --weak-subjectivity-header-digest. Set this
+    /// flag to bypass that requirement (e.g. to import a standalone checkpoint
+    /// file). Only use it when the checkpoint source is fully trusted.
+    #[arg(long, requires = "checkpoint_path")]
+    pub unsafe_skip_checkpoint_verification: bool,
+
     /// IP address for this node (optional, will use genesis if not provided)
     #[arg(long)]
     pub ip: Option<String>,
@@ -408,7 +419,7 @@ async fn run_node_inner(
     context: tokio::Context,
     flags: RunFlags,
     key_store: KeyStore<PrivateKey>,
-    loaded: LoadedCheckpoint<MultisigScheme>,
+    mut loaded: LoadedCheckpoint<MultisigScheme>,
 ) {
     let context = context.with_label("summit_cw");
 
@@ -438,6 +449,9 @@ async fn run_node_inner(
 
     // Verify checkpoint if finalized headers chain was provided
     let weak_subjectivity = weak_subjectivity_from_flags(&flags);
+    // The signature-verified chain terminal, used below to bind the optional
+    // last_block / finalized_header artifacts to the verified history.
+    let mut verified_terminal_header: Option<FinalizedHeader<MultisigScheme>> = None;
     if let (Some(raw_checkpoint), Some(headers_chain)) =
         (&loaded.raw_checkpoint, &loaded.finalized_headers_chain)
     {
@@ -457,13 +471,57 @@ async fn run_node_inner(
             weak_subjectivity_epoch = weak_subjectivity.epoch,
             "checkpoint verified successfully"
         );
-    } else if loaded.raw_checkpoint.is_some() {
-        if weak_subjectivity.is_some() {
-            panic!(
-                "weak-subjectivity checkpoint verification requires a checkpoint directory with finalized_headers/"
+
+        // Bind the optional last_block / finalized_header artifacts to the
+        // verified chain. The chain terminal is a signature-verified
+        // FinalizedHeader whose finalization commits to the terminal block's
+        // digest. Require any supplied last_block to be exactly that block (so a
+        // directory cannot pair a verified checkpoint with an unrelated block),
+        // and hand the verified terminal to the syncer as the finalization to
+        // complete the checkpoint, rather than the separately-loaded, unverified
+        // top-level finalized_header artifact.
+        let terminal = headers_chain
+            .last()
+            .expect("verified finalized-header chain is non-empty");
+        if let Some(last_block) = &loaded.last_block {
+            let committed = terminal.finalization().proposal.payload;
+            assert!(
+                last_block.digest() == committed,
+                "checkpoint last_block does not match the verified terminal header's \
+                 finalized block (last_block {:?}, verified terminal {:?})",
+                last_block.digest(),
+                committed,
             );
         }
-        warn!("checkpoint loaded without finalized headers chain - skipping verification");
+        verified_terminal_header = Some(terminal.clone());
+    } else if loaded.raw_checkpoint.is_some() {
+        // A checkpoint was supplied but there is no finalized-headers chain to
+        // verify it against. Refuse by default; only skip verification when the
+        // operator explicitly opts in via --unsafe-skip-checkpoint-verification.
+        if !flags.unsafe_skip_checkpoint_verification {
+            panic!(
+                "refusing to import an unverified checkpoint: supply a checkpoint directory \
+                 with finalized_headers/ plus --weak-subjectivity-epoch and \
+                 --weak-subjectivity-header-digest, or pass \
+                 --unsafe-skip-checkpoint-verification to import without verification (NOT recommended)"
+            );
+        }
+        if weak_subjectivity.is_some() {
+            warn!(
+                "--weak-subjectivity-* ignored: no finalized_headers chain present and \
+                 --unsafe-skip-checkpoint-verification was set; skipping verification"
+            );
+        }
+        warn!(
+            "UNSAFE: checkpoint imported without verification \
+             (--unsafe-skip-checkpoint-verification)"
+        );
+    }
+
+    // On the verified path, complete the checkpoint from the signature-verified
+    // chain terminal rather than the unverified top-level finalized_header file.
+    if let Some(terminal) = verified_terminal_header {
+        loaded.finalized_header = Some(terminal);
     }
 
     let initial_state = get_initial_state(&genesis, &committee, loaded.consensus_state);

--- a/node/src/args.rs
+++ b/node/src/args.rs
@@ -50,7 +50,7 @@ use summit_types::{
     account::{ValidatorAccount, ValidatorStatus},
     bls12381,
 };
-use summit_types::{Genesis, PrivateKey, PublicKey, Validator, utils::get_expanded_path};
+use summit_types::{Digest, Genesis, PrivateKey, PublicKey, Validator, utils::get_expanded_path};
 use summit_types::{consensus_state::ConsensusState, scheme::MultisigScheme};
 use tracing::{Level, error, info, warn};
 
@@ -415,6 +415,132 @@ mod genesis_path_tests {
     }
 }
 
+/// How checkpoint startup should treat the supplied artifacts. Extracted as a
+/// pure decision so the policy can be unit-tested without the side effects
+/// (signature verification, process exit) of the live startup path — mirrors the
+/// [`GenesisPathState`] pattern above.
+#[derive(Debug, PartialEq, Eq)]
+enum CheckpointStartupDecision {
+    /// No checkpoint supplied; start from genesis (or the local DB).
+    NoCheckpoint,
+    /// A checkpoint and a finalized-headers chain are present; verify the
+    /// checkpoint against the chain before installing it.
+    Verify,
+    /// A checkpoint was supplied without a finalized-headers chain and the
+    /// operator opted into importing it unverified.
+    SkipUnsafe,
+    /// A checkpoint was supplied without a finalized-headers chain and
+    /// verification was not waived; refuse to start.
+    RefuseUnverified,
+}
+
+/// Decide how to treat checkpoint artifacts at startup.
+///
+/// Requiring a finalized-headers chain by default is what closes the
+/// unauthenticated-import hole (#214): once the chain is present, the
+/// signature-verified terminal header authenticates every byte of the checkpoint
+/// through the checkpoint-hash binding, so the decoded consensus state cannot be
+/// tampered with. A bare checkpoint with no chain is refused unless the operator
+/// explicitly waives verification.
+fn classify_checkpoint_startup(
+    has_checkpoint: bool,
+    has_headers_chain: bool,
+    unsafe_skip_verification: bool,
+) -> CheckpointStartupDecision {
+    match (has_checkpoint, has_headers_chain) {
+        (false, _) => CheckpointStartupDecision::NoCheckpoint,
+        (true, true) => CheckpointStartupDecision::Verify,
+        (true, false) if unsafe_skip_verification => CheckpointStartupDecision::SkipUnsafe,
+        (true, false) => CheckpointStartupDecision::RefuseUnverified,
+    }
+}
+
+/// Bind a supplied `last_block` to the verified chain terminal's finalized block
+/// digest. `last_block` and the finalized-headers chain are loaded from
+/// independent files, so a checkpoint directory could otherwise pair a verified
+/// checkpoint with an unrelated block. Returns `Err` with a descriptive message
+/// on mismatch; `Ok` when the block matches or none was supplied.
+fn check_last_block_binding(
+    last_block_digest: Option<Digest>,
+    committed_digest: Digest,
+) -> Result<(), String> {
+    match last_block_digest {
+        Some(d) if d != committed_digest => Err(format!(
+            "checkpoint last_block does not match the verified terminal header's \
+             finalized block (last_block {d:?}, verified terminal {committed_digest:?})"
+        )),
+        _ => Ok(()),
+    }
+}
+
+#[cfg(test)]
+mod checkpoint_startup_tests {
+    use super::*;
+
+    #[test]
+    fn no_checkpoint_starts_from_genesis() {
+        assert_eq!(
+            classify_checkpoint_startup(false, false, false),
+            CheckpointStartupDecision::NoCheckpoint
+        );
+        // Headers/unsafe flags are irrelevant when no checkpoint is supplied.
+        assert_eq!(
+            classify_checkpoint_startup(false, true, true),
+            CheckpointStartupDecision::NoCheckpoint
+        );
+    }
+
+    #[test]
+    fn checkpoint_with_headers_chain_is_verified() {
+        assert_eq!(
+            classify_checkpoint_startup(true, true, false),
+            CheckpointStartupDecision::Verify
+        );
+        // The unsafe flag must not downgrade the verified path when a chain is
+        // present — verification still runs.
+        assert_eq!(
+            classify_checkpoint_startup(true, true, true),
+            CheckpointStartupDecision::Verify
+        );
+    }
+
+    #[test]
+    fn standalone_checkpoint_is_refused_by_default() {
+        // Regression for #214: a checkpoint with no finalized-headers chain must
+        // be refused rather than silently imported unverified.
+        assert_eq!(
+            classify_checkpoint_startup(true, false, false),
+            CheckpointStartupDecision::RefuseUnverified
+        );
+    }
+
+    #[test]
+    fn standalone_checkpoint_allowed_only_with_unsafe_flag() {
+        assert_eq!(
+            classify_checkpoint_startup(true, false, true),
+            CheckpointStartupDecision::SkipUnsafe
+        );
+    }
+
+    #[test]
+    fn last_block_binding_accepts_matching_or_absent() {
+        let committed: Digest = [7u8; 32].into();
+        // No last_block supplied: nothing to bind.
+        assert!(check_last_block_binding(None, committed).is_ok());
+        // last_block matches the verified terminal's finalized block.
+        assert!(check_last_block_binding(Some(committed), committed).is_ok());
+    }
+
+    #[test]
+    fn last_block_binding_rejects_mismatch() {
+        // A directory pairing a verified checkpoint with an unrelated last_block
+        // must be rejected.
+        let committed: Digest = [7u8; 32].into();
+        let unrelated: Digest = [9u8; 32].into();
+        assert!(check_last_block_binding(Some(unrelated), committed).is_err());
+    }
+}
+
 async fn run_node_inner(
     context: tokio::Context,
     flags: RunFlags,
@@ -447,75 +573,89 @@ async fn run_node_inner(
         "loaded genesis configuration"
     );
 
-    // Verify checkpoint if finalized headers chain was provided
+    // Decide how to treat the supplied checkpoint artifacts. By default a
+    // checkpoint MUST be verified against a finalized-headers chain; see
+    // classify_checkpoint_startup.
     let weak_subjectivity = weak_subjectivity_from_flags(&flags);
-    // The signature-verified chain terminal, used below to bind the optional
-    // last_block / finalized_header artifacts to the verified history.
+    // The signature-verified chain terminal, used below to complete the
+    // checkpoint from the verified history rather than an unverified file.
     let mut verified_terminal_header: Option<FinalizedHeader<MultisigScheme>> = None;
-    if let (Some(raw_checkpoint), Some(headers_chain)) =
-        (&loaded.raw_checkpoint, &loaded.finalized_headers_chain)
-    {
-        let weak_subjectivity = weak_subjectivity.as_ref().expect(
-            "checkpoint verification requires --weak-subjectivity-epoch and \
-             --weak-subjectivity-header-digest when finalized_headers/ is present",
-        );
-        checkpoint::verify_checkpoint_chain_with_weak_subjectivity(
-            &genesis,
-            headers_chain,
-            raw_checkpoint,
-            Some(weak_subjectivity),
-        )
-        .expect("checkpoint verification failed");
-        info!(
-            epochs_verified = headers_chain.len(),
-            weak_subjectivity_epoch = weak_subjectivity.epoch,
-            "checkpoint verified successfully"
-        );
-
-        // Bind the optional last_block / finalized_header artifacts to the
-        // verified chain. The chain terminal is a signature-verified
-        // FinalizedHeader whose finalization commits to the terminal block's
-        // digest. Require any supplied last_block to be exactly that block (so a
-        // directory cannot pair a verified checkpoint with an unrelated block),
-        // and hand the verified terminal to the syncer as the finalization to
-        // complete the checkpoint, rather than the separately-loaded, unverified
-        // top-level finalized_header artifact.
-        let terminal = headers_chain
-            .last()
-            .expect("verified finalized-header chain is non-empty");
-        if let Some(last_block) = &loaded.last_block {
-            let committed = terminal.finalization().proposal.payload;
-            assert!(
-                last_block.digest() == committed,
-                "checkpoint last_block does not match the verified terminal header's \
-                 finalized block (last_block {:?}, verified terminal {:?})",
-                last_block.digest(),
-                committed,
+    match classify_checkpoint_startup(
+        loaded.raw_checkpoint.is_some(),
+        loaded.finalized_headers_chain.is_some(),
+        flags.unsafe_skip_checkpoint_verification,
+    ) {
+        CheckpointStartupDecision::NoCheckpoint => {}
+        CheckpointStartupDecision::Verify => {
+            let raw_checkpoint = loaded
+                .raw_checkpoint
+                .as_ref()
+                .expect("raw_checkpoint present on the verify path");
+            let headers_chain = loaded
+                .finalized_headers_chain
+                .as_ref()
+                .expect("finalized-headers chain present on the verify path");
+            let weak_subjectivity = weak_subjectivity.as_ref().expect(
+                "checkpoint verification requires --weak-subjectivity-epoch and \
+                 --weak-subjectivity-header-digest when finalized_headers/ is present",
             );
+            checkpoint::verify_checkpoint_chain_with_weak_subjectivity(
+                &genesis,
+                headers_chain,
+                raw_checkpoint,
+                Some(weak_subjectivity),
+            )
+            .expect("checkpoint verification failed");
+            info!(
+                epochs_verified = headers_chain.len(),
+                weak_subjectivity_epoch = weak_subjectivity.epoch,
+                "checkpoint verified successfully"
+            );
+
+            // Bind the optional last_block artifact to the verified chain. The
+            // chain terminal is a signature-verified FinalizedHeader whose
+            // finalization commits to the terminal block's digest; a supplied
+            // last_block must be exactly that block (so a directory cannot pair a
+            // verified checkpoint with an unrelated block). Then hand the verified
+            // terminal to the syncer as the finalization, rather than the
+            // separately-loaded, unverified top-level finalized_header artifact.
+            let terminal = headers_chain
+                .last()
+                .expect("verified finalized-header chain is non-empty");
+            if let Err(e) = check_last_block_binding(
+                loaded.last_block.as_ref().map(|b| b.digest()),
+                terminal.finalization().proposal.payload,
+            ) {
+                error!("{e}; refusing to start");
+                std::process::exit(1);
+            }
+            verified_terminal_header = Some(terminal.clone());
         }
-        verified_terminal_header = Some(terminal.clone());
-    } else if loaded.raw_checkpoint.is_some() {
-        // A checkpoint was supplied but there is no finalized-headers chain to
-        // verify it against. Refuse by default; only skip verification when the
-        // operator explicitly opts in via --unsafe-skip-checkpoint-verification.
-        if !flags.unsafe_skip_checkpoint_verification {
-            panic!(
+        CheckpointStartupDecision::RefuseUnverified => {
+            // A checkpoint was supplied with no finalized-headers chain to verify
+            // it against. Refuse (matching the genesis path's error+exit rather
+            // than crash-looping on a panic); the operator must supply a verifiable
+            // checkpoint or explicitly waive verification.
+            error!(
                 "refusing to import an unverified checkpoint: supply a checkpoint directory \
                  with finalized_headers/ plus --weak-subjectivity-epoch and \
                  --weak-subjectivity-header-digest, or pass \
                  --unsafe-skip-checkpoint-verification to import without verification (NOT recommended)"
             );
+            std::process::exit(1);
         }
-        if weak_subjectivity.is_some() {
+        CheckpointStartupDecision::SkipUnsafe => {
+            if weak_subjectivity.is_some() {
+                warn!(
+                    "--weak-subjectivity-* ignored: no finalized_headers chain present and \
+                     --unsafe-skip-checkpoint-verification was set; skipping verification"
+                );
+            }
             warn!(
-                "--weak-subjectivity-* ignored: no finalized_headers chain present and \
-                 --unsafe-skip-checkpoint-verification was set; skipping verification"
+                "UNSAFE: checkpoint imported without verification \
+                 (--unsafe-skip-checkpoint-verification)"
             );
         }
-        warn!(
-            "UNSAFE: checkpoint imported without verification \
-             (--unsafe-skip-checkpoint-verification)"
-        );
     }
 
     // On the verified path, complete the checkpoint from the signature-verified

--- a/node/src/args.rs
+++ b/node/src/args.rs
@@ -420,7 +420,7 @@ mod genesis_path_tests {
 /// (signature verification, process exit) of the live startup path — mirrors the
 /// [`GenesisPathState`] pattern above.
 #[derive(Debug, PartialEq, Eq)]
-enum CheckpointStartupDecision {
+pub(crate) enum CheckpointStartupDecision {
     /// No checkpoint supplied; start from genesis (or the local DB).
     NoCheckpoint,
     /// A checkpoint and a finalized-headers chain are present; verify the
@@ -442,7 +442,7 @@ enum CheckpointStartupDecision {
 /// through the checkpoint-hash binding, so the decoded consensus state cannot be
 /// tampered with. A bare checkpoint with no chain is refused unless the operator
 /// explicitly waives verification.
-fn classify_checkpoint_startup(
+pub(crate) fn classify_checkpoint_startup(
     has_checkpoint: bool,
     has_headers_chain: bool,
     unsafe_skip_verification: bool,
@@ -460,7 +460,7 @@ fn classify_checkpoint_startup(
 /// independent files, so a checkpoint directory could otherwise pair a verified
 /// checkpoint with an unrelated block. Returns `Err` with a descriptive message
 /// on mismatch; `Ok` when the block matches or none was supplied.
-fn check_last_block_binding(
+pub(crate) fn check_last_block_binding(
     last_block_digest: Option<Digest>,
     committed_digest: Digest,
 ) -> Result<(), String> {
@@ -470,74 +470,6 @@ fn check_last_block_binding(
              finalized block (last_block {d:?}, verified terminal {committed_digest:?})"
         )),
         _ => Ok(()),
-    }
-}
-
-#[cfg(test)]
-mod checkpoint_startup_tests {
-    use super::*;
-
-    #[test]
-    fn no_checkpoint_starts_from_genesis() {
-        assert_eq!(
-            classify_checkpoint_startup(false, false, false),
-            CheckpointStartupDecision::NoCheckpoint
-        );
-        // Headers/unsafe flags are irrelevant when no checkpoint is supplied.
-        assert_eq!(
-            classify_checkpoint_startup(false, true, true),
-            CheckpointStartupDecision::NoCheckpoint
-        );
-    }
-
-    #[test]
-    fn checkpoint_with_headers_chain_is_verified() {
-        assert_eq!(
-            classify_checkpoint_startup(true, true, false),
-            CheckpointStartupDecision::Verify
-        );
-        // The unsafe flag must not downgrade the verified path when a chain is
-        // present — verification still runs.
-        assert_eq!(
-            classify_checkpoint_startup(true, true, true),
-            CheckpointStartupDecision::Verify
-        );
-    }
-
-    #[test]
-    fn standalone_checkpoint_is_refused_by_default() {
-        // Regression for #214: a checkpoint with no finalized-headers chain must
-        // be refused rather than silently imported unverified.
-        assert_eq!(
-            classify_checkpoint_startup(true, false, false),
-            CheckpointStartupDecision::RefuseUnverified
-        );
-    }
-
-    #[test]
-    fn standalone_checkpoint_allowed_only_with_unsafe_flag() {
-        assert_eq!(
-            classify_checkpoint_startup(true, false, true),
-            CheckpointStartupDecision::SkipUnsafe
-        );
-    }
-
-    #[test]
-    fn last_block_binding_accepts_matching_or_absent() {
-        let committed: Digest = [7u8; 32].into();
-        // No last_block supplied: nothing to bind.
-        assert!(check_last_block_binding(None, committed).is_ok());
-        // last_block matches the verified terminal's finalized block.
-        assert!(check_last_block_binding(Some(committed), committed).is_ok());
-    }
-
-    #[test]
-    fn last_block_binding_rejects_mismatch() {
-        // A directory pairing a verified checkpoint with an unrelated last_block
-        // must be rejected.
-        let committed: Digest = [7u8; 32].into();
-        let unrelated: Digest = [9u8; 32].into();
-        assert!(check_last_block_binding(Some(unrelated), committed).is_err());
     }
 }
 
@@ -1294,15 +1226,15 @@ async fn get_node_ip(
     }
 }
 
-struct LoadedCheckpoint<S: Scheme> {
-    consensus_state: Option<ConsensusState>,
-    last_block: Option<Block>,
-    finalized_header: Option<FinalizedHeader<S>>,
-    raw_checkpoint: Option<Checkpoint>,
-    finalized_headers_chain: Option<Vec<FinalizedHeader<S>>>,
+pub(crate) struct LoadedCheckpoint<S: Scheme> {
+    pub(crate) consensus_state: Option<ConsensusState>,
+    pub(crate) last_block: Option<Block>,
+    pub(crate) finalized_header: Option<FinalizedHeader<S>>,
+    pub(crate) raw_checkpoint: Option<Checkpoint>,
+    pub(crate) finalized_headers_chain: Option<Vec<FinalizedHeader<S>>>,
 }
 
-fn read_checkpoint<S: Scheme>(
+pub(crate) fn read_checkpoint<S: Scheme>(
     checkpoint_path: &String,
     checkpoint_or_default: bool,
 ) -> LoadedCheckpoint<S>

--- a/node/src/bin/observer.rs
+++ b/node/src/bin/observer.rs
@@ -527,6 +527,7 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         checkpoint_or_default: false,
         weak_subjectivity_epoch: None,
         weak_subjectivity_header_digest: None,
+        unsafe_skip_checkpoint_verification: false,
         ip: None,
         bootstrappers: None,
         critical_log_dir: None,

--- a/node/src/bin/protocol_params.rs
+++ b/node/src/bin/protocol_params.rs
@@ -416,6 +416,7 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         checkpoint_or_default: false,
         weak_subjectivity_epoch: None,
         weak_subjectivity_header_digest: None,
+        unsafe_skip_checkpoint_verification: false,
         ip: None,
         bootstrappers: None,
         critical_log_dir: None,

--- a/node/src/bin/stake_and_checkpoint.rs
+++ b/node/src/bin/stake_and_checkpoint.rs
@@ -707,6 +707,7 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         checkpoint_or_default: false,
         weak_subjectivity_epoch: None,
         weak_subjectivity_header_digest: None,
+        unsafe_skip_checkpoint_verification: false,
         ip: None,
         bootstrappers: None,
         critical_log_dir: None,

--- a/node/src/bin/stake_and_join_with_outdated_ckpt.rs
+++ b/node/src/bin/stake_and_join_with_outdated_ckpt.rs
@@ -825,6 +825,7 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         checkpoint_or_default: false,
         weak_subjectivity_epoch: None,
         weak_subjectivity_header_digest: None,
+        unsafe_skip_checkpoint_verification: false,
         ip: None,
         bootstrappers: None,
         critical_log_dir: None,

--- a/node/src/bin/sync_from_genesis.rs
+++ b/node/src/bin/sync_from_genesis.rs
@@ -689,6 +689,7 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         checkpoint_or_default: false,
         weak_subjectivity_epoch: None,
         weak_subjectivity_header_digest: None,
+        unsafe_skip_checkpoint_verification: false,
         ip: None,
         bootstrappers: None,
         critical_log_dir: None,

--- a/node/src/bin/testnet.rs
+++ b/node/src/bin/testnet.rs
@@ -203,6 +203,7 @@ fn get_node_flags(node: usize) -> RunFlags {
         checkpoint_or_default: false,
         weak_subjectivity_epoch: None,
         weak_subjectivity_header_digest: None,
+        unsafe_skip_checkpoint_verification: false,
         ip: None,
         bootstrappers: None,
         critical_log_dir: None,

--- a/node/src/bin/verify_consensus_state_proof.rs
+++ b/node/src/bin/verify_consensus_state_proof.rs
@@ -665,6 +665,7 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         checkpoint_or_default: false,
         weak_subjectivity_epoch: None,
         weak_subjectivity_header_digest: None,
+        unsafe_skip_checkpoint_verification: false,
         ip: None,
         bootstrappers: None,
         critical_log_dir: None,

--- a/node/src/bin/withdraw_and_exit.rs
+++ b/node/src/bin/withdraw_and_exit.rs
@@ -411,6 +411,7 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         checkpoint_or_default: false,
         weak_subjectivity_epoch: None,
         weak_subjectivity_header_digest: None,
+        unsafe_skip_checkpoint_verification: false,
         ip: None,
         bootstrappers: None,
         critical_log_dir: None,

--- a/node/src/tests/checkpointing/mod.rs
+++ b/node/src/tests/checkpointing/mod.rs
@@ -1,3 +1,4 @@
 mod creation;
 mod joining;
+mod startup;
 mod verification;

--- a/node/src/tests/checkpointing/startup.rs
+++ b/node/src/tests/checkpointing/startup.rs
@@ -1,0 +1,131 @@
+use crate::args::{
+    CheckpointStartupDecision, check_last_block_binding, classify_checkpoint_startup,
+    read_checkpoint,
+};
+use alloy_primitives::Address;
+use ssz::Encode as _;
+use std::num::NonZeroU64;
+use summit_types::Digest;
+use summit_types::checkpoint::Checkpoint;
+use summit_types::consensus_state::ConsensusState;
+use summit_types::scheme::MultisigScheme;
+
+#[test]
+fn no_checkpoint_starts_from_genesis() {
+    assert_eq!(
+        classify_checkpoint_startup(false, false, false),
+        CheckpointStartupDecision::NoCheckpoint
+    );
+    // Headers/unsafe flags are irrelevant when no checkpoint is supplied.
+    assert_eq!(
+        classify_checkpoint_startup(false, true, true),
+        CheckpointStartupDecision::NoCheckpoint
+    );
+}
+
+#[test]
+fn checkpoint_with_headers_chain_is_verified() {
+    assert_eq!(
+        classify_checkpoint_startup(true, true, false),
+        CheckpointStartupDecision::Verify
+    );
+    // The unsafe flag must not downgrade the verified path when a chain is
+    // present — verification still runs.
+    assert_eq!(
+        classify_checkpoint_startup(true, true, true),
+        CheckpointStartupDecision::Verify
+    );
+}
+
+#[test]
+fn standalone_checkpoint_is_refused_by_default() {
+    // Regression for #214: a checkpoint with no finalized-headers chain must
+    // be refused rather than silently imported unverified.
+    assert_eq!(
+        classify_checkpoint_startup(true, false, false),
+        CheckpointStartupDecision::RefuseUnverified
+    );
+}
+
+#[test]
+fn standalone_checkpoint_allowed_only_with_unsafe_flag() {
+    assert_eq!(
+        classify_checkpoint_startup(true, false, true),
+        CheckpointStartupDecision::SkipUnsafe
+    );
+}
+
+#[test]
+fn last_block_binding_accepts_matching_or_absent() {
+    let committed: Digest = [7u8; 32].into();
+    // No last_block supplied: nothing to bind.
+    assert!(check_last_block_binding(None, committed).is_ok());
+    // last_block matches the verified terminal's finalized block.
+    assert!(check_last_block_binding(Some(committed), committed).is_ok());
+}
+
+#[test]
+fn last_block_binding_rejects_mismatch() {
+    // A directory pairing a verified checkpoint with an unrelated last_block
+    // must be rejected.
+    let committed: Digest = [7u8; 32].into();
+    let unrelated: Digest = [9u8; 32].into();
+    assert!(check_last_block_binding(Some(unrelated), committed).is_err());
+}
+
+// #214 single-file path: a standalone checkpoint file decodes to a
+// self-consistent state but can never carry a finalized-header chain, so
+// startup must refuse it by default and only import it under the explicit
+// unsafe flag. Exercises the real on-disk read_checkpoint path.
+#[test]
+fn single_file_import_has_no_chain_and_is_refused() {
+    let state = ConsensusState::new(
+        Default::default(),
+        32_000_000_000,
+        64_000_000_000,
+        NonZeroU64::new(10).unwrap(),
+        10_000,
+        Address::ZERO,
+        3,
+        16,
+        0,
+        1,
+    );
+    let checkpoint = Checkpoint::new(&state);
+
+    let path = std::env::temp_dir().join(format!(
+        "summit_single_file_checkpoint_{}.ssz",
+        std::process::id()
+    ));
+    std::fs::write(&path, checkpoint.as_ssz_bytes()).unwrap();
+    let path_str = path.to_str().unwrap().to_string();
+
+    let loaded = read_checkpoint::<MultisigScheme>(&path_str, false);
+    let _ = std::fs::remove_file(&path);
+
+    // A single-file import yields a checkpoint with no chain to verify against.
+    assert!(loaded.raw_checkpoint.is_some());
+    assert!(
+        loaded.finalized_headers_chain.is_none(),
+        "a single-file import cannot carry a finalized-header chain"
+    );
+
+    // So startup refuses it by default, and only imports it when the operator
+    // explicitly waives verification.
+    assert_eq!(
+        classify_checkpoint_startup(
+            loaded.raw_checkpoint.is_some(),
+            loaded.finalized_headers_chain.is_some(),
+            false,
+        ),
+        CheckpointStartupDecision::RefuseUnverified
+    );
+    assert_eq!(
+        classify_checkpoint_startup(
+            loaded.raw_checkpoint.is_some(),
+            loaded.finalized_headers_chain.is_some(),
+            true,
+        ),
+        CheckpointStartupDecision::SkipUnsafe
+    );
+}

--- a/node/src/tests/checkpointing/startup.rs
+++ b/node/src/tests/checkpointing/startup.rs
@@ -90,6 +90,7 @@ fn single_file_import_has_no_chain_and_is_refused() {
         16,
         0,
         1,
+        0,
     );
     let checkpoint = Checkpoint::new(&state);
 

--- a/syncer/src/actor.rs
+++ b/syncer/src/actor.rs
@@ -448,10 +448,23 @@ where
         // If we have a checkpoint, finalize the last block to complete the checkpoint
         if let Some(checkpoint) = checkpoint {
             let height = checkpoint.last_block.height();
+            let last_block_digest = checkpoint.last_block.digest();
             let finalization = checkpoint.finalized_header.map(|h| h.into_finalization());
+            // Defense in depth: last_block and finalized_header arrive as
+            // independent artifacts. The finalization certifies a specific block
+            // digest, so refuse to complete the checkpoint with a finalization
+            // that certifies a different block than the supplied last_block. The
+            // node startup path already binds these against the verified header
+            // chain; asserting it here keeps the boundary safe for any caller.
+            if let Some(finalization) = finalization.as_ref() {
+                assert!(
+                    finalization.proposal.payload == last_block_digest,
+                    "checkpoint finalization certifies a different block than last_block"
+                );
+            }
             self.store_finalization(
                 height,
-                checkpoint.last_block.digest(),
+                last_block_digest,
                 checkpoint.last_block,
                 finalization,
                 &mut application,

--- a/types/src/checkpoint.rs
+++ b/types/src/checkpoint.rs
@@ -533,12 +533,18 @@ pub fn verify_checkpoint_chain_with_weak_subjectivity(
         }
     }
 
-    // Step 4: Bind the decoded state position to the terminal finalized header.
-    // The verified terminal header (`last_header`) authenticates the exact
-    // checkpoint bytes (Step 2), but their decoded *position* is otherwise free.
+    // Step 4: Consistency check on the decoded state position.
+    //
+    // Step 2 already authenticates the exact checkpoint bytes against the signed
+    // terminal header, so the decoded fields are not attacker-malleable on this
+    // path. What Step 2 cannot guarantee is that those signed bytes are
+    // *internally consistent* with the header's own position fields — a buggy (or
+    // colluding) checkpoint creator could sign a state whose position does not
+    // match the header it is committed under. This step catches that.
+    //
     // The checkpoint is created at the penultimate block of an epoch and the
     // terminal header is the last block of that epoch (see finalizer/src/actor.rs),
-    // so for an honest checkpoint: `latest_height` is one below the terminal
+    // so for a well-formed checkpoint: `latest_height` is one below the terminal
     // header's height, `head_digest` is the terminal header's parent, and the
     // epoch matches. Reject any checkpoint whose decoded position does not.
     let terminal = last_header.header();

--- a/types/src/checkpoint.rs
+++ b/types/src/checkpoint.rs
@@ -198,6 +198,12 @@ pub enum CheckpointVerificationError {
     PayloadDigestMismatch {
         epoch: u64,
     },
+    /// The decoded checkpoint state's consensus position (height, epoch, or head
+    /// digest) is not bound to the verified terminal finalized header. The
+    /// checkpoint is created at the penultimate block of an epoch, so a valid
+    /// checkpoint's `latest_height` is exactly one below the terminal (last-block)
+    /// header, its `head_digest` is that header's parent, and its epoch matches.
+    CheckpointStatePositionMismatch(String),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -269,6 +275,12 @@ impl fmt::Display for CheckpointVerificationError {
                 write!(
                     f,
                     "epoch {epoch}: header fields do not match the finalization payload digest"
+                )
+            }
+            Self::CheckpointStatePositionMismatch(reason) => {
+                write!(
+                    f,
+                    "checkpoint state position not bound to terminal header: {reason}"
                 )
             }
         }
@@ -519,6 +531,45 @@ pub fn verify_checkpoint_chain_with_weak_subjectivity(
                 "validator {key:?} is active in checkpoint but not in accumulated signing set"
             )));
         }
+    }
+
+    // Step 4: Bind the decoded state position to the terminal finalized header.
+    // The verified terminal header (`last_header`) authenticates the exact
+    // checkpoint bytes (Step 2), but their decoded *position* is otherwise free.
+    // The checkpoint is created at the penultimate block of an epoch and the
+    // terminal header is the last block of that epoch (see finalizer/src/actor.rs),
+    // so for an honest checkpoint: `latest_height` is one below the terminal
+    // header's height, `head_digest` is the terminal header's parent, and the
+    // epoch matches. Reject any checkpoint whose decoded position does not.
+    let terminal = last_header.header();
+    let expected_terminal_height = checkpoint_state.get_latest_height().saturating_add(1);
+    if terminal.height() != expected_terminal_height {
+        return Err(
+            CheckpointVerificationError::CheckpointStatePositionMismatch(format!(
+                "decoded latest_height {} implies terminal height {}, but terminal header is at height {}",
+                checkpoint_state.get_latest_height(),
+                expected_terminal_height,
+                terminal.height()
+            )),
+        );
+    }
+    if checkpoint_state.get_epoch() != terminal.epoch() {
+        return Err(
+            CheckpointVerificationError::CheckpointStatePositionMismatch(format!(
+                "decoded epoch {} does not match terminal header epoch {}",
+                checkpoint_state.get_epoch(),
+                terminal.epoch()
+            )),
+        );
+    }
+    if checkpoint_state.get_head_digest() != terminal.parent() {
+        return Err(
+            CheckpointVerificationError::CheckpointStatePositionMismatch(format!(
+                "decoded head_digest 0x{} is not the terminal header's parent 0x{}",
+                hex(checkpoint_state.get_head_digest().as_ref()),
+                hex(terminal.parent().as_ref())
+            )),
+        );
     }
 
     Ok(())
@@ -1308,7 +1359,15 @@ mod tests {
     // checkpoint, a *different* ("attacker-controlled") checkpoint, and an honest
     // finalized header whose certificate genuinely signs the honest header digest
     // and whose `checkpoint_hash` commits to the honest checkpoint.
-    fn checkpoint_verification_fixture() -> (
+    // Builds a checkpoint whose decoded state sits at `state_latest_height` and a
+    // terminal finalized header at `terminal_header_height` that validly signs it.
+    // An honest checkpoint sets `terminal_header_height == state_latest_height + 1`
+    // (checkpoint at the penultimate block, terminal header at the last block);
+    // passing any other terminal height produces a position-inconsistent checkpoint.
+    fn checkpoint_verification_fixture(
+        state_latest_height: u64,
+        terminal_header_height: u64,
+    ) -> (
         Genesis,
         Checkpoint,
         Checkpoint,
@@ -1411,6 +1470,10 @@ mod tests {
             0,
         );
         state.set_validator_accounts(validator_accounts);
+        // The terminal header below is always built at height 0; passing a
+        // non-zero `state_latest_height` makes the decoded checkpoint position
+        // disagree with the terminal header it is bound to.
+        state.set_latest_height(state_latest_height);
         let checkpoint = Checkpoint::new(&state);
 
         // A distinct checkpoint the attacker would like the chain to authenticate.
@@ -1422,7 +1485,7 @@ mod tests {
         // Honest header commits to the honest checkpoint.
         let header = Header::new(
             [0u8; 32].into(),
-            0,
+            terminal_header_height,
             0,
             0,
             0,
@@ -1468,6 +1531,40 @@ mod tests {
         (genesis, checkpoint, tampered_checkpoint, finalized_header)
     }
 
+    // Binds the decoded checkpoint state position to the verified terminal header.
+    // The terminal header authenticates the checkpoint *bytes* (sha256), but
+    // without this check the decoded `ConsensusState` could advertise a consensus
+    // position (height/epoch/head_digest) that does not correspond to the verified
+    // header chain, letting a node start from the wrong position. The checkpoint is
+    // taken at the penultimate block, so an honest checkpoint's `latest_height` is
+    // exactly one below the terminal (last-block) header.
+    #[test]
+    fn test_checkpoint_verifier_binds_state_position_to_terminal_header() {
+        // Honest: decoded state at penultimate height 5, terminal header at 6.
+        let (genesis, checkpoint, _tampered, honest) = checkpoint_verification_fixture(5, 6);
+        super::verify_checkpoint_chain(&genesis, std::slice::from_ref(&honest), &checkpoint)
+            .expect("a position-consistent checkpoint must verify");
+
+        // Inconsistent: same decoded state (latest_height 5) but the terminal header
+        // claims height 9, so latest_height + 1 (6) != 9. The bytes are still validly
+        // committed by the terminal header and the validator set checks out, yet the
+        // position binding must reject it.
+        let (genesis, checkpoint, _tampered, mismatched) = checkpoint_verification_fixture(5, 9);
+        let result = super::verify_checkpoint_chain(
+            &genesis,
+            std::slice::from_ref(&mismatched),
+            &checkpoint,
+        );
+        assert!(
+            matches!(
+                result,
+                Err(super::CheckpointVerificationError::CheckpointStatePositionMismatch(_))
+            ),
+            "verifier must reject a checkpoint whose decoded state position is not bound \
+             to the terminal finalized header, got {result:?}"
+        );
+    }
+
     // Closes the typed-API trust-boundary gap: a finalized header carries header
     // fields (e.g. `checkpoint_hash`) and a certificate that signs a digest. The
     // fields must be bound to the signed digest, otherwise an attacker can pair a
@@ -1477,7 +1574,8 @@ mod tests {
     fn test_checkpoint_verifier_rejects_typed_header_field_mutation() {
         use crate::header::{FinalizedHeader, FinalizedHeaderError, Header};
 
-        let (genesis, checkpoint, tampered_checkpoint, honest) = checkpoint_verification_fixture();
+        let (genesis, checkpoint, tampered_checkpoint, honest) =
+            checkpoint_verification_fixture(0, 1);
 
         // Sanity: the honest finalized header verifies against the honest checkpoint.
         super::verify_checkpoint_chain(&genesis, std::slice::from_ref(&honest), &checkpoint)

--- a/types/src/checkpoint.rs
+++ b/types/src/checkpoint.rs
@@ -6,6 +6,7 @@ use crate::header::FinalizedHeader;
 use crate::scheme::MultisigScheme;
 use bytes::{Buf, BufMut, Bytes};
 use commonware_codec::{DecodeExt, Encode, EncodeSize, Error, Read, ReadExt, Write};
+use commonware_consensus::types::Epoch;
 use commonware_cryptography::bls12381::primitives::variant::{MinPk, Variant};
 use commonware_cryptography::{Hasher, Sha256, ed25519};
 use commonware_parallel::Sequential;
@@ -576,6 +577,39 @@ pub fn verify_checkpoint_chain_with_weak_subjectivity(
                 hex(terminal.parent().as_ref())
             )),
         );
+    }
+
+    // Step 5: The embedded DynamicEpocher must actually cover the decoded
+    // position. The epocher drives epoch-boundary classification (which heights
+    // are first/penultimate/last of an epoch), so a schedule that does not
+    // contain the decoded `epoch`/`latest_height` would make the node
+    // misclassify future boundaries. Like Step 4 this is an internal-consistency
+    // check the checkpoint-hash binding cannot provide: it authenticates the
+    // epocher bytes but not that they agree with the rest of the state.
+    let decoded_epoch = checkpoint_state.get_epoch();
+    let decoded_height = checkpoint_state.get_latest_height();
+    match checkpoint_state
+        .get_epocher()
+        .epoch_bounds(Epoch::new(decoded_epoch))
+    {
+        None => {
+            return Err(
+                CheckpointVerificationError::CheckpointStatePositionMismatch(format!(
+                    "embedded epocher does not cover decoded epoch {decoded_epoch}"
+                )),
+            );
+        }
+        Some((start, end)) => {
+            let (start, end) = (start.get(), end.get());
+            if decoded_height < start || decoded_height > end {
+                return Err(
+                    CheckpointVerificationError::CheckpointStatePositionMismatch(format!(
+                        "decoded latest_height {decoded_height} is outside the epocher bounds \
+                         [{start}, {end}] for decoded epoch {decoded_epoch}"
+                    )),
+                );
+            }
+        }
     }
 
     Ok(())
@@ -1361,24 +1395,16 @@ mod tests {
         );
     }
 
-    // Builds a single-epoch checkpoint chain: a genesis validator set, a matching
-    // checkpoint, a *different* ("attacker-controlled") checkpoint, and an honest
-    // finalized header whose certificate genuinely signs the honest header digest
-    // and whose `checkpoint_hash` commits to the honest checkpoint.
-    // Builds a checkpoint whose decoded state sits at `state_latest_height` and a
-    // terminal finalized header at `terminal_header_height` that validly signs it.
-    // An honest checkpoint sets `terminal_header_height == state_latest_height + 1`
-    // (checkpoint at the penultimate block, terminal header at the last block);
-    // passing any other terminal height produces a position-inconsistent checkpoint.
-    fn checkpoint_verification_fixture(
-        state_latest_height: u64,
-        terminal_header_height: u64,
-    ) -> (
-        Genesis,
-        Checkpoint,
-        Checkpoint,
-        FinalizedHeader<MultisigScheme>,
-    ) {
+    // Builds a single-epoch checkpoint plus a terminal finalized header whose
+    // certificate genuinely signs the header digest and whose `checkpoint_hash`
+    // commits to that checkpoint. `apply` mutates the decoded state before the
+    // checkpoint is sealed, so a test can introduce a position inconsistency that
+    // is nonetheless validly committed by the terminal header; `header_height`
+    // sets the terminal header's height.
+    fn build_checkpoint_and_header(
+        apply: impl FnOnce(&mut ConsensusState),
+        header_height: u64,
+    ) -> (Genesis, Checkpoint, FinalizedHeader<MultisigScheme>) {
         use crate::account::{ValidatorAccount, ValidatorStatus};
         use crate::genesis::GenesisValidator;
         use crate::header::Header;
@@ -1476,22 +1502,15 @@ mod tests {
             0,
         );
         state.set_validator_accounts(validator_accounts);
-        // The terminal header below is always built at height 0; passing a
-        // non-zero `state_latest_height` makes the decoded checkpoint position
-        // disagree with the terminal header it is bound to.
-        state.set_latest_height(state_latest_height);
+        // Let the test introduce any decoded-state inconsistency before the
+        // checkpoint is sealed; the header below still commits to the result.
+        apply(&mut state);
         let checkpoint = Checkpoint::new(&state);
 
-        // A distinct checkpoint the attacker would like the chain to authenticate.
-        let mut tampered_state = state.clone();
-        tampered_state.set_latest_height(1);
-        let tampered_checkpoint = Checkpoint::new(&tampered_state);
-        assert_ne!(checkpoint.digest, tampered_checkpoint.digest);
-
-        // Honest header commits to the honest checkpoint.
+        // Honest header commits to the (possibly mutated) checkpoint.
         let header = Header::new(
             [0u8; 32].into(),
-            terminal_header_height,
+            header_height,
             0,
             0,
             0,
@@ -1534,6 +1553,31 @@ mod tests {
         let finalized_header = FinalizedHeader::new(header, finalization, schemes.len())
             .expect("honest header is bound to its certificate");
 
+        (genesis, checkpoint, finalized_header)
+    }
+
+    // Convenience wrapper over `build_checkpoint_and_header`: a checkpoint whose
+    // decoded state sits at `state_latest_height`, a terminal header at
+    // `terminal_header_height`, and a *distinct* ("attacker-controlled")
+    // checkpoint at latest_height 1. An honest checkpoint sets
+    // `terminal_header_height == state_latest_height + 1` (checkpoint at the
+    // penultimate block, terminal header at the last block).
+    fn checkpoint_verification_fixture(
+        state_latest_height: u64,
+        terminal_header_height: u64,
+    ) -> (
+        Genesis,
+        Checkpoint,
+        Checkpoint,
+        FinalizedHeader<MultisigScheme>,
+    ) {
+        let (genesis, checkpoint, finalized_header) = build_checkpoint_and_header(
+            |s| s.set_latest_height(state_latest_height),
+            terminal_header_height,
+        );
+        let (_, tampered_checkpoint, _) =
+            build_checkpoint_and_header(|s| s.set_latest_height(1), terminal_header_height);
+        assert_ne!(checkpoint.digest, tampered_checkpoint.digest);
         (genesis, checkpoint, tampered_checkpoint, finalized_header)
     }
 
@@ -1568,6 +1612,92 @@ mod tests {
             ),
             "verifier must reject a checkpoint whose decoded state position is not bound \
              to the terminal finalized header, got {result:?}"
+        );
+    }
+
+    // #215: the verifier must reject a checkpoint whose decoded position or epoch
+    // schedule is inconsistent with the verified terminal header — across every
+    // position field, not just latest_height. Each case pairs a validly committed
+    // (sha256-bound), validly certified terminal header with a decoded state that
+    // disagrees on one field.
+    #[test]
+    fn test_checkpoint_verifier_rejects_inconsistent_decoded_position() {
+        use super::CheckpointVerificationError::CheckpointStatePositionMismatch;
+
+        // Decoded epoch disagrees with the terminal header epoch (0).
+        let (genesis, checkpoint, header) = build_checkpoint_and_header(
+            |s| {
+                s.set_latest_height(5);
+                s.set_epoch(1);
+            },
+            6,
+        );
+        let result =
+            super::verify_checkpoint_chain(&genesis, std::slice::from_ref(&header), &checkpoint);
+        assert!(
+            matches!(result, Err(CheckpointStatePositionMismatch(_))),
+            "decoded epoch mismatch must be rejected, got {result:?}"
+        );
+
+        // Decoded head_digest is not the terminal header's parent ([0u8; 32]).
+        let (genesis, checkpoint, header) = build_checkpoint_and_header(
+            |s| {
+                s.set_latest_height(5);
+                s.set_head_digest([9u8; 32].into());
+            },
+            6,
+        );
+        let result =
+            super::verify_checkpoint_chain(&genesis, std::slice::from_ref(&header), &checkpoint);
+        assert!(
+            matches!(result, Err(CheckpointStatePositionMismatch(_))),
+            "decoded head_digest mismatch must be rejected, got {result:?}"
+        );
+
+        // Decoded latest_height (50) lies outside the embedded epocher's bounds
+        // for the decoded epoch (epoch 0 of a 10-block schedule), so the epocher
+        // does not cover the position. The terminal header at 51 keeps the
+        // latest_height/terminal-height check satisfied so the epocher coverage
+        // check (Step 5) is what fires.
+        let (genesis, checkpoint, _t, header) = checkpoint_verification_fixture(50, 51);
+        let result =
+            super::verify_checkpoint_chain(&genesis, std::slice::from_ref(&header), &checkpoint);
+        assert!(
+            matches!(result, Err(CheckpointStatePositionMismatch(_))),
+            "decoded position outside the epocher bounds must be rejected, got {result:?}"
+        );
+    }
+
+    // #215: fields with no independent representation in the terminal header
+    // (forkchoice, epoch_genesis_hash, the epocher segments) cannot be bound to
+    // header fields — they are protected solely by the checkpoint-hash binding.
+    // Mutating forkchoice changes the checkpoint bytes, so the honest terminal
+    // header no longer commits them and verification fails at the hash check.
+    #[test]
+    fn test_checkpoint_verifier_rejects_forkchoice_mutation_via_hash_binding() {
+        // Honest checkpoint + terminal header at the matching penultimate position.
+        let (genesis, _honest_ckpt, header) =
+            build_checkpoint_and_header(|s| s.set_latest_height(5), 6);
+        // A checkpoint at the same position but with a different forkchoice — same
+        // height/epoch/head_digest, different bytes, hence a different digest.
+        let (_g, forkchoice_mutated, _h) = build_checkpoint_and_header(
+            |s| {
+                s.set_latest_height(5);
+                s.set_forkchoice_head(alloy_primitives::B256::repeat_byte(7));
+            },
+            6,
+        );
+        let result = super::verify_checkpoint_chain(
+            &genesis,
+            std::slice::from_ref(&header),
+            &forkchoice_mutated,
+        );
+        assert!(
+            matches!(
+                result,
+                Err(super::CheckpointVerificationError::CheckpointHashMismatch)
+            ),
+            "a forkchoice-mutated checkpoint must fail the hash binding, got {result:?}"
         );
     }
 


### PR DESCRIPTION
Builds on https://github.com/SeismicSystems/summit/pull/402.

Addresses https://github.com/SeismicSystems/summit/issues/214.

Changes:
- **Require verification by default.** `run_node_inner` now panics when a checkpoint is supplied without a finalized-headers chain to verify against, instead of warning and continuing.
- **Add `--unsafe-skip-checkpoint-verification`** (`RunFlags`, requires `--checkpoint-path`) as the explicit opt-out for importing a checkpoint without verification artifacts; logs a loud UNSAFE warning when used.
- **Bind `last_block` to the verified chain.** On the verified path, require `last_block.digest() == terminal.finalization().proposal.payload` (the verified chain terminal), panicking on mismatch.
- **Use the signature-verified terminal as the completion finalization.** Replace the separately-loaded, unverified top-level `finalized_header` with the chain terminal `FinalizedHeader` (whose certificate was verified by `verify_checkpoint_chain`) before handing it to the syncer.