### PR TITLE
perf: speedup ci by splitting tests into parallel default/all-features jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,16 +58,28 @@ jobs:
       - name: check warnings with all features
         run: RUSTFLAGS="-D warnings" cargo check --all-features
 
+  # The two feature sets are not redundant: `bench` and `bad-blocks` swap in
+  # alternative engine clients, so `--all-features` never exercises the
+  # production block-building path that the default run covers.
   test:
+    name: test (${{ matrix.name }})
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: default features
+            features: ""
+            cache-key: "test-cache-default"
+          - name: all features
+            features: "--all-features"
+            cache-key: "test-cache-all-features"
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "test-cache"
-      - name: cargo test with default features
-        run: cargo test
-      - name: cargo test with all features
-        run: cargo test --all-features
+          shared-key: ${{ matrix.cache-key }}
+      - name: cargo test
+        run: cargo test ${{ matrix.features }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,20 +62,40 @@ target/debug/summit --help
 
 ## Test
 
-### Unit & integration tests (153 tests)
+### Unit & integration tests (613 tests)
 
 ```bash
-cargo test                            # default features — 153 tests
-cargo test --all-features             # includes e2e test harness — 170 tests
+cargo test                            # default features — 613 tests
+cargo test --all-features             # 644 tests
 ```
 
-Test breakdown by crate:
+Test breakdown by crate (default / all features):
 
-- `summit` (node): 40 tests (syncer, checkpointing, execution requests, deposits, withdrawals)
-- `summit-finalizer`: 19 tests (validator lifecycle, fork handling, state queries)
-- `summit-syncer`: 11 tests
-- `summit-types`: 75 tests (codec, consensus state, headers, withdrawals, protocol params)
-- `summit-rpc`: 8 integration tests
+| Crate | Default | All features | Covers |
+| --- | --- | --- | --- |
+| `summit-types` | 406 | 408 | codec, consensus state, headers, withdrawals, protocol params |
+| `summit` (node) | 91 | 93 | syncer, checkpointing, execution requests, deposits, withdrawals |
+| `summit-finalizer` | 55 | 55 | validator lifecycle, fork handling, state queries |
+| `summit-application` | 23 | 23 | propose/verify, Automaton + Relay |
+| `summit-rpc` | 22 | 35 | integration tests; `permissioned` adds the auth suite |
+| `summit-syncer` | 13 | 27 | block cache, backfill, subscriptions |
+| `summit-orchestrator` | 3 | 3 | epoch transitions |
+
+`--all-features` runs a strict superset of the default test *names* — no test
+exists only under default features. The two runs are still not redundant,
+because some features change behavior in place instead of adding tests:
+
+- `bench` swaps `start_building_block` for a variant that takes a height and
+  drops the state root (`application/src/actor.rs`)
+- `bad-blocks` swaps in `BadBlockEngineClient` (`node/src/args.rs`)
+- `permissioned` changes the RPC auth path (`rpc/src/server.rs`)
+
+So `--all-features` never exercises the production block-building path. The
+default run is what covers it.
+
+Runtime is dominated by the `summit` lib test binary — heavy multi-node
+integration tests, ~5 minutes of the ~8 minute total. Every other crate
+finishes in about a second.
 
 ### CI checks (must pass before PR)
 
@@ -242,7 +262,7 @@ GitHub Actions (`.github/workflows/ci.yml`) on push/PR to `main`:
 1. **rustfmt** — `cargo +nightly fmt --all --check`
 2. **build** — default, no-default-features, `prom`, `jemalloc`, all-features
 3. **warnings** — `RUSTFLAGS="-D warnings" cargo check` (default + all-features)
-4. **test** — `cargo test` + `cargo test --all-features`
+4. **test** — two parallel matrix jobs: `cargo test` and `cargo test --all-features`
 
 ## Troubleshooting
 


### PR DESCRIPTION
The test job ran `cargo test` and `cargo test --all-features` back to back: 7.8m + 7.7m, about 16m of wall clock. A two-entry matrix runs them side by side and cuts that to about 8m. Each entry gets its own rust-cache shared-key, so the two jobs no longer overwrite each other's cache. `fail-fast: false` keeps a failure in one config from cancelling the other.

Timings from run 32185252971:
```
  cargo test                 7.8m   (2m34s compile, ~5m10s tests)
  cargo test --all-features  7.7m   (1m52s compile, ~5m50s tests)
```

Compilation is only about 30% of the cost. Almost all the rest is one binary: the `summit` lib test target (94 tests in 307s, 96 tests in 287s). Every other crate finishes in under a second, except `summit-syncer` under all-features (27 tests, 56s).

Both configs earn their place. `--all-features` runs a strict superset of the default test names (613 -> 644, and no test is default-only). But three features change behavior in place instead of adding tests:

  - `bench` swaps `start_building_block` for a variant that takes a height and drops the state root (application/src/actor.rs)
  - `bad-blocks` swaps in `BadBlockEngineClient` (node/src/args.rs)
  - `permissioned` changes the RPC auth path (rpc/src/server.rs)

`bench` is on under `--all-features`, so that run never exercises the production block-building path. The default run is what covers it.

## Possible Follow-ups (not done here)

  - `--all-features` turns on `bench` and `bad-blocks` together. No deployment runs that combination. A named feature set, such as `--features prom,permissioned,e2e`, would test a real configuration instead of a frankenconfig.
  - To get below ~8m, shard the `summit` lib binary with `cargo nextest run --partition count:N/M` over a matrix. The slowest tests are multi-node integration tests. Local timings: 207s for test_checkpoint_verification_fixed_committee, 175s for test_process_time_invalid_new_validator_refund_does_not_merge_with_reused_pubkey_withdrawal, 158s for test_deposit_request_top_up.