### PR TITLE
fix: gate consensus channels by committee membership before the mux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6097,6 +6097,7 @@ dependencies = [
  "commonware-utils",
  "futures",
  "governor",
+ "metrics",
  "rand 0.8.5",
  "rand_core 0.6.4",
  "summit-syncer",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -154,6 +154,10 @@ prom = [
   "procfs",
   "libc",
   "summit-types/prom",
+  "summit-finalizer/prom",
+  "summit-syncer/prom",
+  "summit-orchestrator/prom",
+  "summit-application/prom",
 ]
 tokio-console = ["console-subscriber"]
 jemalloc = ["dep:tikv-jemalloc-ctl"]

--- a/orchestrator/Cargo.toml
+++ b/orchestrator/Cargo.toml
@@ -27,4 +27,10 @@ rand_core.workspace = true
 tokio-util.workspace = true
 tracing.workspace = true
 
+# For metrics - activate with `prom` feature
+metrics = { version = "0.24.0", optional = true }
+
+[features]
+prom = ["metrics"]
+
 

--- a/orchestrator/src/actor.rs
+++ b/orchestrator/src/actor.rs
@@ -22,8 +22,14 @@ use commonware_utils::{NZU16, NZUsize, vec::NonEmptyVec};
 use futures::{StreamExt, channel::mpsc};
 use governor::clock::Clock as GClock;
 use rand_core::CryptoRngCore;
-use std::{collections::BTreeMap, time::Duration};
+use std::{
+    collections::BTreeMap,
+    sync::{Arc, RwLock},
+    time::Duration,
+};
 use summit_types::scheme::{EpochSchemeProvider, MultisigScheme};
+
+use crate::committee_filter::{ActiveCommittees, CommitteeFilteredReceiver};
 use tracing::info;
 
 /// Configuration for the orchestrator.
@@ -163,6 +169,22 @@ where
             impl Receiver<PublicKey = PublicKey>,
         ),
     ) {
+        // Consensus-channel ingress membership filter: drop messages from senders
+        // not in the target epoch's committee before they can occupy a bounded
+        // mux subchannel and starve honest validator traffic. The committee map
+        // is maintained from the Enter/Exit transitions below. Messages for
+        // not-yet-entered epochs pass through, preserving the pending-channel
+        // backup / hint_finalized catch-up path. See `committee_filter`.
+        // Drops are counted via the `consensus_ingress_rejected{channel}` metric
+        // (prom feature) and logged at trace level inside the filter.
+        let committees: ActiveCommittees = Arc::new(RwLock::new(BTreeMap::new()));
+        let pending_receiver =
+            CommitteeFilteredReceiver::new(pending_receiver, committees.clone(), "pending");
+        let recovered_receiver =
+            CommitteeFilteredReceiver::new(recovered_receiver, committees.clone(), "recovered");
+        let resolver_receiver =
+            CommitteeFilteredReceiver::new(resolver_receiver, committees.clone(), "resolver");
+
         // Start muxers for each physical channel used by consensus
         let (mux, mut pending_mux, mut pending_backup) = Muxer::builder(
             self.context.with_label("pending_mux"),
@@ -243,6 +265,20 @@ where
                         let num_validators = transition.validator_keys.len();
                         assert!(self.scheme_provider.register(transition.epoch, scheme.clone()));
 
+                        // Record this epoch's committee so the consensus-ingress
+                        // filter admits only these node keys onto the epoch's
+                        // subchannels. Inserted before the subchannel is
+                        // registered in `enter_epoch`, so there is no window in
+                        // which a non-committee sender is admitted.
+                        committees.write().expect("committees lock poisoned").insert(
+                            transition.epoch,
+                            transition
+                                .validator_keys
+                                .iter()
+                                .map(|(node_key, _)| node_key.clone())
+                                .collect(),
+                        );
+
                         // Enter the new epoch.
                         let engine = self
                             .enter_epoch(
@@ -271,6 +307,12 @@ where
 
                         // Unregister the signing scheme for the epoch.
                         assert!(self.scheme_provider.unregister(&epoch));
+
+                        // Drop the epoch's committee from the ingress filter.
+                        committees
+                            .write()
+                            .expect("committees lock poisoned")
+                            .remove(&epoch);
 
                         info!(epoch = epoch.get(), "exited epoch");
                     }

--- a/orchestrator/src/committee_filter.rs
+++ b/orchestrator/src/committee_filter.rs
@@ -1,0 +1,159 @@
+//! Membership filter for consensus-channel ingress.
+//!
+//! Summit tracks non-voting identities (joining validators and observer-derived
+//! keys) as secondary P2P peers so they can connect and follow the chain. The
+//! authenticated network does not gate per-channel sends by peer role, and the
+//! epoch multiplexer drops on a full subchannel via `try_send` BEFORE Simplex
+//! validates sender membership. A non-voting peer can therefore fill a bounded
+//! validator-only consensus subchannel and starve honest validator messages
+//! (an epoch-liveness DoS) without holding any BLS voting power.
+//!
+//! [`CommitteeFilteredReceiver`] wraps a consensus-channel [`Receiver`] and drops
+//! a message whose sender is not in the active committee of the epoch
+//! (subchannel) it targets, BEFORE it reaches the bounded subchannel. Messages
+//! for epochs the orchestrator has NOT entered are passed through untouched: on
+//! the `pending` channel those reach the mux backup and drive `hint_finalized`
+//! catch-up from peers ahead of us, so they must not be filtered against our
+//! (possibly stale) committee view.
+
+use std::collections::{BTreeMap, HashSet};
+use std::fmt;
+use std::sync::{Arc, RwLock};
+
+use commonware_consensus::types::Epoch;
+use commonware_p2p::{Channel, Message, Receiver, utils::mux};
+use summit_types::PublicKey;
+use tracing::trace;
+
+/// Active committees keyed by entered epoch: the node keys allowed to send on
+/// that epoch's consensus subchannels. Written by the orchestrator loop on epoch
+/// `Enter`/`Exit`, read by the ingress filters running inside the mux tasks.
+pub type ActiveCommittees = Arc<RwLock<BTreeMap<Epoch, HashSet<PublicKey>>>>;
+
+/// Whether a message from `from`, targeting `subchannel` (an epoch), is admitted
+/// onto the consensus channels.
+///
+/// - Entered epoch: only that epoch's committee may send (protects the bounded
+///   subchannel capacity from non-voting peers).
+/// - Not-yet-entered (ahead) epoch: admit, so the mux backup / `hint_finalized`
+///   catch-up path keeps working regardless of our current committee view.
+fn admit(
+    committees: &BTreeMap<Epoch, HashSet<PublicKey>>,
+    subchannel: Channel,
+    from: &PublicKey,
+) -> bool {
+    match committees.get(&Epoch::new(subchannel)) {
+        Some(committee) => committee.contains(from),
+        None => true,
+    }
+}
+
+pub struct CommitteeFilteredReceiver<R> {
+    inner: R,
+    committees: ActiveCommittees,
+    channel: &'static str,
+}
+
+impl<R> CommitteeFilteredReceiver<R> {
+    pub fn new(inner: R, committees: ActiveCommittees, channel: &'static str) -> Self {
+        Self {
+            inner,
+            committees,
+            channel,
+        }
+    }
+}
+
+impl<R: fmt::Debug> fmt::Debug for CommitteeFilteredReceiver<R> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CommitteeFilteredReceiver")
+            .field("channel", &self.channel)
+            .field("inner", &self.inner)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<R> Receiver for CommitteeFilteredReceiver<R>
+where
+    R: Receiver<PublicKey = PublicKey>,
+{
+    type Error = R::Error;
+    type PublicKey = PublicKey;
+
+    async fn recv(&mut self) -> Result<Message<Self::PublicKey>, Self::Error> {
+        loop {
+            let (from, bytes) = self.inner.recv().await?;
+
+            // Peek the target subchannel (epoch). `parse` consumes the varint
+            // prefix, so peek a cheap clone and forward the original bytes for
+            // the mux to re-parse.
+            let admitted = match mux::parse(bytes.clone()) {
+                Ok((subchannel, _)) => {
+                    let committees = self.committees.read().expect("committees lock poisoned");
+                    admit(&committees, subchannel, &from)
+                }
+                // Malformed (no subchannel prefix): let the mux reject it.
+                Err(_) => true,
+            };
+
+            if admitted {
+                return Ok((from, bytes));
+            }
+            #[cfg(feature = "prom")]
+            metrics::counter!("consensus_ingress_rejected", "channel" => self.channel).increment(1);
+            trace!(
+                channel = self.channel,
+                ?from,
+                "dropped consensus ingress from non-committee sender"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use commonware_cryptography::{Signer, ed25519};
+
+    fn key(seed: u64) -> PublicKey {
+        ed25519::PrivateKey::from_seed(seed).public_key()
+    }
+
+    #[test]
+    fn entered_epoch_admits_only_its_committee() {
+        let member = key(0);
+        let outsider = key(1);
+        let mut committees = BTreeMap::new();
+        committees.insert(Epoch::new(7), HashSet::from([member.clone()]));
+
+        // A committee member sending on its own epoch is admitted.
+        assert!(admit(&committees, 7, &member));
+        // A non-member (joining/observer/bootstrapper) on an entered epoch is
+        // dropped before it can consume that epoch's bounded subchannel.
+        assert!(!admit(&committees, 7, &outsider));
+    }
+
+    #[test]
+    fn member_of_other_entered_epoch_is_not_admitted() {
+        // Per-epoch, not union: a validator of epoch 7 cannot send on epoch 8's
+        // subchannel (Simplex would reject it anyway; we save the capacity).
+        let member = key(0);
+        let mut committees = BTreeMap::new();
+        committees.insert(Epoch::new(7), HashSet::from([member.clone()]));
+        committees.insert(Epoch::new(8), HashSet::from([key(2)]));
+        assert!(!admit(&committees, 8, &member));
+    }
+
+    #[test]
+    fn unentered_epoch_passes_through_for_catchup() {
+        // Messages for an epoch we have not entered (e.g. a peer ahead of us)
+        // are passed through so the mux backup / hint_finalized catch-up works,
+        // even from a sender not in any committee we currently track.
+        let committees = BTreeMap::new();
+        assert!(admit(&committees, 99, &key(3)));
+
+        let mut committees = BTreeMap::new();
+        committees.insert(Epoch::new(7), HashSet::from([key(0)]));
+        assert!(admit(&committees, 99, &key(3)));
+    }
+}

--- a/orchestrator/src/lib.rs
+++ b/orchestrator/src/lib.rs
@@ -3,5 +3,7 @@
 mod actor;
 pub use actor::{Actor, Config};
 
+mod committee_filter;
+
 mod ingress;
 pub use ingress::{Mailbox, Message};


### PR DESCRIPTION
Addresses https://github.com/SeismicSystems/summit/issues/232.

Summit tracks non-voting identities (joining validators and observer-derived keys) as secondary P2P peers so they can connect and sync. The authenticated network does not gate per-channel sends by peer role, and the epoch multiplexer drops on a full subchannel (try_send) before Simplex validates sender membership. A non-voting peer can therefore fill a bounded validator-only consensus subchannel and starve honest validator messages. A single staked deposit yields the joining key plus its observer child keys, amplifying the effect.

Changes:
- `orchestrator/src/committee_filter.rs`: `CommitteeFilteredReceiver` wraps a consensus-channel receiver and drops messages whose sender is not in the target epoch's committee, before they reach the bounded mux subchannel. It is epoch-aware via the public `mux::parse`: messages for entered epochs are gated by that epoch's committee; messages for not-yet-entered (ahead) epochs pass through, preserving the pending-channel backup / hint_finalized catch-up path.
- `orchestrator/src/actor.rs`: maintains a per-epoch committee map updated on `Enter` (before the subchannel is registered) and `Exit`, and wraps the pending, recovered, and resolver receivers with the filter. The broadcaster and backfiller channels stay open so joining validators and observers can still sync.
- `node/Cargo.toml`: chain summit-{finalizer,syncer,orchestrator,application}/prom into the node prom feature (previously only summit-types/prom), so all crate metrics actually emit in prom builds.