### PR TITLE
feat: add --rpc-ip to set the public RPC listen address

### DIFF
--- a/node/src/args.rs
+++ b/node/src/args.rs
@@ -108,6 +108,10 @@ pub struct RunFlags {
     #[arg(long, default_value_t = 9090)]
     pub prom_port: u16,
 
+    /// Public RPC server bind address. 0.0.0.0 by default; set 127.0.0.1 when
+    /// it's only reached via a local reverse proxy like nginx.
+    #[arg(long, default_value_t = String::from("0.0.0.0"))]
+    pub rpc_ip: String,
     /// Port RPC server runs on
     #[arg(long, default_value_t = 3030)]
     pub rpc_port: u16,
@@ -1061,6 +1065,10 @@ where
 
     // Start RPC server
     let key_store_path = flags.key_store_path;
+    let rpc_listen_addr = flags
+        .rpc_ip
+        .parse::<IpAddr>()
+        .expect("invalid --rpc-ip address");
     let rpc_port = flags.rpc_port;
     let admin_rpc_port = flags.admin_rpc_port;
     let rpc_body_limits = RpcBodyLimits {
@@ -1076,6 +1084,7 @@ where
             key_store_path,
             genesis_hash,
             namespace,
+            rpc_listen_addr,
             rpc_port,
             admin_rpc_port,
             rpc_body_limits,

--- a/node/src/bin/observer.rs
+++ b/node/src/bin/observer.rs
@@ -535,6 +535,7 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         port: (26600 + (node * 10)) as u16,
         prom_port: (28600 + (node * 10)) as u16,
         prom_ip: "0.0.0.0".into(),
+        rpc_ip: "0.0.0.0".into(),
         rpc_port: (3030 + (node * 10)) as u16,
         admin_rpc_port: (3031 + (node * 10)) as u16,
         rpc_max_request_body_size: summit_rpc::DEFAULT_RPC_BODY_LIMIT_BYTES,

--- a/node/src/bin/protocol_params.rs
+++ b/node/src/bin/protocol_params.rs
@@ -409,6 +409,7 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         port: (26600 + (node * 10)) as u16,
         prom_port: (28600 + (node * 10)) as u16,
         prom_ip: "0.0.0.0".into(),
+        rpc_ip: "0.0.0.0".into(),
         rpc_port: (3030 + (node * 10)) as u16,
         admin_rpc_port: (3031 + (node * 10)) as u16,
         rpc_max_request_body_size: summit_rpc::DEFAULT_RPC_BODY_LIMIT_BYTES,

--- a/node/src/bin/stake_and_checkpoint.rs
+++ b/node/src/bin/stake_and_checkpoint.rs
@@ -722,6 +722,7 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         port: (26600 + (node * 10)) as u16,
         prom_port: (28600 + (node * 10)) as u16,
         prom_ip: "0.0.0.0".into(),
+        rpc_ip: "0.0.0.0".into(),
         rpc_port: (3030 + (node * 10)) as u16,
         admin_rpc_port: (3031 + (node * 10)) as u16,
         rpc_max_request_body_size: summit_rpc::DEFAULT_RPC_BODY_LIMIT_BYTES,

--- a/node/src/bin/stake_and_join_with_outdated_ckpt.rs
+++ b/node/src/bin/stake_and_join_with_outdated_ckpt.rs
@@ -853,6 +853,7 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         port: (26600 + (node * 10)) as u16,
         prom_port: (28600 + (node * 10)) as u16,
         prom_ip: "0.0.0.0".into(),
+        rpc_ip: "0.0.0.0".into(),
         rpc_port: (3030 + (node * 10)) as u16,
         admin_rpc_port: (3031 + (node * 10)) as u16,
         rpc_max_request_body_size: summit_rpc::DEFAULT_RPC_BODY_LIMIT_BYTES,

--- a/node/src/bin/sync_from_genesis.rs
+++ b/node/src/bin/sync_from_genesis.rs
@@ -699,6 +699,7 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         port: (26600 + (node * 10)) as u16,
         prom_port: (28600 + (node * 10)) as u16,
         prom_ip: "0.0.0.0".into(),
+        rpc_ip: "0.0.0.0".into(),
         rpc_port: (3030 + (node * 10)) as u16,
         admin_rpc_port: (3031 + (node * 10)) as u16,
         rpc_max_request_body_size: summit_rpc::DEFAULT_RPC_BODY_LIMIT_BYTES,

--- a/node/src/bin/testnet.rs
+++ b/node/src/bin/testnet.rs
@@ -201,6 +201,7 @@ fn get_node_flags(node: usize) -> RunFlags {
         port: (26600 + (node * 10)) as u16,
         prom_port: (28600 + (node * 10)) as u16,
         prom_ip: "0.0.0.0".into(),
+        rpc_ip: "0.0.0.0".into(),
         rpc_port: (3030 + (node * 10)) as u16,
         admin_rpc_port: (3031 + (node * 10)) as u16,
         rpc_max_request_body_size: summit_rpc::DEFAULT_RPC_BODY_LIMIT_BYTES,

--- a/node/src/bin/verify_consensus_state_proof.rs
+++ b/node/src/bin/verify_consensus_state_proof.rs
@@ -663,6 +663,7 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         port: (26600 + (node * 10)) as u16,
         prom_port: (28600 + (node * 10)) as u16,
         prom_ip: "0.0.0.0".into(),
+        rpc_ip: "0.0.0.0".into(),
         rpc_port: (3030 + (node * 10)) as u16,
         admin_rpc_port: (3031 + (node * 10)) as u16,
         rpc_max_request_body_size: summit_rpc::DEFAULT_RPC_BODY_LIMIT_BYTES,

--- a/node/src/bin/withdraw_and_exit.rs
+++ b/node/src/bin/withdraw_and_exit.rs
@@ -412,6 +412,7 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         port: (26600 + (node * 10)) as u16,
         prom_port: (28600 + (node * 10)) as u16,
         prom_ip: "0.0.0.0".into(),
+        rpc_ip: "0.0.0.0".into(),
         rpc_port: (3030 + (node * 10)) as u16,
         admin_rpc_port: (3031 + (node * 10)) as u16,
         rpc_max_request_body_size: summit_rpc::DEFAULT_RPC_BODY_LIMIT_BYTES,

--- a/rpc/src/builder.rs
+++ b/rpc/src/builder.rs
@@ -1,6 +1,6 @@
 use http::{HeaderValue, Method};
 use jsonrpsee::server::{BatchRequestConfig, ServerBuilder, ServerConfigBuilder, ServerHandle};
-use std::net::SocketAddr;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::time::Duration;
 use tower::ServiceBuilder;
 use tower_http::cors::{AllowOrigin, Any, CorsLayer};
@@ -41,31 +41,29 @@ impl RpcServer {
 }
 
 impl RpcServerBuilder {
+    /// Listen on all interfaces (`0.0.0.0`).
     pub fn new(port: u16) -> Self {
+        Self::new_with_listen_addr(IpAddr::V4(Ipv4Addr::UNSPECIFIED), port)
+    }
+
+    /// Listen on 127.0.0.1 only. Used for the admin RPC listener so the
+    /// validator-key signing methods (`SummitAdminApi`) can't be reached
+    /// from off-host even if the firewall is misconfigured.
+    pub fn new_localhost(port: u16) -> Self {
+        Self::new_with_listen_addr(IpAddr::V4(Ipv4Addr::LOCALHOST), port)
+    }
+
+    /// Listen on an explicit address (e.g. from `--rpc-ip`); `new` /
+    /// `new_localhost` are the `0.0.0.0` / `127.0.0.1` shorthands. Holds the
+    /// canonical server config so the hardening below lives in exactly one place.
+    pub fn new_with_listen_addr(listen_addr: IpAddr, port: u16) -> Self {
         Self {
-            addr: SocketAddr::from(([0, 0, 0, 0], port)),
+            addr: SocketAddr::new(listen_addr, port),
             // http-only: Summit's RPC is request/response (no subscriptions), so
             // websockets are not needed. jsonrpsee enables websockets with pings
             // disabled by default, and an idle upgraded connection holds its
             // max_connections permit until the client closes; disabling websocket
             // upgrades removes that idle-permit-exhaustion vector entirely.
-            // The batch config caps calls per JSON-RPC batch (see `with_batch_limit`).
-            config: ServerConfigBuilder::new()
-                .http_only()
-                .set_batch_request_config(default_batch_config()),
-            cors_domains: None,
-            request_timeout: Duration::from_secs(crate::DEFAULT_RPC_REQUEST_TIMEOUT_SECS),
-        }
-    }
-
-    /// Bind to 127.0.0.1 only. Used for the admin RPC listener so the
-    /// validator-key signing methods (`SummitAdminApi`) can't be reached
-    /// from off-host even if the firewall is misconfigured.
-    pub fn new_localhost(port: u16) -> Self {
-        Self {
-            addr: SocketAddr::from(([127, 0, 0, 1], port)),
-            // http-only: see `new`. websockets are unused, so disabling upgrades
-            // closes the idle-connection permit-exhaustion vector.
             // The batch config caps calls per JSON-RPC batch (see `with_batch_limit`).
             config: ServerConfigBuilder::new()
                 .http_only()

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -20,7 +20,7 @@ pub use api::{SummitPermissionedApiClient, SummitPermissionedApiServer};
 
 use commonware_runtime::signal::Signal;
 use jsonrpsee::server::ServerHandle;
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 #[cfg(feature = "permissioned")]
 use std::sync::Arc;
 #[cfg(feature = "permissioned")]
@@ -68,6 +68,7 @@ pub async fn start_rpc_server(
     key_store_path: String,
     genesis_hash: [u8; 32],
     namespace: Vec<u8>,
+    rpc_listen_addr: IpAddr,
     port: u16,
     admin_port: u16,
     body_limits: RpcBodyLimits,
@@ -90,7 +91,7 @@ pub async fn start_rpc_server(
     #[cfg(feature = "permissioned")]
     public_methods.merge(SummitPermissionedApiServer::into_rpc(rpc_impl.clone()))?;
 
-    let public_server = builder::RpcServerBuilder::new(port)
+    let public_server = builder::RpcServerBuilder::new_with_listen_addr(rpc_listen_addr, port)
         .with_max_connections(1000)
         .with_max_request_body_size(body_limits.max_request_body_size)
         .with_max_response_body_size(body_limits.max_response_body_size)
@@ -102,7 +103,7 @@ pub async fn start_rpc_server(
 
     let public_handle = public_server.start(public_methods);
 
-    tracing::info!("RPC Server listening on http://0.0.0.0:{port}");
+    tracing::info!("RPC Server listening on http://{rpc_listen_addr}:{port}");
 
     // Admin RPC: hosts `SummitAdminApi` (validator-key signing methods).
     let admin_methods = SummitAdminApiServer::into_rpc(rpc_impl);


### PR DESCRIPTION
The public RPC listener was hardcoded to 0.0.0.0. Deployments that front it with nginx want it bound to 127.0.0.1 so it isn't reachable off-box; the default stays 0.0.0.0 for direct/local setups and the testnet. Add --rpc-ip (mirrors --prom-ip; default 0.0.0.0), parse it to an IpAddr, and thread it into the public server. The admin RPC stays localhost-only.

Consolidate RpcServerBuilder's constructors while here: new()/new_localhost() delegate to a single new_with_listen_addr(), keeping the server hardening (http-only, batch cap, request timeout) in one place rather than duplicated.

The in-code RunFlags builders (testnet + e2e bins) set rpc_ip to 0.0.0.0, preserving their current behavior.