### PR TITLE
fix: derive the advertised port from --port, not from --ip

### DIFF
--- a/node/src/args.rs
+++ b/node/src/args.rs
@@ -200,9 +200,15 @@ pub struct RunFlags {
     #[arg(long, requires = "checkpoint_path")]
     pub unsafe_skip_checkpoint_verification: bool,
 
-    /// IP address for this node (optional, will use genesis if not provided)
+    /// Public IP address this node advertises to its peers, paired with
+    /// `--port` to form the address they dial. Optional: a node in the genesis
+    /// committee takes the address recorded there, and one that is not resolves
+    /// its public IP at startup. Set it whenever the node's own view of its
+    /// address is the authoritative one — a node joining an existing network
+    /// has no committee entry to read, and an operator who knows the address
+    /// need not have it discovered.
     #[arg(long)]
-    pub ip: Option<String>,
+    pub ip: Option<IpAddr>,
 
     /// Path to a TOML file containing bootstrapper nodes (pubkey and address) for syncing
     #[arg(long)]
@@ -410,6 +416,42 @@ mod genesis_path_tests {
         let listen = wildcard_listen_for(dialable, 26000);
         assert_eq!(listen, "0.0.0.0:26000".parse::<SocketAddr>().unwrap());
         assert!(listen.is_ipv4());
+    }
+
+    /// Parse `summit run <args>` and return the run flags.
+    fn run_flags(args: &[&str]) -> RunFlags {
+        let argv = [&["summit", "run"], args].concat();
+        match CliArgs::try_parse_from(argv)
+            .expect("flags should parse")
+            .cmd
+        {
+            Command::Run { flags } => *flags,
+            other => panic!("expected the run subcommand, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn advertised_ip_is_a_bare_address() {
+        // --ip carries the host only; --port supplies the port the peers dial,
+        // the same one the node listens on, so the two cannot disagree.
+        let flags = run_flags(&["--ip", "203.0.113.7", "--port", "26000"]);
+        assert_eq!(flags.ip, Some("203.0.113.7".parse::<IpAddr>().unwrap()));
+        assert_eq!(flags.port, 26000);
+    }
+
+    #[test]
+    fn advertised_ip_accepts_ipv6_unbracketed() {
+        let flags = run_flags(&["--ip", "2001:db8::7"]);
+        assert_eq!(flags.ip, Some("2001:db8::7".parse::<IpAddr>().unwrap()));
+    }
+
+    #[test]
+    fn advertised_ip_rejects_a_socket_address() {
+        // A port here would be a second, silently authoritative copy of --port.
+        // Rejecting it at parse time keeps the failure a usage error the
+        // operator sees immediately.
+        let argv = ["summit", "run", "--ip", "203.0.113.7:18551"];
+        assert!(CliArgs::try_parse_from(argv).is_err());
     }
 
     #[test]
@@ -1225,10 +1267,8 @@ async fn get_node_ip(
     key_store: &KeyStore<PrivateKey>,
     committee: &[Validator],
 ) -> SocketAddr {
-    if let Some(ref ip_str) = flags.ip {
-        ip_str
-            .parse::<SocketAddr>()
-            .expect("Invalid IP address format")
+    if let Some(ip) = flags.ip {
+        SocketAddr::new(ip, flags.port)
     } else if let Some(addr) = committee.iter().find_map(|v| {
         if v.node_public_key == key_store.node_key.public_key() {
             Some(v.ip_address)

--- a/node/src/bin/observer.rs
+++ b/node/src/bin/observer.rs
@@ -285,7 +285,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             observer_flags.observer = Some(OBSERVER_DERIVE_IDX);
             // Pin the observer's advertised IP so it does NOT inherit the master
             // validator's genesis IP (which is already bound by validator 1).
-            observer_flags.ip = Some(format!("127.0.0.1:{}", 26600 + OBSERVER_SLOT * 10));
+            observer_flags.ip = Some(std::net::Ipv4Addr::LOCALHOST.into());
 
             println!(
                 "Starting observer consensus engine (master = node{}, derive index = {})",

--- a/node/src/bin/stake_and_checkpoint.rs
+++ b/node/src/bin/stake_and_checkpoint.rs
@@ -517,7 +517,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             fs::write(&consensus_key_path, encoded_consensus_key).expect("Unable to write consensus key to disk");
 
             flags.key_store_path = format!("{}/node{}/data", args.data_dir, x);
-            flags.ip = Some("127.0.0.1:26640".to_string());
+            flags.ip = Some(std::net::Ipv4Addr::LOCALHOST.into());
 
             println!(
                 "Starting consensus engine for node {} with checkpoint",

--- a/node/src/bin/stake_and_join_with_outdated_ckpt.rs
+++ b/node/src/bin/stake_and_join_with_outdated_ckpt.rs
@@ -561,7 +561,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             fs::write(&consensus_key_path, encoded_consensus_key).expect("Unable to write consensus key to disk");
 
             flags.key_store_path = format!("{}/node{}/data", args.data_dir, x);
-            flags.ip = Some("127.0.0.1:26640".to_string());
+            flags.ip = Some(std::net::Ipv4Addr::LOCALHOST.into());
 
             println!(
                 "Starting consensus engine for node {} with checkpoint",

--- a/node/src/bin/sync_from_genesis.rs
+++ b/node/src/bin/sync_from_genesis.rs
@@ -512,7 +512,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
 
             flags.key_store_path = format!("{}/node{}/data", args.data_dir, x);
-            flags.ip = Some("127.0.0.1:26640".to_string());
+            flags.ip = Some(std::net::Ipv4Addr::LOCALHOST.into());
 
             // Create a bootstrappers.toml file with one of the genesis validators
             // Read the genesis to get a validator's public key


### PR DESCRIPTION
--ip parsed its value as a SocketAddr, making its port a second copy of --port that silently won on one side of the node. The listen address comes from wildcard_listen_for(our_ip, flags.port), which takes only the address family from --ip and the port from --port, while the address handed to the P2P config is --ip verbatim. So --ip 203.0.113.7:18551 with --port 26000 leaves the node listening on 26000 and signing a gossiped peer record that tells the cohort to dial 18551. Peers dial a port nothing accepts on, the node looks healthy locally, and no validation anywhere compares the two.

Take --ip as an IpAddr and pair it with --port, which is what the public-IP fallback in get_node_ip already does for the third resolution path. One port, from one flag, and the mismatch stops being representable. This mirrors the shape of --prom-ip/--prom-port and --rpc-ip/--rpc-port, drops the IPv6 bracketing burden on callers (2001:db8::7 with a port appended never parsed), and lets clap reject a malformed value as a usage error instead of panicking on a later parse.

The flag matters most to a node joining an existing network: it has no genesis committee entry to read its address from, so without --ip it resolves its public IP by asking external IP-echo services and signs whatever they return. An operator who already knows the address — a deployment that assigns it, or one whose execution client is advertising that same address — can now supply just the host.

Found while wiring Seismic's TEE node images, which are the first caller that needs --ip. A TDX node receives its public address in the boot configuration it is sent on every boot, and tdx-init hands that one address to both reth and summit:
https://github.com/SeismicSystems/enclave/tree/seismic/bin/tdx-init Nothing in-tree passes --ip today (the RunFlags builders in the testnet and e2e binaries leave it None), so this was a latent footgun rather than a live defect.