### PR TITLE
docs: improve documentation discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-# WIP
 # Summit
 
 <img alt="Summit consensus client" src="assets/graphic.png" />
@@ -94,6 +93,10 @@ Summit acts as the consensus layer, communicating with EVM execution clients thr
 - Deeper benchmarks
 - More optimizations (potentially DKG threshold signatures to improve throughput)
 - Full Audit and completeness Q4 2025
+
+## Documentation
+
+Detailed documentation for developers and auditors lives in [`docs/`](docs/README.md), covering the [architecture](docs/architecture.md), [security model](docs/security-model.md), [checkpointing](docs/checkpointing.md), [deposits and withdrawals](docs/deposits-and-withdrawals.md), and [running a local network](docs/running-local-network.md).
 
 ## Resources
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ This documentation is designed to provide auditors and developers with a compreh
 - **[Engine API Integration](./engine-api-integration.md)** - Communication patterns with execution clients (Reth)
 - **[Security Model](./security-model.md)** - Cryptographic primitives and security considerations
 - **[Staking and Participating](./staking-and-participating.md)** - How to become a validator
+- **[Running a Local Network](./running-local-network.md)** - Spin up a 4-node Summit + Reth testnet locally
 - **[Deposits and Withdrawals](./deposits-and-withdrawals.md)** - Internal state management for deposits and withdrawals
 - **[Checkpointing](./checkpointing.md)** - Checkpoint creation, loading, and verification
 - **[SSZ Merklization](./ssz-merklization.md)** - SSZ binary Merkle tree structure, incremental update optimizations, and proof format


### PR DESCRIPTION
The `docs/` folder has a thorough set of guides, but they aren't reachable from the project's entry points. This makes a few small, purely-documentation fixes so the existing docs are discoverable:

- **Link `docs/` from the top-level README.** The README had no pointer to the documentation set, so the architecture, security-model, checkpointing, and deposits/withdrawals guides were only findable by browsing the tree. Added a short **Documentation** section linking to them.
- **List the local-network guide in the docs index.** `docs/running-local-network.md` was the only page under `docs/` missing from `docs/README.md`'s table of contents. Added it under the operational guides.
- **Drop the stray duplicate `# WIP` heading in the README.** It rendered as a second top-level `#` heading above `# Summit`; the work-in-progress status is already stated in the **Status** section.

No source or behavior changes. All added links point to files that already exist in the repo.
