### PR TITLE
chore: add rust-analyzer to rust-toolchain

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "1.91.1"
-components = ["rustfmt", "clippy"]
+components = ["rustfmt", "clippy", "rust-analyzer"]


### PR DESCRIPTION
newest vscode's shipped rust-analyzer is too new and not compatible with our pinned 1.91.1 rust version, so we need this.

Was getting this error on vscode:
<img width="255" height="359" alt="image" src="https://github.com/user-attachments/assets/bef1ee91-558e-436f-b552-b43ce98a7eb0" />
