### PR TITLE
chore(rust-toolchain): bump channel to 1.95

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.91.1"
+channel = "1.95.0"
 components = ["rustfmt", "clippy", "rust-analyzer"]


### PR DESCRIPTION
commonware has bumped to 1.95 on their main branch recently (https://github.com/commonwarexyz/monorepo/pull/4258) so we'll pull that in at some point.

This bump is also needed for vscode tooling since now that the rust-analyzer is added as a component, it creates problems when opening our seismic workspace since our other repos (seismic-reth, alloy, etc) dont have a toolchain that pins, so they are using the latest cargo (1.97) which has breaking changes wrt 1.91 and therefore disables rust-analyzer across the workspace.