### PR TITLE
feat(rpc): make pause admin address configurable via CLI flag

### DIFF
--- a/node/src/args.rs
+++ b/node/src/args.rs
@@ -109,6 +109,11 @@ pub struct RunFlags {
     #[arg(long, default_value_t = 3030)]
     pub rpc_port: u16,
 
+    /// Address authorized to sign pause/unpause RPC requests
+    #[cfg(feature = "permissioned")]
+    #[arg(long, default_value_t = String::from(summit_rpc::DEFAULT_PAUSE_ADMIN_ADDRESS_HEX))]
+    pub pause_admin_address: String,
+
     /// Number of tokio worker threads (defaults to number of logical CPUs)
     #[arg(long)]
     pub worker_threads: Option<usize>,
@@ -674,6 +679,11 @@ where
     let engine: Engine<_, _, _, _> = Engine::new(context.with_label("engine"), config).await;
     #[cfg(feature = "permissioned")]
     let paused = engine.paused.clone();
+    #[cfg(feature = "permissioned")]
+    let pause_admin = match summit_rpc::parse_admin_address(&flags.pause_admin_address) {
+        Ok(address) => address,
+        Err(_) => panic!("invalid --pause-admin-address"),
+    };
 
     let finalizer_mailbox = engine.finalizer_mailbox.clone();
     let engine = engine.start(pending, recovered, resolver, broadcaster, backfiller);
@@ -692,6 +702,8 @@ where
             stop_signal,
             #[cfg(feature = "permissioned")]
             paused,
+            #[cfg(feature = "permissioned")]
+            pause_admin,
         )
         .await
         {

--- a/node/src/bin/observer.rs
+++ b/node/src/bin/observer.rs
@@ -501,6 +501,8 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         prom_port: (28600 + (node * 10)) as u16,
         prom_ip: "0.0.0.0".into(),
         rpc_port: (3030 + (node * 10)) as u16,
+        #[cfg(feature = "permissioned")]
+        pause_admin_address: summit_rpc::DEFAULT_PAUSE_ADMIN_ADDRESS_HEX.into(),
         worker_threads: Some(2),
         log_level: "debug".into(),
         db_prefix: format!("{node}"),

--- a/node/src/bin/protocol_params.rs
+++ b/node/src/bin/protocol_params.rs
@@ -400,6 +400,8 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         prom_port: (28600 + (node * 10)) as u16,
         prom_ip: "0.0.0.0".into(),
         rpc_port: (3030 + (node * 10)) as u16,
+        #[cfg(feature = "permissioned")]
+        pause_admin_address: summit_rpc::DEFAULT_PAUSE_ADMIN_ADDRESS_HEX.into(),
         worker_threads: Some(2),
         log_level: "debug".into(),
         db_prefix: format!("{node}"),

--- a/node/src/bin/stake_and_checkpoint.rs
+++ b/node/src/bin/stake_and_checkpoint.rs
@@ -687,6 +687,8 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         prom_port: (28600 + (node * 10)) as u16,
         prom_ip: "0.0.0.0".into(),
         rpc_port: (3030 + (node * 10)) as u16,
+        #[cfg(feature = "permissioned")]
+        pause_admin_address: summit_rpc::DEFAULT_PAUSE_ADMIN_ADDRESS_HEX.into(),
         worker_threads: Some(2),
         log_level: "debug".into(),
         db_prefix: format!("{node}"),

--- a/node/src/bin/stake_and_join_with_outdated_ckpt.rs
+++ b/node/src/bin/stake_and_join_with_outdated_ckpt.rs
@@ -805,6 +805,8 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         prom_port: (28600 + (node * 10)) as u16,
         prom_ip: "0.0.0.0".into(),
         rpc_port: (3030 + (node * 10)) as u16,
+        #[cfg(feature = "permissioned")]
+        pause_admin_address: summit_rpc::DEFAULT_PAUSE_ADMIN_ADDRESS_HEX.into(),
         worker_threads: Some(2),
         log_level: "debug".into(),
         db_prefix: format!("{node}"),

--- a/node/src/bin/sync_from_genesis.rs
+++ b/node/src/bin/sync_from_genesis.rs
@@ -670,6 +670,8 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         prom_port: (28600 + (node * 10)) as u16,
         prom_ip: "0.0.0.0".into(),
         rpc_port: (3030 + (node * 10)) as u16,
+        #[cfg(feature = "permissioned")]
+        pause_admin_address: summit_rpc::DEFAULT_PAUSE_ADMIN_ADDRESS_HEX.into(),
         worker_threads: Some(2),
         log_level: "debug".into(),
         db_prefix: format!("{node}"),

--- a/node/src/bin/testnet.rs
+++ b/node/src/bin/testnet.rs
@@ -187,6 +187,8 @@ fn get_node_flags(node: usize) -> RunFlags {
         prom_port: (28600 + (node * 10)) as u16,
         prom_ip: "0.0.0.0".into(),
         rpc_port: (3030 + (node * 10)) as u16,
+        #[cfg(feature = "permissioned")]
+        pause_admin_address: summit_rpc::DEFAULT_PAUSE_ADMIN_ADDRESS_HEX.into(),
         worker_threads: Some(2),
         log_level: "debug".into(),
         db_prefix: format!("{node}"),

--- a/node/src/bin/verify_consensus_state_proof.rs
+++ b/node/src/bin/verify_consensus_state_proof.rs
@@ -547,6 +547,8 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         prom_port: (28600 + (node * 10)) as u16,
         prom_ip: "0.0.0.0".into(),
         rpc_port: (3030 + (node * 10)) as u16,
+        #[cfg(feature = "permissioned")]
+        pause_admin_address: summit_rpc::DEFAULT_PAUSE_ADMIN_ADDRESS_HEX.into(),
         worker_threads: Some(2),
         log_level: "debug".into(),
         db_prefix: format!("{node}"),

--- a/node/src/bin/withdraw_and_exit.rs
+++ b/node/src/bin/withdraw_and_exit.rs
@@ -395,6 +395,8 @@ fn get_node_flags(node: usize, genesis_path: &str) -> RunFlags {
         prom_port: (28600 + (node * 10)) as u16,
         prom_ip: "0.0.0.0".into(),
         rpc_port: (3030 + (node * 10)) as u16,
+        #[cfg(feature = "permissioned")]
+        pause_admin_address: summit_rpc::DEFAULT_PAUSE_ADMIN_ADDRESS_HEX.into(),
         worker_threads: Some(2),
         log_level: "debug".into(),
         db_prefix: format!("{node}"),

--- a/rpc/src/auth.rs
+++ b/rpc/src/auth.rs
@@ -4,19 +4,23 @@ use commonware_utils::from_hex_formatted;
 use std::str::FromStr;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-// TODO: replace with the real admin address before production use.
-pub const PAUSE_ADMIN_ADDRESS_HEX: &str = "0xD9b09DCAe1B5D2fFd36200E12f2617414D5fcC30";
+/// Default pause admin address, used when `--pause-admin-address` is not provided.
+pub const DEFAULT_PAUSE_ADMIN_ADDRESS_HEX: &str = "0xD9b09DCAe1B5D2fFd36200E12f2617414D5fcC30";
+
+/// Parses a pause admin address from its hex representation.
+///
+/// Intended to be called once at startup so that a misconfigured address
+/// fails fast instead of surfacing on the first `pause`/`unpause` call.
+pub fn parse_admin_address(hex: &str) -> Result<Address, RpcError> {
+    Address::from_str(hex)
+        .map_err(|e| RpcError::InvalidAdminAddress(format!("admin address parse failed: {e}")))
+}
 
 pub const TIMESTAMP_WINDOW_SECS: u64 = 30;
 pub const DOMAIN: &str = "summit-pause-v1";
 
 pub const ACTION_PAUSE: &str = "pause";
 pub const ACTION_UNPAUSE: &str = "unpause";
-
-fn admin_address() -> Result<Address, RpcError> {
-    Address::from_str(PAUSE_ADMIN_ADDRESS_HEX)
-        .map_err(|e| RpcError::InvalidAdminAddress(format!("admin address parse failed: {e}")))
-}
 
 fn now_secs() -> Result<u64, RpcError> {
     SystemTime::now()
@@ -26,12 +30,12 @@ fn now_secs() -> Result<u64, RpcError> {
 }
 
 pub fn verify_action(
+    admin: &Address,
     action: &str,
     timestamp_secs: u64,
     signature_hex: &str,
 ) -> Result<(), RpcError> {
-    let admin = admin_address()?;
-    verify_action_with(&admin, now_secs()?, action, timestamp_secs, signature_hex)
+    verify_action_with(admin, now_secs()?, action, timestamp_secs, signature_hex)
 }
 
 pub(crate) fn verify_action_with(
@@ -129,7 +133,7 @@ mod tests {
     }
 
     #[test]
-    fn rejects_wrong_signer() {
+    fn rejects_signature_from_non_admin() {
         let attacker = PrivateKeySigner::random();
         let admin = PrivateKeySigner::random();
         let now = 1_700_000_000;
@@ -163,7 +167,13 @@ mod tests {
     }
 
     #[test]
-    fn placeholder_admin_address_parses() {
-        assert!(admin_address().is_ok());
+    fn default_admin_address_parses() {
+        assert!(parse_admin_address(DEFAULT_PAUSE_ADMIN_ADDRESS_HEX).is_ok());
+    }
+
+    #[test]
+    fn rejects_malformed_admin_address() {
+        let err = parse_admin_address("0xnot-an-address").unwrap_err();
+        assert!(matches!(err, RpcError::InvalidAdminAddress(_)));
     }
 }

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -17,6 +17,8 @@ pub use api::{
 };
 #[cfg(feature = "permissioned")]
 pub use api::{SummitPermissionedApiClient, SummitPermissionedApiServer};
+#[cfg(feature = "permissioned")]
+pub use auth::{DEFAULT_PAUSE_ADMIN_ADDRESS_HEX, parse_admin_address};
 
 use commonware_runtime::signal::Signal;
 use jsonrpsee::server::ServerHandle;
@@ -36,12 +38,15 @@ pub async fn start_rpc_server(
     port: u16,
     stop_signal: Signal,
     #[cfg(feature = "permissioned")] paused: Arc<AtomicBool>,
+    #[cfg(feature = "permissioned")] pause_admin: alloy_primitives::Address,
 ) -> anyhow::Result<()> {
     let rpc_impl = SummitRpcServer::new(
         key_store_path,
         finalizer_mailbox,
         #[cfg(feature = "permissioned")]
         paused,
+        #[cfg(feature = "permissioned")]
+        pause_admin,
     );
 
     let mut methods = SummitApiServer::into_rpc(rpc_impl.clone());
@@ -74,12 +79,15 @@ pub async fn start_rpc_server_with_handle(
     key_store_path: String,
     port: u16,
     #[cfg(feature = "permissioned")] paused: Arc<AtomicBool>,
+    #[cfg(feature = "permissioned")] pause_admin: alloy_primitives::Address,
 ) -> anyhow::Result<(ServerHandle, SocketAddr)> {
     let rpc_impl = SummitRpcServer::new(
         key_store_path,
         finalizer_mailbox,
         #[cfg(feature = "permissioned")]
         paused,
+        #[cfg(feature = "permissioned")]
+        pause_admin,
     );
 
     let mut methods = SummitApiServer::into_rpc(rpc_impl.clone());

--- a/rpc/src/server.rs
+++ b/rpc/src/server.rs
@@ -34,6 +34,8 @@ pub struct SummitRpcServer {
     finalizer_mailbox: FinalizerMailbox<MultisigScheme, Block>,
     #[cfg(feature = "permissioned")]
     paused: Arc<AtomicBool>,
+    #[cfg(feature = "permissioned")]
+    pause_admin: alloy_primitives::Address,
 }
 
 impl SummitRpcServer {
@@ -41,12 +43,15 @@ impl SummitRpcServer {
         key_store_path: String,
         finalizer_mailbox: FinalizerMailbox<MultisigScheme, Block>,
         #[cfg(feature = "permissioned")] paused: Arc<AtomicBool>,
+        #[cfg(feature = "permissioned")] pause_admin: alloy_primitives::Address,
     ) -> Self {
         Self {
             key_store_path,
             finalizer_mailbox,
             #[cfg(feature = "permissioned")]
             paused,
+            #[cfg(feature = "permissioned")]
+            pause_admin,
         }
     }
 }
@@ -379,14 +384,24 @@ impl SummitApiServer for SummitRpcServer {
 #[async_trait]
 impl SummitPermissionedApiServer for SummitRpcServer {
     async fn pause(&self, timestamp_secs: u64, signature: String) -> RpcResult<bool> {
-        auth::verify_action(auth::ACTION_PAUSE, timestamp_secs, &signature)?;
+        auth::verify_action(
+            &self.pause_admin,
+            auth::ACTION_PAUSE,
+            timestamp_secs,
+            &signature,
+        )?;
         self.paused.store(true, Ordering::Relaxed);
         tracing::info!("consensus paused via RPC");
         Ok(true)
     }
 
     async fn unpause(&self, timestamp_secs: u64, signature: String) -> RpcResult<bool> {
-        auth::verify_action(auth::ACTION_UNPAUSE, timestamp_secs, &signature)?;
+        auth::verify_action(
+            &self.pause_admin,
+            auth::ACTION_UNPAUSE,
+            timestamp_secs,
+            &signature,
+        )?;
         self.paused.store(false, Ordering::Relaxed);
         tracing::info!("consensus unpaused via RPC");
         Ok(true)

--- a/rpc/tests/integration_test.rs
+++ b/rpc/tests/integration_test.rs
@@ -10,6 +10,14 @@ use summit_rpc::{
 };
 use utils::{MockFinalizerState, create_test_finalizer_mailbox, create_test_keystore};
 
+#[cfg(feature = "permissioned")]
+fn test_pause_admin() -> alloy_primitives::Address {
+    match summit_rpc::parse_admin_address(summit_rpc::DEFAULT_PAUSE_ADMIN_ADDRESS_HEX) {
+        Ok(address) => address,
+        Err(_) => panic!("default pause admin address should parse in tests"),
+    }
+}
+
 #[tokio::test]
 async fn test_health_endpoint() {
     use summit_rpc::SummitApiClient;
@@ -24,6 +32,8 @@ async fn test_health_endpoint() {
         0,
         #[cfg(feature = "permissioned")]
         Arc::new(AtomicBool::new(false)),
+        #[cfg(feature = "permissioned")]
+        test_pause_admin(),
     )
     .await
     .unwrap();
@@ -56,6 +66,8 @@ async fn test_get_latest_height() {
         0,
         #[cfg(feature = "permissioned")]
         Arc::new(AtomicBool::new(false)),
+        #[cfg(feature = "permissioned")]
+        test_pause_admin(),
     )
     .await
     .unwrap();
@@ -88,6 +100,8 @@ async fn test_get_latest_epoch() {
         0,
         #[cfg(feature = "permissioned")]
         Arc::new(AtomicBool::new(false)),
+        #[cfg(feature = "permissioned")]
+        test_pause_admin(),
     )
     .await
     .unwrap();
@@ -116,6 +130,8 @@ async fn test_validator_balance_not_found() {
         0,
         #[cfg(feature = "permissioned")]
         Arc::new(AtomicBool::new(false)),
+        #[cfg(feature = "permissioned")]
+        test_pause_admin(),
     )
     .await
     .unwrap();
@@ -148,6 +164,8 @@ async fn test_get_public_keys() {
         0,
         #[cfg(feature = "permissioned")]
         Arc::new(AtomicBool::new(false)),
+        #[cfg(feature = "permissioned")]
+        test_pause_admin(),
     )
     .await
     .unwrap();
@@ -245,6 +263,8 @@ async fn test_get_minimum_stake() {
         0,
         #[cfg(feature = "permissioned")]
         Arc::new(AtomicBool::new(false)),
+        #[cfg(feature = "permissioned")]
+        test_pause_admin(),
     )
     .await
     .unwrap();
@@ -270,9 +290,15 @@ async fn test_pause_rejects_invalid_signature() {
     let key_store_path = temp_dir.path().to_str().unwrap().to_string();
     let paused = Arc::new(AtomicBool::new(false));
 
-    let (handle, addr) = start_rpc_server_with_handle(mailbox, key_store_path, 0, paused.clone())
-        .await
-        .unwrap();
+    let (handle, addr) = start_rpc_server_with_handle(
+        mailbox,
+        key_store_path,
+        0,
+        paused.clone(),
+        test_pause_admin(),
+    )
+    .await
+    .unwrap();
 
     let url = format!("http://{}", addr);
     let client = HttpClientBuilder::default().build(&url).unwrap();
@@ -307,9 +333,15 @@ async fn test_pause_rejects_stale_timestamp() {
     let key_store_path = temp_dir.path().to_str().unwrap().to_string();
     let paused = Arc::new(AtomicBool::new(false));
 
-    let (handle, addr) = start_rpc_server_with_handle(mailbox, key_store_path, 0, paused.clone())
-        .await
-        .unwrap();
+    let (handle, addr) = start_rpc_server_with_handle(
+        mailbox,
+        key_store_path,
+        0,
+        paused.clone(),
+        test_pause_admin(),
+    )
+    .await
+    .unwrap();
 
     let url = format!("http://{}", addr);
     let client = HttpClientBuilder::default().build(&url).unwrap();
@@ -336,10 +368,15 @@ async fn test_is_paused_open_access() {
     let temp_dir = create_test_keystore().unwrap();
     let key_store_path = temp_dir.path().to_str().unwrap().to_string();
 
-    let (handle, addr) =
-        start_rpc_server_with_handle(mailbox, key_store_path, 0, Arc::new(AtomicBool::new(false)))
-            .await
-            .unwrap();
+    let (handle, addr) = start_rpc_server_with_handle(
+        mailbox,
+        key_store_path,
+        0,
+        Arc::new(AtomicBool::new(false)),
+        test_pause_admin(),
+    )
+    .await
+    .unwrap();
 
     let url = format!("http://{}", addr);
     let client = HttpClientBuilder::default().build(&url).unwrap();
@@ -367,6 +404,8 @@ async fn test_get_maximum_stake() {
         0,
         #[cfg(feature = "permissioned")]
         Arc::new(AtomicBool::new(false)),
+        #[cfg(feature = "permissioned")]
+        test_pause_admin(),
     )
     .await
     .unwrap();


### PR DESCRIPTION
Closes #436.

This removes the hardcoded production pause-admin TODO from `rpc/src/auth.rs` by making the address configurable via `--pause-admin-address`. The flag defaults to the current constant, so existing permissioned deployments keep the same behavior unless they opt into a different admin address.

The address is now parsed once at startup and the node fails fast on misconfiguration instead of surfacing an error on the first emergency pause/unpause call. The configured admin address is threaded from `RunFlags` through RPC startup into `SummitRpcServer`, and the permissioned auth path verifies against that explicit address.

I also updated the permissioned RPC integration tests and the node bin helpers that construct `RunFlags` manually so the workspace continues to compile under `--features permissioned`.

Validation:
- `cargo fmt --check`
- `cargo check -p summit-rpc --features permissioned`
- `cargo test -p summit-rpc --features permissioned`
- `cargo check -p summit --features permissioned`
- `cargo clippy --features permissioned`

Opened against `main`, which is the current default branch. If you would prefer this on another active audit branch, I can retarget.