### PR TITLE
chore: report critical events

### DIFF
--- a/finalizer/src/actor.rs
+++ b/finalizer/src/actor.rs
@@ -30,7 +30,7 @@ use std::marker::PhantomData;
 use std::num::NonZero;
 use std::time::{Duration, Instant};
 use summit_orchestrator::Message;
-use summit_syncer::Update;
+use summit_syncer::{FaultEvidence, Update};
 use summit_types::account::ValidatorStatus;
 use summit_types::checkpoint::Checkpoint;
 use summit_types::consensus_state_query::{
@@ -584,6 +584,9 @@ impl<
                                         self.cancellation_token.cancel();
                                         break;
                                     }
+                                }
+                                Update::Fault(evidence) => {
+                                    self.handle_fault(evidence);
                                 }
                     }
                 }
@@ -1367,6 +1370,45 @@ impl<
             }
         }
         Ok(HandleOutcome::Applied)
+    }
+
+    /// Handles Byzantine fault evidence observed by the local consensus engine:
+    /// a committee member signed conflicting votes.
+    ///
+    /// This is not deterministic. Only nodes that saw both votes observe it.
+    fn handle_fault(
+        &self,
+        evidence: FaultEvidence<Digest, bls12381_multisig::Scheme<PublicKey, V>>,
+    ) {
+        // The signer index refers to the epoch committee sorted by node public
+        // key (the same order used to build the signing scheme). Resolution is
+        // only valid when the evidence epoch matches the current canonical
+        // state epoch.
+        let validator = (evidence.epoch.get() == self.canonical_state.get_epoch())
+            .then(|| {
+                self.canonical_state
+                    .get_current_epoch_validators()
+                    .into_iter()
+                    .nth(evidence.signer.get() as usize)
+                    .map(|(node_key, _)| node_key)
+            })
+            .flatten();
+        error!(
+            target: "critical",
+            epoch = evidence.epoch.get(),
+            view = evidence.view.get(),
+            signer_index = evidence.signer.get(),
+            ?validator,
+            kind = ?evidence.kind(),
+            "validator equivocated (Byzantine fault detected)"
+        );
+        #[cfg(feature = "prom")]
+        counter!(
+            "critical_errors_total",
+            "reason" => evidence.kind().as_reason(),
+            "severity" => "critical"
+        )
+        .increment(1);
     }
 
     async fn handle_notarized_block(&mut self, block: Block) -> Result<HandleOutcome> {

--- a/node/src/prom/server.rs
+++ b/node/src/prom/server.rs
@@ -45,6 +45,19 @@ impl MetricServer {
 
     /// Spawns the metrics server
     pub async fn serve(&self, stop_signal: Signal) -> eyre::Result<()> {
+        // Install the global recorder eagerly, before any actor can emit
+        // metrics. The recorder is a LazyLock; if installation were deferred
+        // to the first scrape connection (as before), every counter!/gauge!/
+        // histogram! call prior to that would hit the metrics crate's no-op
+        // default recorder and be silently lost — including critical errors
+        // fired during startup.
+        //
+        // Spawn the upkeep task alongside: render() drains histograms on each
+        // scrape, but if the endpoint is never scraped, raw histogram samples
+        // accumulate unboundedly in the registry. Upkeep bounds that growth.
+        let recorder = install_prometheus_recorder();
+        recorder.spawn_upkeep();
+
         let MetricServerConfig {
             listen_addr,
             hooks,

--- a/orchestrator/src/actor.rs
+++ b/orchestrator/src/actor.rs
@@ -1,10 +1,10 @@
 //! Consensus engine orchestrator for epoch transitions.
-use crate::{Mailbox, Message};
+use crate::{Mailbox, Message, reporter::SyncerActivityFilter};
 use summit_types::{Block, Digest, PublicKey, scheme::SummitSchemeProvider};
 
 use commonware_consensus::{
     CertifiableAutomaton, Relay,
-    simplex::{self, types::Context},
+    simplex::{self, scheme::reporter::AttributableReporter, types::Context},
     types::{Epoch, Epocher, ViewDelta},
 };
 use commonware_cryptography::Sha256;
@@ -346,6 +346,14 @@ where
 
         // Start the new engine
         let elector = simplex::elector::RoundRobin::<Sha256>::default();
+        let reporter = AttributableReporter::new(
+            self.context.child("activity_reporter"),
+            scheme.clone(),
+            self.syncer_mailbox.clone(),
+            St::default(),
+            true,
+        );
+        let reporter = SyncerActivityFilter::new(reporter);
         let engine = simplex::Engine::new(
             self.context
                 .child("consensus_engine")
@@ -356,7 +364,7 @@ where
                 blocker: self.oracle.clone(),
                 automaton: self.application.clone(),
                 relay: self.application.clone(),
-                reporter: self.syncer_mailbox.clone(),
+                reporter,
                 strategy: St::default(),
                 partition: format!("{}_consensus_{}", self.partition_prefix, epoch),
                 mailbox_size: NZUsize!(1024),

--- a/orchestrator/src/lib.rs
+++ b/orchestrator/src/lib.rs
@@ -7,3 +7,5 @@ mod committee_filter;
 
 mod ingress;
 pub use ingress::{Mailbox, Message};
+
+mod reporter;

--- a/orchestrator/src/reporter.rs
+++ b/orchestrator/src/reporter.rs
@@ -1,0 +1,52 @@
+use commonware_actor::Feedback;
+use commonware_consensus::{
+    Reporter,
+    simplex::{scheme::Scheme, types::Activity},
+};
+use commonware_cryptography::Digest;
+use std::marker::PhantomData;
+
+/// Filters Simplex activity down to the reports consumed by the syncer.
+///
+/// The syncer mailbox also filters activities in its [`Reporter`] implementation.
+/// This outer filter is intentionally redundant: it runs before Commonware's
+/// `AttributableReporter` so ignored individual votes are not synchronously
+/// verified only to be discarded by the syncer mailbox.
+#[derive(Clone)]
+pub(crate) struct SyncerActivityFilter<S, D, R> {
+    inner: R,
+    _activity: PhantomData<fn() -> (S, D)>,
+}
+
+impl<S, D, R> SyncerActivityFilter<S, D, R> {
+    pub(crate) const fn new(inner: R) -> Self {
+        Self {
+            inner,
+            _activity: PhantomData,
+        }
+    }
+}
+
+impl<S, D, R> Reporter for SyncerActivityFilter<S, D, R>
+where
+    S: Scheme<D>,
+    D: Digest,
+    R: Reporter<Activity = Activity<S, D>>,
+{
+    type Activity = Activity<S, D>;
+
+    fn report(&mut self, activity: Self::Activity) -> Feedback {
+        if matches!(
+            &activity,
+            Activity::Notarization(_)
+                | Activity::Finalization(_)
+                | Activity::ConflictingNotarize(_)
+                | Activity::ConflictingFinalize(_)
+                | Activity::NullifyFinalize(_)
+        ) {
+            self.inner.report(activity)
+        } else {
+            Feedback::Ok
+        }
+    }
+}

--- a/syncer/src/actor.rs
+++ b/syncer/src/actor.rs
@@ -737,6 +737,19 @@ where
                         .ignore();
                 }
             }
+            Message::Fault { evidence } => {
+                // A committee member signed conflicting votes (Byzantine fault).
+                // Forward to the application (finalizer), which owns critical
+                // logging, metrics, and identity resolution against consensus state.
+                debug!(
+                    epoch = evidence.epoch.get(),
+                    view = evidence.view.get(),
+                    signer_index = evidence.signer.get(),
+                    kind = ?evidence.kind(),
+                    "forwarding Byzantine fault evidence to application"
+                );
+                application.report(Update::Fault(evidence));
+            }
             Message::GetBlock {
                 identifier,
                 response,

--- a/syncer/src/ingress/mailbox.rs
+++ b/syncer/src/ingress/mailbox.rs
@@ -1,3 +1,4 @@
+use crate::FaultEvidence;
 use crate::durability::Durable as _;
 use commonware_actor::{
     Feedback,
@@ -189,6 +190,11 @@ pub(crate) enum Message<S: Scheme<B::Digest>, B: Block> {
         /// The finalization.
         finalization: Finalization<S, B::Digest>,
     },
+    /// Evidence of Byzantine behavior (equivocation) reported by the consensus engine.
+    Fault {
+        /// The fault evidence.
+        evidence: FaultEvidence<B::Digest, S>,
+    },
     /// Attempts to set the sync starting point from a finalized commitment.
     ///
     /// If the verified finalization advances the current floor, the syncer
@@ -246,7 +252,8 @@ impl<S: Scheme<B::Digest>, B: Block> Message<S, B> {
             | Self::SetFloor { .. }
             | Self::Prune { .. }
             | Self::Notarization { .. }
-            | Self::Finalization { .. } => false,
+            | Self::Finalization { .. }
+            | Self::Fault { .. } => false,
         }
     }
 
@@ -268,7 +275,8 @@ impl<S: Scheme<B::Digest>, B: Block> Message<S, B> {
             | Self::SetFloor { .. }
             | Self::Prune { .. }
             | Self::Notarization { .. }
-            | Self::Finalization { .. } => false,
+            | Self::Finalization { .. }
+            | Self::Fault { .. } => false,
         }
     }
 }
@@ -726,6 +734,15 @@ impl<S: Scheme<B::Digest>, B: Block> Reporter for Mailbox<S, B> {
         let message = match activity {
             Activity::Notarization(notarization) => Message::Notarization { notarization },
             Activity::Finalization(finalization) => Message::Finalization { finalization },
+            Activity::ConflictingNotarize(evidence) => Message::Fault {
+                evidence: FaultEvidence::conflicting_notarize(evidence),
+            },
+            Activity::ConflictingFinalize(evidence) => Message::Fault {
+                evidence: FaultEvidence::conflicting_finalize(evidence),
+            },
+            Activity::NullifyFinalize(evidence) => Message::Fault {
+                evidence: FaultEvidence::nullify_finalize(evidence),
+            },
             _ => return Feedback::Ok,
         };
         self.sender.enqueue(message)

--- a/syncer/src/lib.rs
+++ b/syncer/src/lib.rs
@@ -80,9 +80,13 @@ mod stream;
 pub mod variant;
 pub use variant::{Buffer, Variant};
 
-use commonware_consensus::Block;
 use commonware_consensus::simplex::scheme::Scheme;
-use commonware_consensus::simplex::types::Finalization;
+use commonware_consensus::simplex::types::{
+    Attributable as _, ConflictingFinalize, ConflictingNotarize, Finalization, NullifyFinalize,
+};
+use commonware_consensus::types::{Epoch, Participant, View};
+use commonware_consensus::{Block, Epochable as _, Viewable as _};
+use commonware_cryptography::Digest;
 use commonware_utils::{Acknowledgement, acknowledgement::Exact};
 
 /// An update reported to the application: finalized tips, finalized blocks, or notarized blocks.
@@ -111,6 +115,102 @@ pub enum Update<B: Block, S: Scheme<B::Digest>, A: Acknowledgement = Exact> {
     /// blocks without waiting for finalization. For a given block, this update is reported before
     /// its [`Self::FinalizedBlock`] update.
     NotarizedBlock(B),
+    /// Locally observed evidence of Byzantine behavior (equivocation) by a validator.
+    ///
+    /// Reported by the consensus batcher when a committee member signs conflicting votes.
+    /// Delivery is best-effort and NOT deterministic: only nodes that received both
+    /// conflicting votes observe the fault, and different nodes may observe it at
+    /// different times (or not at all). Consumers must not apply state transitions
+    /// based on this update alone.
+    Fault(FaultEvidence<B::Digest, S>),
+}
+
+/// The kind of Byzantine fault observed.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FaultKind {
+    /// The validator signed notarize votes for two different proposals in the same view.
+    ConflictingNotarize,
+    /// The validator signed finalize votes for two different proposals in the same view.
+    ConflictingFinalize,
+    /// The validator signed both a nullify and a finalize for the same view.
+    NullifyFinalize,
+}
+
+impl FaultKind {
+    /// Stable label for metrics.
+    pub const fn as_reason(self) -> &'static str {
+        match self {
+            Self::ConflictingNotarize => "equivocation_notarize",
+            Self::ConflictingFinalize => "equivocation_finalize",
+            Self::NullifyFinalize => "nullify_finalize",
+        }
+    }
+}
+
+/// Cryptographic evidence of a Byzantine fault, self-contained and verifiable
+/// against the epoch's committee.
+#[derive(Clone, Debug)]
+pub enum FaultProof<D: Digest, S: Scheme<D>> {
+    /// Two conflicting signed notarize votes.
+    ConflictingNotarize(ConflictingNotarize<S, D>),
+    /// Two conflicting signed finalize votes.
+    ConflictingFinalize(ConflictingFinalize<S, D>),
+    /// A signed nullify and a signed finalize for the same view.
+    NullifyFinalize(NullifyFinalize<S, D>),
+}
+
+/// Locally observed Byzantine fault evidence with its consensus coordinates.
+#[derive(Clone, Debug)]
+pub struct FaultEvidence<D: Digest, S: Scheme<D>> {
+    /// The epoch in which the fault occurred.
+    pub epoch: Epoch,
+    /// The view in which the fault occurred.
+    pub view: View,
+    /// The committee index of the faulting validator (per the epoch's committee order).
+    pub signer: Participant,
+    /// The signed evidence.
+    pub proof: FaultProof<D, S>,
+}
+
+impl<D: Digest, S: Scheme<D>> FaultEvidence<D, S> {
+    /// Builds evidence from a [`ConflictingNotarize`] activity.
+    pub fn conflicting_notarize(evidence: ConflictingNotarize<S, D>) -> Self {
+        Self {
+            epoch: evidence.epoch(),
+            view: evidence.view(),
+            signer: evidence.signer(),
+            proof: FaultProof::ConflictingNotarize(evidence),
+        }
+    }
+
+    /// Builds evidence from a [`ConflictingFinalize`] activity.
+    pub fn conflicting_finalize(evidence: ConflictingFinalize<S, D>) -> Self {
+        Self {
+            epoch: evidence.epoch(),
+            view: evidence.view(),
+            signer: evidence.signer(),
+            proof: FaultProof::ConflictingFinalize(evidence),
+        }
+    }
+
+    /// Builds evidence from a [`NullifyFinalize`] activity.
+    pub fn nullify_finalize(evidence: NullifyFinalize<S, D>) -> Self {
+        Self {
+            epoch: evidence.epoch(),
+            view: evidence.view(),
+            signer: evidence.signer(),
+            proof: FaultProof::NullifyFinalize(evidence),
+        }
+    }
+
+    /// The kind of fault this evidence proves.
+    pub const fn kind(&self) -> FaultKind {
+        match self.proof {
+            FaultProof::ConflictingNotarize(_) => FaultKind::ConflictingNotarize,
+            FaultProof::ConflictingFinalize(_) => FaultKind::ConflictingFinalize,
+            FaultProof::NullifyFinalize(_) => FaultKind::NullifyFinalize,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/syncer/src/mocks/application.rs
+++ b/syncer/src/mocks/application.rs
@@ -77,6 +77,7 @@ impl<B: Block, S: Scheme<B::Digest>> Reporter for Application<B, S> {
                     .unwrap()
                     .push(RecordedUpdate::Notarized(block.digest()));
             }
+            Update::Fault(_) => {}
         }
         Feedback::Ok
     }


### PR DESCRIPTION
Builds on https://github.com/SeismicSystems/summit/pull/442 (which builds on https://github.com/SeismicSystems/summit/pull/440).

Changes:
- Add counters for critical error logs.
- Report equivocation to finalizer and add critical logs with counters that will be picked up by AlertManager.