### PR TITLE
fix: assemble genesis with the canonical Genesis type

### DIFF
--- a/node/src/bin/genesis.rs
+++ b/node/src/bin/genesis.rs
@@ -1,35 +1,9 @@
 use alloy_primitives::FixedBytes;
 use clap::Parser;
-use serde::{Deserialize, Serialize};
 use std::fs;
-use summit_types::GenesisValidator;
+use summit_types::{Genesis, GenesisValidator};
 
 const DEFAULT_GENESIS_FILE: &str = "./example_genesis.toml";
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct GenesisConfig {
-    eth_genesis_hash: String,
-    leader_timeout_ms: u64,
-    notarization_timeout_ms: u64,
-    nullify_timeout_ms: u64,
-    activity_timeout_views: u64,
-    skip_timeout_views: u64,
-    max_message_size_bytes: u64,
-    namespace: String,
-    blocks_per_epoch: u64,
-    allowed_timestamp_future_ms: u64,
-    #[serde(default)]
-    treasury_address: Option<String>,
-    pub validators: Vec<GenesisValidator>,
-}
-
-impl GenesisConfig {
-    pub fn load(path: &str) -> Result<GenesisConfig, Box<dyn std::error::Error>> {
-        let genesis_content = std::fs::read_to_string(path)?;
-        let genesis_config: GenesisConfig = toml::from_str(&genesis_content)?;
-        Ok(genesis_config)
-    }
-}
 
 #[derive(Parser, Debug)]
 struct Args {
@@ -68,17 +42,22 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let validators = parse_validators(&args.validators_path)?;
     let node_count = validators.len() as u32;
 
-    let mut genesis_config = GenesisConfig::load(&args.genesis_in)?;
+    // Load the template into summit's canonical Genesis type rather than a
+    // local copy — a private struct here silently drops fields the runtime
+    // requires (e.g. validator_minimum_stake), producing a genesis the node
+    // can't load. Fill in the validators, then write it back out.
+    let mut genesis: Genesis = toml::from_str(&fs::read_to_string(&args.genesis_in)?)?;
     if let Some(genesis_hash) = args.genesis_hash {
         let hash_str = genesis_hash.to_string();
         println!("Overriding eth_genesis_hash to {hash_str}");
-        genesis_config.eth_genesis_hash = hash_str;
+        genesis.eth_genesis_hash = hash_str;
     }
-    genesis_config.validators = validators;
+    genesis.validators = validators;
 
-    // Write the updated genesis config
-    let updated_genesis = toml::to_string_pretty(&genesis_config)?;
-    fs::write(format!("{}/genesis.toml", args.out_dir), updated_genesis)?;
+    fs::write(
+        format!("{}/genesis.toml", args.out_dir),
+        toml::to_string_pretty(&genesis)?,
+    )?;
     println!("Updated genesis config at {}", args.out_dir);
     println!("\nSetup complete for {} nodes", node_count);
 


### PR DESCRIPTION
The `genesis` binary defined its own `GenesisConfig` — a partial copy of `summit_types::Genesis` that predated the staking fields. With no `deny_unknown_fields`, deserializing the template into it silently dropped `validator_minimum_stake` / `validator_maximum_stake`, so the emitted genesis.toml was missing fields the node's runtime loader requires and `summit run` panicked at startup ("missing field `validator_minimum_stake`").

Load and serialize the template as `summit_types::Genesis` directly and drop the local struct, so there is a single genesis schema the binary can't drift from.

Context: this surfaced in the Seismic deploy flow, whose operator CLI shells out to this `genesis` binary to build a network's genesis. A few rough edges there: it has to be built and installed via cargo; it's named just `genesis`, which collides easily on PATH and doesn't read as part of summit; and (as above) it's a separately-built, independently-versioned copy of the node's genesis logic, with nothing guaranteeing it matches the summit running on the node.

## Proposed alternative designs

  - Move assembly into the node: have `sendGenesis` take the template + validator set rather than a pre-built genesis.toml, and let each node build its own genesis with its own `Genesis` type and sort — e.g. a shared `assemble_genesis(template, validators)` backing both this binary and the RPC handler. The node could also fill `eth_genesis_hash` from its own reth, which would remove the external binary and the version-skew question altogether.
  - Or, if a standalone tool is preferred, fold this into the `summit` binary as a `summit genesis` subcommand (alongside `run`/`keys`), so it shares the genesis types and isn't a stray `genesis` on PATH.