### PR TITLE
fix(cli): correct --prom-port help text

### DIFF
--- a/node/src/args.rs
+++ b/node/src/args.rs
@@ -131,7 +131,7 @@ pub struct RunFlags {
     /// Prometheus address
     #[arg(long, default_value_t = String::from("0.0.0.0"))]
     pub prom_ip: String,
-    /// Port Consensus runs on
+    /// Port the Prometheus metrics endpoint runs on
     #[arg(long, default_value_t = 9090)]
     pub prom_port: u16,
 


### PR DESCRIPTION
`--prom-port` (default `9090`, paired with `--prom-ip` "Prometheus address") sets the port for the Prometheus metrics endpoint, but its help string was copied from `--port` and reads **"Port Consensus runs on"**.

As a result `summit run --help` labels both `--port` and `--prom-port` identically, describing the metrics port as the consensus port. This corrects the `--prom-port` description to the flag it actually configures. `--port` is left unchanged.

Doc-comment only; no behavior change.
